### PR TITLE
Make Codex Cloud Maven warm-up resilient

### DIFF
--- a/.codex/cloud/maintenance.sh
+++ b/.codex/cloud/maintenance.sh
@@ -12,5 +12,4 @@ source "${HOME}/.sniffy-codex-env"
 
 # Resolve dependencies again after checkout. With a warm ~/.m2 cache this is
 # cheap, while still downloading dependencies introduced by the selected branch.
-mvn -T 1C -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -P ci \
-  || mvn -T 1C -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -P ci
+bash .codex/cloud/warm-maven-cache.sh

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -44,7 +44,7 @@ install_jdk() {
   archive="$(mktemp)"
   unpack="$(mktemp -d)"
 
-  curl --fail --location --retry 5 --retry-delay 2 \
+  curl --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
     "https://api.adoptium.net/v3/binary/latest/${feature}/ga/linux/${ADOPTIUM_ARCH}/jdk/hotspot/normal/eclipse?project=jdk" \
     --output "${archive}"
   tar -xzf "${archive}" -C "${unpack}"
@@ -67,7 +67,7 @@ done
 if [[ ! -x "${MAVEN_HOME_DIR}/bin/mvn" ]]; then
   echo "Installing Apache Maven ${MAVEN_VERSION}..."
   archive="$(mktemp)"
-  curl --fail --location --retry 5 --retry-delay 2 \
+  curl --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
     "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
     --output "${archive}"
   tar -xzf "${archive}" -C "${TOOLS_DIR}"
@@ -113,9 +113,6 @@ EOF_TOOLCHAINS
 java -version
 mvn -version
 
-# Prime the Maven cache using the same resolver and profile as CI. The retry
-# handles transient repository failures; it must not be copied into test runs.
-mvn -T 1C -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -U -P ci \
-  || mvn -T 1C -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -U -P ci
+bash .codex/cloud/warm-maven-cache.sh
 
 echo "Sniffy Codex Cloud environment is ready."

--- a/.codex/cloud/warm-maven-cache.sh
+++ b/.codex/cloud/warm-maven-cache.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Warm the Maven cache during Codex Cloud setup/maintenance.
+#
+# Setup and maintenance run with internet access, but all outbound traffic goes
+# through a proxy and transient Maven Central failures can occur. Retry with
+# backoff instead of immediately failing the whole environment build.
+
+MAX_ATTEMPTS="${SNIFFY_MAVEN_WARMUP_ATTEMPTS:-6}"
+BASE_DELAY_SECONDS="${SNIFFY_MAVEN_WARMUP_DELAY_SECONDS:-10}"
+CENTRAL_PROBE_URL="${SNIFFY_MAVEN_CENTRAL_PROBE_URL:-https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/5.1.1/maven-bundle-plugin-5.1.1.pom}"
+
+if ! [[ "${MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SNIFFY_MAVEN_WARMUP_ATTEMPTS must be a positive integer." >&2
+  exit 2
+fi
+
+if ! [[ "${BASE_DELAY_SECONDS}" =~ ^[0-9]+$ ]]; then
+  echo "SNIFFY_MAVEN_WARMUP_DELAY_SECONDS must be a non-negative integer." >&2
+  exit 2
+fi
+
+maven_args=(
+  -T 1C
+  -B
+  de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+  -U
+  -P ci
+  -Dmaven.wagon.http.retryHandler.count=5
+)
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  echo "Warming Maven cache (attempt ${attempt}/${MAX_ATTEMPTS})..."
+
+  if command -v curl >/dev/null 2>&1; then
+    if ! curl \
+      --fail \
+      --silent \
+      --show-error \
+      --location \
+      --retry 3 \
+      --retry-all-errors \
+      --retry-delay 2 \
+      --connect-timeout 15 \
+      --max-time 90 \
+      "${CENTRAL_PROBE_URL}" \
+      --output /dev/null; then
+      echo "Maven Central connectivity probe failed; Maven may still succeed." >&2
+    fi
+  fi
+
+  if mvn "${maven_args[@]}"; then
+    echo "Maven cache warm-up completed."
+    exit 0
+  fi
+
+  if ((attempt < MAX_ATTEMPTS)); then
+    delay=$((BASE_DELAY_SECONDS * attempt))
+    echo "Maven cache warm-up failed; retrying in ${delay} seconds." >&2
+    sleep "${delay}"
+  fi
+done
+
+echo "Maven cache warm-up failed after ${MAX_ATTEMPTS} attempts." >&2
+echo "The toolchain was installed, but the Cloud task would not be reliable with agent internet disabled." >&2
+echo "Retry after resetting the environment cache. For diagnosis only, increase SNIFFY_MAVEN_WARMUP_ATTEMPTS." >&2
+exit 1

--- a/docs/codex-cloud-troubleshooting.md
+++ b/docs/codex-cloud-troubleshooting.md
@@ -1,0 +1,25 @@
+# Codex Cloud environment troubleshooting
+
+## Maven cache warm-up failures
+
+Codex Cloud setup and maintenance run with internet access, but outbound traffic still passes through the Cloud network proxy. A temporary Maven Central failure can therefore occur even when the JDK and Maven downloads succeeded.
+
+The Sniffy environment uses `.codex/cloud/warm-maven-cache.sh` to:
+
+- probe Maven Central directly before each Maven attempt;
+- let Maven retry individual HTTP transfers five times;
+- retry the complete dependency-resolution command six times;
+- wait progressively longer between attempts;
+- fail with an explicit diagnostic rather than immediately aborting after two identical attempts.
+
+The cache warm-up remains mandatory because normal agent-phase internet is disabled. Allowing setup to succeed with an incomplete `~/.m2` cache would only move the same failure into the task itself.
+
+If setup still fails after all retries:
+
+1. Check whether the final output reports a failed Maven Central probe or a Maven resolution error.
+2. Ensure the environment uses the latest `develop` branch.
+3. Select **Reset cache** on the `sniffy` environment page. Codex also invalidates the cache automatically when setup or maintenance scripts change.
+4. Start the environment validation task again.
+5. For diagnosis, increase the `SNIFFY_MAVEN_WARMUP_ATTEMPTS` environment variable. Do not reduce it to zero or bypass cache warm-up while agent-phase internet is disabled.
+
+The setup script installs the toolchain before warming dependencies, so repeated runs reuse already installed JDKs and Maven from the cached container whenever the cache is available.


### PR DESCRIPTION
## Summary

Fix the Codex Cloud environment setup failure observed while warming the Maven cache.

## Root cause

The JDKs and Maven were installed successfully, but the setup script treated the Maven cache warm-up as a single mandatory command with only one immediate retry. A transient Maven Central/proxy failure while resolving `maven-bundle-plugin` therefore aborted the whole environment build.

## Changes

- add `.codex/cloud/warm-maven-cache.sh`;
- probe Maven Central before each resolve attempt;
- enable five Maven Wagon HTTP retries per attempt;
- retry the complete dependency resolution up to six times with increasing delays;
- use the same helper from setup and maintenance;
- keep warm-up mandatory when agent-phase internet is disabled;
- add troubleshooting and cache-reset instructions.

## Validation

- `bash -n` passes for setup, maintenance, and warm-up scripts;
- invalid retry/delay configuration is rejected explicitly;
- the branch diff contains only Cloud environment scripts and documentation.

## Follow-up validation

After merge, reset the `sniffy` Codex Cloud environment cache and rerun the environment validation task. The setup/maintenance script change should also invalidate the cache automatically, but an explicit reset avoids reusing the failed container state.