### PR TITLE
issues/253 stop capturing multiple stack traces for network operations

### DIFF
--- a/sniffy-core/src/main/java/io/sniffy/CurrentThreadSpy.java
+++ b/sniffy-core/src/main/java/io/sniffy/CurrentThreadSpy.java
@@ -15,7 +15,10 @@ import java.util.Map;
  */
 public class CurrentThreadSpy extends BaseSpy<CurrentThreadSpy> implements Closeable {
 
-    public CurrentThreadSpy() {
+    protected final boolean captureStackTraces;
+
+    public CurrentThreadSpy(boolean captureStackTraces) {
+        this.captureStackTraces = captureStackTraces;
         Sniffy.registerCurrentThreadSpy(this);
     }
 

--- a/sniffy-core/src/main/java/io/sniffy/socket/SnifferSocketImpl.java
+++ b/sniffy-core/src/main/java/io/sniffy/socket/SnifferSocketImpl.java
@@ -108,8 +108,9 @@ class SnifferSocketImpl extends SocketImpl {
     }
 
     protected void logSocket(long millis, int bytesDown, int bytesUp) {
-        if (Sniffy.hasSpies() && null != address && (millis > 0 || bytesDown > 0 || bytesUp > 0)) {
-            Sniffy.logSocket(id, address, millis, bytesDown, bytesUp);
+        Sniffy.SniffyMode sniffyMode = Sniffy.getSniffyMode();
+        if (sniffyMode.isEnabled() && null != address && (millis > 0 || bytesDown > 0 || bytesUp > 0)) {
+            Sniffy.logSocket(id, address, millis, bytesDown, bytesUp, sniffyMode.isCaptureStackTraces());
         }
     }
 

--- a/sniffy-core/src/main/java/io/sniffy/sql/StatementInvocationHandler.java
+++ b/sniffy-core/src/main/java/io/sniffy/sql/StatementInvocationHandler.java
@@ -126,10 +126,12 @@ class StatementInvocationHandler<T extends Statement> extends SniffyInvocationHa
             }
             return result;
         } finally {
+            // TODO: reuse exitJdbcMethod() instead
             long elapsedTime = System.currentTimeMillis() - start;
             Sniffy.logSqlTime(sql, elapsedTime);
-            if (Sniffy.hasSpies()) {
-                String stackTrace = printStackTrace(getTraceForProxiedMethod(method));
+            Sniffy.SniffyMode sniffyMode = Sniffy.getSniffyMode();
+            if (sniffyMode.isEnabled()) {
+                String stackTrace = sniffyMode.isCaptureStackTraces() ? printStackTrace(getTraceForProxiedMethod(method)) : null;
                 lastStatementMetaData = Sniffy.executeStatement(sql, elapsedTime, stackTrace, rowsUpdated);
             } else {
                 Sniffer.executedStatementsGlobalCounter.incrementAndGet();

--- a/sniffy-web/src/main/java/io/sniffy/servlet/SniffyRequestProcessor.java
+++ b/sniffy-web/src/main/java/io/sniffy/servlet/SniffyRequestProcessor.java
@@ -71,7 +71,11 @@ class SniffyRequestProcessor implements BufferedServletResponseListener {
         this.httpServletRequest = httpServletRequest;
         this.httpServletResponse = httpServletResponse;
 
-        spy = Sniffy.spyCurrentThread();
+        // Capture stack traces only if injectHtml is enabled globally or by header explicitly
+        spy = Sniffy.spyCurrentThread(
+                sniffyFilter.injectHtml ||
+                Boolean.parseBoolean(httpServletRequest.getHeader(INJECT_HTML_ENABLED_PARAMETER))
+        );
 
         Object requestIdAttribute = httpServletRequest.getAttribute(SNIFFY_REQUEST_ID_REQUEST_ATTRIBUTE_NAME);
         if (requestIdAttribute instanceof String) {


### PR DESCRIPTION
Do not capture stack traces if Sniffy Widget UI is disabled;
Fixes/implements https://github.com/sniffy/sniffy/issues/253