### PR TITLE
Prepare Sniffy for autonomous Codex workflows

### DIFF
--- a/.codex/cloud/maintenance.sh
+++ b/.codex/cloud/maintenance.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Codex runs this when resuming a cached cloud environment on a task branch.
+
+if [[ ! -f "${HOME}/.sniffy-codex-env" ]]; then
+  exec bash .codex/cloud/setup.sh
+fi
+
+# shellcheck disable=SC1090
+source "${HOME}/.sniffy-codex-env"
+
+# Resolve dependencies again after checkout. With a warm ~/.m2 cache this is
+# cheap, while still downloading dependencies introduced by the selected branch.
+mvn -T 1C -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -P ci \
+  || mvn -T 1C -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -P ci

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Codex Cloud setup script for Sniffy.
+# Configure the environment setup command as:
+#   bash .codex/cloud/setup.sh
+
+MAVEN_VERSION="${MAVEN_VERSION:-3.9.11}"
+JDK_FEATURES="${SNIFFY_JDK_FEATURES:-8 11 17 21 25}"
+TOOLS_DIR="${HOME}/.local/share/sniffy-codex"
+JDKS_DIR="${HOME}/.jdks"
+MAVEN_HOME_DIR="${TOOLS_DIR}/apache-maven-${MAVEN_VERSION}"
+ENV_FILE="${HOME}/.sniffy-codex-env"
+
+case "$(uname -m)" in
+  x86_64) ADOPTIUM_ARCH="x64" ;;
+  aarch64|arm64) ADOPTIUM_ARCH="aarch64" ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "${TOOLS_DIR}" "${JDKS_DIR}" "${HOME}/.m2"
+
+for command_name in curl tar git find; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "Required command '${command_name}' is unavailable." >&2
+    exit 1
+  fi
+done
+
+install_jdk() {
+  local feature="$1"
+  local destination="${JDKS_DIR}/temurin-${feature}"
+
+  if [[ -x "${destination}/bin/java" ]]; then
+    echo "Temurin JDK ${feature} already installed."
+    return
+  fi
+
+  echo "Installing latest Temurin JDK ${feature} GA release..."
+  local archive unpack extracted
+  archive="$(mktemp)"
+  unpack="$(mktemp -d)"
+
+  curl --fail --location --retry 5 --retry-delay 2 \
+    "https://api.adoptium.net/v3/binary/latest/${feature}/ga/linux/${ADOPTIUM_ARCH}/jdk/hotspot/normal/eclipse?project=jdk" \
+    --output "${archive}"
+  tar -xzf "${archive}" -C "${unpack}"
+
+  extracted="$(find "${unpack}" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+  if [[ -z "${extracted}" ]]; then
+    echo "Could not locate extracted JDK ${feature}." >&2
+    exit 1
+  fi
+
+  rm -rf "${destination}"
+  mv "${extracted}" "${destination}"
+  rm -rf "${archive}" "${unpack}"
+}
+
+for feature in ${JDK_FEATURES}; do
+  install_jdk "${feature}"
+done
+
+if [[ ! -x "${MAVEN_HOME_DIR}/bin/mvn" ]]; then
+  echo "Installing Apache Maven ${MAVEN_VERSION}..."
+  archive="$(mktemp)"
+  curl --fail --location --retry 5 --retry-delay 2 \
+    "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+    --output "${archive}"
+  tar -xzf "${archive}" -C "${TOOLS_DIR}"
+  rm -f "${archive}"
+fi
+
+cat > "${ENV_FILE}" <<EOF_ENV
+export SNIFFY_JDK8_HOME="${JDKS_DIR}/temurin-8"
+export SNIFFY_JDK11_HOME="${JDKS_DIR}/temurin-11"
+export SNIFFY_JDK17_HOME="${JDKS_DIR}/temurin-17"
+export SNIFFY_JDK21_HOME="${JDKS_DIR}/temurin-21"
+export SNIFFY_JDK25_HOME="${JDKS_DIR}/temurin-25"
+export JAVA_HOME="${JDKS_DIR}/temurin-25"
+export MAVEN_HOME="${MAVEN_HOME_DIR}"
+export PATH="${MAVEN_HOME_DIR}/bin:${JDKS_DIR}/temurin-25/bin:\${PATH}"
+EOF_ENV
+
+for shell_file in "${HOME}/.bashrc" "${HOME}/.profile"; do
+  touch "${shell_file}"
+  if ! grep -Fq '.sniffy-codex-env' "${shell_file}"; then
+    cat >> "${shell_file}" <<'EOF_SHELL'
+
+# Sniffy Codex Cloud toolchain
+[ -f "$HOME/.sniffy-codex-env" ] && source "$HOME/.sniffy-codex-env"
+EOF_SHELL
+  fi
+done
+
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+
+cat > "${HOME}/.m2/toolchains.xml" <<EOF_TOOLCHAINS
+<?xml version="1.0" encoding="UTF-8"?>
+<toolchains>
+  <toolchain><type>jdk</type><provides><version>8</version><vendor>temurin</vendor></provides><configuration><jdkHome>${JDKS_DIR}/temurin-8</jdkHome></configuration></toolchain>
+  <toolchain><type>jdk</type><provides><version>11</version><vendor>temurin</vendor></provides><configuration><jdkHome>${JDKS_DIR}/temurin-11</jdkHome></configuration></toolchain>
+  <toolchain><type>jdk</type><provides><version>17</version><vendor>temurin</vendor></provides><configuration><jdkHome>${JDKS_DIR}/temurin-17</jdkHome></configuration></toolchain>
+  <toolchain><type>jdk</type><provides><version>21</version><vendor>temurin</vendor></provides><configuration><jdkHome>${JDKS_DIR}/temurin-21</jdkHome></configuration></toolchain>
+  <toolchain><type>jdk</type><provides><version>25</version><vendor>temurin</vendor></provides><configuration><jdkHome>${JDKS_DIR}/temurin-25</jdkHome></configuration></toolchain>
+</toolchains>
+EOF_TOOLCHAINS
+
+java -version
+mvn -version
+
+# Prime the Maven cache using the same resolver and profile as CI. The retry
+# handles transient repository failures; it must not be copied into test runs.
+mvn -T 1C -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -U -P ci \
+  || mvn -T 1C -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -U -P ci
+
+echo "Sniffy Codex Cloud environment is ready."

--- a/.codex/cloud/use-jdk.sh
+++ b/.codex/cloud/use-jdk.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Source this file to switch the current shell, for example:
+#   source .codex/cloud/use-jdk.sh 8
+
+feature="${1:-}"
+case "${feature}" in
+  8|11|17|21|25) ;;
+  *)
+    echo "Usage: source .codex/cloud/use-jdk.sh {8|11|17|21|25}" >&2
+    return 2 2>/dev/null || exit 2
+    ;;
+esac
+
+jdk_home="${HOME}/.jdks/temurin-${feature}"
+if [[ ! -x "${jdk_home}/bin/java" ]]; then
+  echo "JDK ${feature} is not installed. Run bash .codex/cloud/setup.sh first." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+export JAVA_HOME="${jdk_home}"
+export PATH="${JAVA_HOME}/bin:${PATH}"
+java -version

--- a/.codex/local/run-issue.sh
+++ b/.codex/local/run-issue.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run only inside an isolated VM or dev container. This grants Codex unrestricted
+# access as the current user and disables interactive approval prompts.
+
+issue_number="${1:-}"
+branch_name="${2:-}"
+
+if [[ -z "${issue_number}" || ! "${issue_number}" =~ ^[0-9]+$ ]]; then
+  echo "Usage: bash .codex/local/run-issue.sh ISSUE_NUMBER [BRANCH_NAME]" >&2
+  exit 2
+fi
+
+for command_name in git gh codex; do
+  command -v "${command_name}" >/dev/null 2>&1 || {
+    echo "Required command '${command_name}' is unavailable." >&2
+    exit 1
+  }
+done
+
+gh auth status >/dev/null
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree is not clean. Refusing to mix unrelated changes." >&2
+  exit 1
+fi
+
+repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+default_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
+issue_url="$(gh issue view "${issue_number}" --repo "${repo}" --json url --jq .url)"
+
+if [[ -z "${branch_name}" ]]; then
+  branch_name="agent/issue-${issue_number}"
+fi
+
+git fetch origin "${default_branch}" "${branch_name}" 2>/dev/null || git fetch origin "${default_branch}"
+
+if git show-ref --verify --quiet "refs/heads/${branch_name}"; then
+  git switch "${branch_name}"
+elif git show-ref --verify --quiet "refs/remotes/origin/${branch_name}"; then
+  git switch --track "origin/${branch_name}"
+else
+  git switch -c "${branch_name}" "origin/${default_branch}"
+fi
+
+issue_markdown="$(gh issue view "${issue_number}" --repo "${repo}" --json title,body,url --template '{{.title}}\n\n{{.body}}\n\nIssue: {{.url}}')"
+
+model="${CODEX_MODEL:-gpt-5.6-sol}"
+reasoning="${CODEX_REASONING_EFFORT:-xhigh}"
+
+codex \
+  --model "${model}" \
+  --config "model_reasoning_effort=\"${reasoning}\"" \
+  --ask-for-approval never \
+  --sandbox danger-full-access \
+  --search \
+  exec - <<PROMPT
+Work autonomously on the GitHub issue below in repository ${repo}.
+
+Read AGENTS.md and inspect the repository before editing. The issue is authoritative. Implement the task end to end, add or update tests and documentation, run all locally applicable checks, review the final diff, commit, push ${branch_name} without force-pushing, and create or update a draft pull request linked to the issue. Do not ask for routine decisions or approval. Make conservative maintainable implementation decisions yourself. Do not merge the pull request. Stop only for a genuine blocker and report it precisely.
+
+${issue_markdown}
+PROMPT
+
+printf 'Codex run finished for %s on branch %s.\n' "${issue_url}" "${branch_name}"

--- a/.github/ISSUE_TEMPLATE/codex-task.yml
+++ b/.github/ISSUE_TEMPLATE/codex-task.yml
@@ -1,0 +1,80 @@
+name: Autonomous implementation task
+description: A task refined enough for Codex Cloud or unattended local Codex execution
+title: ""
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Complete every relevant section. The issue should contain enough information for an agent to implement and test the change without an interactive clarification round.
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe observable user or developer behavior after the task is complete.
+      placeholder: What should work, for whom, and why?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and current behavior
+      description: Include relevant modules, APIs, links, prior attempts, errors, and constraints.
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: State the decisions already made. Avoid leaving product choices to the implementation agent.
+      placeholder: |
+        - Requirement 1
+        - Requirement 2
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: Explicitly exclude tempting adjacent work.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Use verifiable checkboxes.
+      placeholder: |
+        - [ ] Behavior is covered by tests
+        - [ ] Compatibility requirements are preserved
+        - [ ] Documentation is updated
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Required validation
+      description: List focused tests, full build commands, JDKs, platforms, or manual checks.
+    validations:
+      required: true
+  - type: dropdown
+    id: execution
+    attributes:
+      label: Proposed execution route
+      description: The delivery lead may change this during refinement.
+      options:
+        - Codex Cloud
+        - Unattended local Codex in an isolated VM/container
+        - Human-led implementation
+    validations:
+      required: true
+  - type: checkboxes
+    id: readiness
+    attributes:
+      label: Autonomous readiness
+      options:
+        - label: Product and compatibility decisions are explicit.
+          required: true
+        - label: Acceptance criteria are testable.
+          required: true
+        - label: The agent may make ordinary implementation decisions without asking for approval.
+          required: true
+        - label: Required credentials, external services, and branch constraints are documented.
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,67 @@
 # Repository agent instructions
 
-These rules apply to every change in this repository. More specific `AGENTS.md` files may add constraints for their
-subtrees.
+These rules apply to every change in this repository. More specific `AGENTS.md` or `AGENTS.override.md` files may add
+constraints for their subtrees.
+
+## Task ownership and autonomy
+
+- Treat the linked GitHub issue and its acceptance criteria as the source of truth. Read the complete issue, relevant
+  comments, existing pull requests, and current code before editing.
+- For tasks explicitly marked ready for autonomous execution, do not stop for routine design choices or ask for
+  confirmation. Inspect the repository, choose the smallest maintainable solution consistent with the issue, and record
+  material decisions in the pull request. Stop only for a real blocker such as missing credentials, unavailable external
+  infrastructure, destructive ambiguity, or mutually incompatible acceptance criteria.
+- Complete the task end to end when permissions allow: implement, add or update tests, run applicable checks, review the
+  diff, commit, push, and update or open a draft pull request. Never merge a pull request unless the task explicitly says
+  to do so.
+- Preserve unrelated user changes. Do not reset, clean, force-push, rebase shared branches, or rewrite history unless the
+  issue explicitly requires it. Prefer a new `agent/<short-description>` branch from `develop` for new work.
 
 ## Compatibility and scope
 
 - Preserve Java 8 source, bytecode, and runtime compatibility unless a task explicitly changes the supported baseline.
   Do not use post-Java-8 language features or APIs in shared production or test sources. JDK-specific integrations must
-  stay behind the existing capability probes and Maven profiles.
+  stay behind capability probes, isolated modules, or Maven profiles.
 - Keep changes inside the requested behavior. Preserve public contracts and existing user changes; do not turn a
   focused fix into an unrelated redesign.
+- Prefer the smallest compatible dependency update. Do not perform broad dependency modernization as part of an
+  unrelated task. Document security-motivated upgrades and compatibility trade-offs in the pull request.
 
 ## Concurrency and lifecycle
 
 - Treat deterministic concurrency tests as executable contracts. Do not weaken assertions, add retries, retry a failed
-  run to green, replace latches/hooks with timing sleeps, or increase timeouts to hide an ordering defect.
+  test run to green, replace latches/hooks with timing sleeps, or increase timeouts to hide an ordering defect.
 - Instrumentation is secondary to application resource safety. Monitoring, proxy parsing, logging, registry, or
   callback failure must not prevent required physical close, shutdown, cancellation, wakeup, or cleanup. Preserve the
   first failure and suppress later cleanup failures when multiple steps fail.
 - Keep application callbacks out of private JDK/provider locks and internal construction scopes. Preserve documented
   lock order and ownership rather than relying on a particular OS/JDK implementation.
 
-## Verification
+## Build and verification
 
+- The Codex Cloud environment is described in `docs/codex-workflow.md`. Use `source .codex/cloud/use-jdk.sh <version>`
+  to switch among the installed JDK 8, 11, 17, 21, and 25 toolchains.
 - Run focused tests for the changed behavior first.
 - For NIO changes, run `mvn -pl sniffy-module-nio -am clean test` on Java 8 and the current development JDK.
 - For TLS changes, run `mvn -pl sniffy-module-tls -am clean test` on Java 8 and the current development JDK.
 - For cross-module or release-facing changes, run
   `mvn -T 1C -B clean verify --file pom.xml -U -P ci -Dgpg.skip=true -Dmaven.wagon.http.retryHandler.count=3`.
 - Run `git diff --check` before committing. A failing or skipped required check must be reported with its exact reason;
-  never describe a partial or ignored run as passing.
+  never describe a partial, retried, or ignored run as passing.
+
+## Pull requests
+
+- Keep pull requests draft until the implementation and locally applicable verification are complete.
+- The pull request description must explain the problem, design, compatibility impact, tests executed, checks not run,
+  dependency changes, and remaining risks. Link the authoritative issue.
+- Do not hide limitations. If the environment cannot run a platform-, JDK-, or credential-dependent check, say exactly
+  what is missing and leave CI to perform that check.
+
+## Review guidelines
+
+- Prioritize correctness, compatibility, resource safety, concurrency, public API stability, and test integrity over
+  formatting preferences.
+- Flag tests that were weakened, made timing-dependent, skipped, or retried to conceal a failure.
+- Flag accidental Java baseline increases, use of newer JDK APIs in Java 8 artifacts, and unintentional dependency or
+  public API changes.
+- Flag resource leaks or cleanup paths where Sniffy instrumentation can prevent application resources from closing.

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -8,6 +8,7 @@ This document describes the one-time Codex Cloud setup for Sniffy and the operat
 - `.codex/cloud/setup.sh` installs Maven and Temurin JDK 8, 11, 17, 21, and 25, writes Maven toolchains, persists the environment, and primes the Maven dependency cache.
 - `.codex/cloud/maintenance.sh` refreshes dependencies when a cached cloud environment is resumed on another branch.
 - `.codex/cloud/use-jdk.sh` switches the current shell between installed JDKs.
+- `.codex/local/run-issue.sh` prepares an issue branch and launches unattended local Codex in an isolated machine.
 - `.github/ISSUE_TEMPLATE/codex-task.yml` provides a Definition-of-Ready template for autonomous tasks.
 
 Codex loads `AGENTS.md` automatically. More specific instructions can be added later in subdirectories when a module needs different build or review rules.
@@ -95,21 +96,13 @@ Examples: focused fixes, tests, documentation, ordinary refactoring, dependency 
 
 The local run should still be non-interactive: use `--ask-for-approval never`, run inside a disposable VM/container, put the complete specification in the issue, and instruct the agent to implement, test, commit, push, and update the draft pull request without asking routine questions.
 
-Recommended command shape:
+Recommended launcher:
 
 ```bash
-codex \
-  --model gpt-5.6-sol \
-  --config 'model_reasoning_effort="xhigh"' \
-  --ask-for-approval never \
-  --sandbox danger-full-access \
-  --search \
-  exec - <<'PROMPT'
-Read the complete linked GitHub issue and AGENTS.md. Treat the issue as authoritative. Work autonomously end to end: inspect, implement, test, review the diff, commit, push, and create or update a draft pull request. Do not ask for routine decisions or approval. Stop only for a real blocker and report it precisely.
-
-Issue: https://github.com/sniffy/sniffy/issues/NUMBER
-PROMPT
+bash .codex/local/run-issue.sh NUMBER [BRANCH_NAME]
 ```
+
+The script requires authenticated `gh`, a clean working tree, and an installed Codex CLI. It fetches the issue text, switches to an existing issue branch or creates `agent/issue-NUMBER` from the default branch, and starts Codex with `gpt-5.6-sol`, Extra High reasoning, no approvals, search enabled, and `danger-full-access`. Override the defaults with `CODEX_MODEL` and `CODEX_REASONING_EFFORT`.
 
 `danger-full-access` is appropriate only inside the isolated environment because it grants the agent the same filesystem and network authority as the executing user.
 

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -1,0 +1,207 @@
+# Codex Cloud and autonomous delivery workflow
+
+This document describes the one-time Codex Cloud setup for Sniffy and the operating model for turning product ideas into reviewed pull requests with minimal interactive intervention.
+
+## 1. What is stored in the repository
+
+- `AGENTS.md` contains repository-wide engineering, autonomy, verification, and review rules.
+- `.codex/cloud/setup.sh` installs Maven and Temurin JDK 8, 11, 17, 21, and 25, writes Maven toolchains, persists the environment, and primes the Maven dependency cache.
+- `.codex/cloud/maintenance.sh` refreshes dependencies when a cached cloud environment is resumed on another branch.
+- `.codex/cloud/use-jdk.sh` switches the current shell between installed JDKs.
+- `.github/ISSUE_TEMPLATE/codex-task.yml` provides a Definition-of-Ready template for autonomous tasks.
+
+Codex loads `AGENTS.md` automatically. More specific instructions can be added later in subdirectories when a module needs different build or review rules.
+
+## 2. One-time Codex Cloud setup
+
+The repository files cannot create an environment in another user's OpenAI account, so the following UI setup is required once.
+
+1. Open Codex Cloud and connect the GitHub account that has access to `sniffy/sniffy`.
+2. Allow Codex access to the repository.
+3. Create an environment named `sniffy` for repository `sniffy/sniffy`.
+4. Use `develop` as the default branch.
+5. Set the setup script to:
+
+   ```bash
+   bash .codex/cloud/setup.sh
+   ```
+
+6. Set the maintenance script to:
+
+   ```bash
+   bash .codex/cloud/maintenance.sh
+   ```
+
+7. Keep agent-phase internet disabled for ordinary implementation tasks. Enable limited internet only when a task explicitly requires current external documentation, vulnerability/advisory lookup, or dependency metadata that was not available during setup.
+8. Do not add repository or Maven Central credentials: Sniffy is public and its normal build should use public dependencies. Add a secret only for a task that genuinely requires a private external service. Cloud secrets are intended for setup and are removed before the agent phase.
+9. Reset the environment cache after changing the setup or maintenance scripts, or when the cached toolchain becomes inconsistent.
+10. In Codex settings, enable code review for this repository. Automatic review may be enabled after the review rules in `AGENTS.md` have produced useful results on several test pull requests.
+
+The setup phase has internet access and the agent phase follows the environment's configured internet policy. Cached environments may be reused, so the maintenance script must remain safe and idempotent.
+
+## 3. Validating the environment
+
+Start a small cloud task on `develop` with this prompt:
+
+```text
+Validate the Sniffy development environment only. Read AGENTS.md, report the active Java and Maven versions, switch to JDK 8 and JDK 25 using .codex/cloud/use-jdk.sh, run git diff --check, and run one small focused Maven test without changing tracked files. Report every command and result. Do not create a pull request.
+```
+
+For manual validation inside a shell:
+
+```bash
+source .codex/cloud/use-jdk.sh 8
+mvn -version
+
+source .codex/cloud/use-jdk.sh 25
+mvn -version
+```
+
+## 4. Definition of Ready for autonomous work
+
+An issue is ready when it states:
+
+- the desired observable outcome;
+- relevant current behavior, modules, and links;
+- product, compatibility, and migration decisions;
+- explicit non-goals;
+- testable acceptance criteria;
+- required JDKs, platforms, tests, and documentation;
+- branch/history constraints and external-service requirements;
+- whether the agent may commit/push and whether it should create or update a pull request.
+
+The issue must not delegate unresolved product decisions to Codex. Implementation choices may remain open when a conservative, maintainable answer can be derived from the repository.
+
+## 5. Routing tasks
+
+### Use Codex Cloud by default when
+
+- work starts from a clean branch based on `develop`;
+- the task is well specified and can be validated in the cloud container;
+- dependencies are public or can be installed in the setup phase;
+- no unusual Git history surgery is required;
+- no private local service, hardware, proprietary IDE, or operating-system-specific environment is required;
+- the task can finish as a reviewable diff or draft pull request.
+
+Examples: focused fixes, tests, documentation, ordinary refactoring, dependency updates, adding a new isolated module, and most issue-driven implementation.
+
+### Use unattended local Codex in an isolated VM or dev container when
+
+- the existing branch and commit ancestry must be manipulated precisely;
+- the task needs unrestricted Git/GitHub CLI operations against an existing pull request;
+- several local services, Docker, special networking, hardware, or corporate resources are needed;
+- debugging requires an environment not available in Codex Cloud;
+- the task is broad enough that persistent local artifacts and manual inspection are valuable.
+
+The local run should still be non-interactive: use `--ask-for-approval never`, run inside a disposable VM/container, put the complete specification in the issue, and instruct the agent to implement, test, commit, push, and update the draft pull request without asking routine questions.
+
+Recommended command shape:
+
+```bash
+codex \
+  --model gpt-5.6-sol \
+  --config 'model_reasoning_effort="xhigh"' \
+  --ask-for-approval never \
+  --sandbox danger-full-access \
+  --search \
+  exec - <<'PROMPT'
+Read the complete linked GitHub issue and AGENTS.md. Treat the issue as authoritative. Work autonomously end to end: inspect, implement, test, review the diff, commit, push, and create or update a draft pull request. Do not ask for routine decisions or approval. Stop only for a real blocker and report it precisely.
+
+Issue: https://github.com/sniffy/sniffy/issues/NUMBER
+PROMPT
+```
+
+`danger-full-access` is appropriate only inside the isolated environment because it grants the agent the same filesystem and network authority as the executing user.
+
+## 6. Starting and following up cloud work
+
+1. Refine the issue with the autonomous task template.
+2. Select the `sniffy` environment and the intended base branch in Codex Cloud, then reference the issue as the authoritative specification.
+3. For complex architectural work, select the strongest available coding model and Extra High reasoning. For small mechanical tasks, use the default reasoning level unless deeper analysis is needed.
+4. Ask for implementation, validation, and a draft pull request—not merely a plan.
+5. Review the cloud task summary, commands, tests, and diff.
+6. Use a follow-up task for bounded corrections.
+7. On a Codex-created pull request, a comment such as `@codex fix the CI failures` starts another cloud task with that pull request as context when the GitHub integration has permission.
+8. Request a high-signal review with `@codex review`, or rely on automatic reviews after they have been enabled.
+
+A standard dispatch prompt is:
+
+```text
+Implement the complete linked issue autonomously. Read AGENTS.md and the entire issue thread first; the issue is authoritative. Make ordinary engineering decisions yourself using the most conservative maintainable option. Implement the change, add or update tests and documentation, run all checks available in the environment, review the final diff, and open a draft pull request linked to the issue. Do not stop for a plan or ask for routine clarification. If a genuine blocker remains, leave the repository clean and report the exact blocker and the smallest decision or permission needed.
+```
+
+## 7. Operating model
+
+### Product Owner — Dmitry
+
+- defines desired outcomes, user value, priorities, and release constraints;
+- makes product and compatibility decisions when trade-offs affect users;
+- accepts or rejects the result after review.
+
+### Delivery lead — ChatGPT
+
+- owns the book of work in GitHub Projects and issues;
+- converts discussions into issues with explicit requirements, non-goals, acceptance criteria, and validation;
+- selects Cloud, unattended local Codex, or human-led execution;
+- dispatches ready tasks and tracks blockers, CI, reviews, and follow-ups;
+- reviews implementation and architecture against the issue and `AGENTS.md`;
+- keeps project status and issue descriptions current;
+- prepares a weekly retrospective.
+
+### Codex Cloud
+
+- executes well-defined, isolated tasks in parallel;
+- follows `AGENTS.md`, implements and validates the change, and returns a reviewable diff or draft pull request;
+- does not make unresolved product decisions;
+- reports precise blockers instead of waiting for an interactive answer.
+
+### Unattended local Codex
+
+- handles tasks requiring a privileged or specialized disposable environment, unusual branch operations, existing PR surgery, or services unavailable in Cloud;
+- receives the same issue-driven specification and Definition of Done;
+- commits, pushes, and updates the draft pull request when explicitly authorized.
+
+## 8. Book-of-work states
+
+Recommended GitHub Project states:
+
+1. `Idea` — captured but not refined.
+2. `Needs product decision` — blocked on outcome, compatibility, or scope.
+3. `Ready for agent` — satisfies Definition of Ready.
+4. `In progress: cloud` or `In progress: local` — dispatched with a task/branch link.
+5. `Agent blocked` — exact blocker and requested decision recorded in the issue.
+6. `Review` — draft PR exists and checks/review are in progress.
+7. `Ready to merge` — acceptance criteria and required checks pass.
+8. `Done` — merged or intentionally closed with rationale.
+
+Useful labels include `agent:cloud`, `agent:local`, `agent:blocked`, `needs:product`, `needs:review`, and `security`. Labels describe routing and attention; the GitHub Project status remains the workflow source of truth.
+
+## 9. Review and Definition of Done
+
+The delivery lead reviews:
+
+- whether the implementation matches every acceptance criterion;
+- compatibility and public API impact;
+- module boundaries and unnecessary complexity;
+- test quality, including whether tests were weakened or made flaky;
+- exact commands and JDKs used;
+- dependency/security changes;
+- documentation and migration impact;
+- accidental generated files or unrelated edits.
+
+A task is done only when required checks pass, known limitations are documented, review findings are resolved or accepted explicitly, and the issue/project state is updated.
+
+## 10. Weekly retrospective
+
+The weekly retrospective should cover:
+
+- completed and merged work;
+- work started, still running, or blocked;
+- lead time from `Ready for agent` to draft PR and merge;
+- cloud vs local routing decisions and whether they were correct;
+- CI failures, escaped defects, and repeated review findings;
+- tasks that required human clarification and how to improve their issue specification;
+- changes needed in `AGENTS.md`, setup scripts, templates, or the test matrix;
+- the next week's top priorities and capacity risks.
+
+The retrospective should result in concrete issue/template/instruction changes, not only a narrative summary.


### PR DESCRIPTION
## Summary

Prepare the repository for repeatable Codex Cloud tasks and unattended local Codex execution.

## Changes

- add Codex Cloud setup and maintenance scripts;
- install and expose Temurin JDK 8, 11, 17, 21, and 25 plus Maven toolchains;
- add a helper for switching JDKs during compatibility testing;
- add an unattended local issue runner for isolated VMs/dev containers;
- strengthen `AGENTS.md` with autonomy, branch, pull-request, dependency, validation, and review rules;
- add an autonomous-task GitHub issue form;
- document one-time Cloud setup, task routing, dispatch prompts, review flow, book-of-work ownership, and weekly retrospectives.

## AGENTS.md assessment

The existing file already had strong compatibility, concurrency, lifecycle, and verification guidance. It was not sufficient by itself for autonomous end-to-end delivery because it did not explain issue authority, ordinary decision-making without clarification, branch/history safety, draft PR expectations, dependency scope, or review priorities. This PR adds those rules while keeping the file comfortably below Codex's default project-instruction size limit.

## Validation

- `bash -n` passed for all four shell scripts;
- the issue form parsed successfully as YAML;
- branch diff was reviewed and contains only the intended seven files;
- no production code or Maven project configuration is changed.

## Not validated here

The full Cloud setup script was not executed because this change was prepared outside a Codex Cloud environment and the current tool environment cannot download the JDK/Maven archives. After merging, follow `docs/codex-workflow.md` to create the environment, reset its cache, and run the documented validation task.

## Manual account setup still required

Repository files cannot connect another user's OpenAI/GitHub account or create their Codex Cloud environment. The documentation gives the exact one-time settings: repository, default branch, setup command, maintenance command, internet policy, code review toggle, and validation prompt.