### PR TITLE
Configure Maven for Codex Cloud proxy

### DIFF
--- a/.codex/cloud/configure-maven-proxy.sh
+++ b/.codex/cloud/configure-maven-proxy.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Translate the standard proxy environment variables used by Codex Cloud into
+# Maven's supported ~/.m2/settings.xml proxy configuration.
+#
+# curl honours HTTPS_PROXY/HTTP_PROXY automatically. Maven does not reliably do
+# so, and Maven's official proxy configuration lives in settings.xml.
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required to configure Maven proxy settings." >&2
+  exit 1
+}
+
+python3 - <<'PY'
+import os
+import sys
+import urllib.parse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+PROXY_ID = "codex-cloud-env-proxy"
+DEFAULT_NS = "http://maven.apache.org/SETTINGS/1.0.0"
+XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
+SCHEMA_LOCATION = (
+    "http://maven.apache.org/SETTINGS/1.0.0 "
+    "https://maven.apache.org/xsd/settings-1.0.0.xsd"
+)
+
+
+def first_env(*names):
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def namespace_of(tag):
+    if tag.startswith("{"):
+        return tag[1:].split("}", 1)[0]
+    return ""
+
+
+def normalize_no_proxy(value):
+    if not value:
+        return ""
+    result = []
+    for token in value.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token.startswith("."):
+            token = "*" + token
+        result.append(token)
+    return "|".join(result)
+
+
+proxy_url = first_env("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy")
+settings_path = Path.home() / ".m2" / "settings.xml"
+
+if not proxy_url and not settings_path.exists():
+    print("No proxy environment variable is set; Maven proxy configuration is not required.")
+    sys.exit(0)
+
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+ET.register_namespace("", DEFAULT_NS)
+ET.register_namespace("xsi", XSI_NS)
+
+if settings_path.exists():
+    try:
+        tree = ET.parse(settings_path)
+    except ET.ParseError as exc:
+        print(f"Refusing to overwrite invalid Maven settings at {settings_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    root = tree.getroot()
+    namespace = namespace_of(root.tag)
+else:
+    namespace = DEFAULT_NS
+    root = ET.Element(
+        f"{{{namespace}}}settings",
+        {f"{{{XSI_NS}}}schemaLocation": SCHEMA_LOCATION},
+    )
+    tree = ET.ElementTree(root)
+
+
+def qname(local):
+    return f"{{{namespace}}}{local}" if namespace else local
+
+
+def child(parent, name, text=None):
+    element = ET.SubElement(parent, qname(name))
+    if text is not None:
+        element.text = text
+    return element
+
+
+proxies = root.find(qname("proxies"))
+if proxies is None:
+    proxies = child(root, "proxies")
+
+for existing in list(proxies):
+    proxy_id = existing.find(qname("id"))
+    if proxy_id is not None and proxy_id.text == PROXY_ID:
+        proxies.remove(existing)
+
+if not proxy_url:
+    if len(proxies) == 0:
+        root.remove(proxies)
+    ET.indent(tree, space="  ")
+    tree.write(settings_path, encoding="UTF-8", xml_declaration=True)
+    settings_path.chmod(0o600)
+    print("Removed stale Codex Cloud Maven proxy configuration.")
+    sys.exit(0)
+
+if "://" not in proxy_url:
+    proxy_url = "http://" + proxy_url
+
+try:
+    parsed = urllib.parse.urlsplit(proxy_url)
+    hostname = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+except ValueError as exc:
+    print(f"Invalid proxy URL: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if not hostname:
+    print("Proxy URL does not contain a hostname.", file=sys.stderr)
+    sys.exit(1)
+
+protocol = parsed.scheme or "http"
+username = urllib.parse.unquote(parsed.username) if parsed.username else None
+password = urllib.parse.unquote(parsed.password) if parsed.password else None
+non_proxy_hosts = normalize_no_proxy(first_env("NO_PROXY", "no_proxy"))
+
+# Maven supports only one active proxy. Keep any existing definitions, but make
+# the Cloud environment proxy the active one for this disposable environment.
+for existing in list(proxies):
+    active = existing.find(qname("active"))
+    if active is not None and (active.text or "").strip().lower() == "true":
+        active.text = "false"
+
+proxy = child(proxies, "proxy")
+child(proxy, "id", PROXY_ID)
+child(proxy, "active", "true")
+child(proxy, "protocol", protocol)
+child(proxy, "host", hostname)
+child(proxy, "port", str(port))
+if username is not None:
+    child(proxy, "username", username)
+if password is not None:
+    child(proxy, "password", password)
+if non_proxy_hosts:
+    child(proxy, "nonProxyHosts", non_proxy_hosts)
+
+ET.indent(tree, space="  ")
+tree.write(settings_path, encoding="UTF-8", xml_declaration=True)
+settings_path.chmod(0o600)
+print(f"Configured Maven proxy {hostname}:{port} from the Cloud proxy environment.")
+PY

--- a/.codex/cloud/maintenance.sh
+++ b/.codex/cloud/maintenance.sh
@@ -10,6 +10,10 @@ fi
 # shellcheck disable=SC1090
 source "${HOME}/.sniffy-codex-env"
 
+# Proxy endpoints are task-environment details and may change when a cached
+# container is resumed, so refresh Maven's settings before resolving anything.
+bash .codex/cloud/configure-maven-proxy.sh
+
 # Resolve dependencies again after checkout. With a warm ~/.m2 cache this is
 # cheap, while still downloading dependencies introduced by the selected branch.
 bash .codex/cloud/warm-maven-cache.sh

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -23,7 +23,7 @@ esac
 
 mkdir -p "${TOOLS_DIR}" "${JDKS_DIR}" "${HOME}/.m2"
 
-for command_name in curl tar git find; do
+for command_name in curl tar git find python3; do
   if ! command -v "${command_name}" >/dev/null 2>&1; then
     echo "Required command '${command_name}' is unavailable." >&2
     exit 1
@@ -109,6 +109,8 @@ cat > "${HOME}/.m2/toolchains.xml" <<EOF_TOOLCHAINS
   <toolchain><type>jdk</type><provides><version>25</version><vendor>temurin</vendor></provides><configuration><jdkHome>${JDKS_DIR}/temurin-25</jdkHome></configuration></toolchain>
 </toolchains>
 EOF_TOOLCHAINS
+
+bash .codex/cloud/configure-maven-proxy.sh
 
 java -version
 mvn -version

--- a/.codex/cloud/warm-maven-cache.sh
+++ b/.codex/cloud/warm-maven-cache.sh
@@ -3,13 +3,15 @@ set -uo pipefail
 
 # Warm the Maven cache during Codex Cloud setup/maintenance.
 #
-# Setup and maintenance run with internet access, but all outbound traffic goes
-# through a proxy and transient Maven Central failures can occur. Retry with
-# backoff instead of immediately failing the whole environment build.
+# Codex Cloud exposes outbound access through standard proxy environment
+# variables. configure-maven-proxy.sh translates them into Maven settings before
+# this script runs. Retries remain useful for individual repository failures, but
+# they are not a substitute for configuring Maven's proxy.
 
-MAX_ATTEMPTS="${SNIFFY_MAVEN_WARMUP_ATTEMPTS:-6}"
-BASE_DELAY_SECONDS="${SNIFFY_MAVEN_WARMUP_DELAY_SECONDS:-10}"
+MAX_ATTEMPTS="${SNIFFY_MAVEN_WARMUP_ATTEMPTS:-3}"
+BASE_DELAY_SECONDS="${SNIFFY_MAVEN_WARMUP_DELAY_SECONDS:-5}"
 CENTRAL_PROBE_URL="${SNIFFY_MAVEN_CENTRAL_PROBE_URL:-https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/5.1.1/maven-bundle-plugin-5.1.1.pom}"
+SETTINGS_FILE="${HOME}/.m2/settings.xml"
 
 if ! [[ "${MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
   echo "SNIFFY_MAVEN_WARMUP_ATTEMPTS must be a positive integer." >&2
@@ -21,36 +23,53 @@ if ! [[ "${BASE_DELAY_SECONDS}" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+proxy_url="${HTTPS_PROXY:-${https_proxy:-${HTTP_PROXY:-${http_proxy:-}}}}"
+if [[ -n "${proxy_url}" ]]; then
+  if [[ ! -f "${SETTINGS_FILE}" ]] || ! grep -Fq 'codex-cloud-env-proxy' "${SETTINGS_FILE}"; then
+    echo "Cloud proxy variables are set, but Maven proxy settings are missing." >&2
+    echo "Run: bash .codex/cloud/configure-maven-proxy.sh" >&2
+    exit 1
+  fi
+fi
+
 maven_args=(
   -T 1C
   -B
   de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
   -U
   -P ci
-  -Dmaven.wagon.http.retryHandler.count=5
+  -Dmaven.wagon.http.retryHandler.count=3
 )
+
+curl_probe_succeeded=false
+if command -v curl >/dev/null 2>&1; then
+  if curl \
+    --fail \
+    --silent \
+    --show-error \
+    --location \
+    --retry 2 \
+    --retry-all-errors \
+    --retry-delay 1 \
+    --connect-timeout 15 \
+    --max-time 90 \
+    "${CENTRAL_PROBE_URL}" \
+    --output /dev/null; then
+    curl_probe_succeeded=true
+  else
+    echo "Maven Central connectivity probe failed; Maven may still succeed." >&2
+  fi
+fi
 
 for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
   echo "Warming Maven cache (attempt ${attempt}/${MAX_ATTEMPTS})..."
 
-  if command -v curl >/dev/null 2>&1; then
-    if ! curl \
-      --fail \
-      --silent \
-      --show-error \
-      --location \
-      --retry 3 \
-      --retry-all-errors \
-      --retry-delay 2 \
-      --connect-timeout 15 \
-      --max-time 90 \
-      "${CENTRAL_PROBE_URL}" \
-      --output /dev/null; then
-      echo "Maven Central connectivity probe failed; Maven may still succeed." >&2
+  if ((attempt == MAX_ATTEMPTS)); then
+    if mvn -e "${maven_args[@]}"; then
+      echo "Maven cache warm-up completed."
+      exit 0
     fi
-  fi
-
-  if mvn "${maven_args[@]}"; then
+  elif mvn "${maven_args[@]}"; then
     echo "Maven cache warm-up completed."
     exit 0
   fi
@@ -63,6 +82,10 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
 done
 
 echo "Maven cache warm-up failed after ${MAX_ATTEMPTS} attempts." >&2
+if [[ "${curl_probe_succeeded}" == true ]]; then
+  echo "curl reached Maven Central through the environment proxy; inspect the Maven exception above and ~/.m2/settings.xml." >&2
+else
+  echo "Both the direct connectivity probe and Maven resolution failed; inspect Cloud internet policy and proxy variables." >&2
+fi
 echo "The toolchain was installed, but the Cloud task would not be reliable with agent internet disabled." >&2
-echo "Retry after resetting the environment cache. For diagnosis only, increase SNIFFY_MAVEN_WARMUP_ATTEMPTS." >&2
 exit 1

--- a/docs/codex-cloud-troubleshooting.md
+++ b/docs/codex-cloud-troubleshooting.md
@@ -2,24 +2,51 @@
 
 ## Maven cache warm-up failures
 
-Codex Cloud setup and maintenance run with internet access, but outbound traffic still passes through the Cloud network proxy. A temporary Maven Central failure can therefore occur even when the JDK and Maven downloads succeeded.
+Codex Cloud setup and maintenance run with internet access, but outbound traffic is exposed through standard proxy environment variables such as `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY`.
 
-The Sniffy environment uses `.codex/cloud/warm-maven-cache.sh` to:
+Command-line tools such as `curl` read those variables automatically. Maven does not reliably translate them into its own proxy configuration. Maven's supported proxy configuration lives in `${user.home}/.m2/settings.xml`.
 
-- probe Maven Central directly before each Maven attempt;
-- let Maven retry individual HTTP transfers five times;
-- retry the complete dependency-resolution command six times;
-- wait progressively longer between attempts;
-- fail with an explicit diagnostic rather than immediately aborting after two identical attempts.
+This distinction matters when logs show both of the following:
+
+- JDK and Maven archives download successfully with `curl`;
+- Maven repeatedly fails on the first artifact descriptor, for example `maven-bundle-plugin`, while the direct Maven Central probe succeeds.
+
+That pattern is a proxy-configuration failure, not a transient repository timeout. Repeating the same Maven command cannot fix it.
+
+The Sniffy environment now uses `.codex/cloud/configure-maven-proxy.sh` before dependency resolution. The script:
+
+- reads upper- and lower-case `HTTPS_PROXY` / `HTTP_PROXY` variables;
+- parses optional proxy credentials without printing them;
+- converts `NO_PROXY` into Maven `nonProxyHosts` syntax;
+- creates or updates the `codex-cloud-env-proxy` entry in `~/.m2/settings.xml`;
+- preserves unrelated Maven settings and makes the generated file readable only by the current user;
+- runs during both initial setup and cached-environment maintenance.
+
+`.codex/cloud/warm-maven-cache.sh` then:
+
+- verifies that Maven proxy settings exist when Cloud proxy variables are present;
+- probes Maven Central separately for diagnosis;
+- retries Maven dependency resolution three times for genuine transient failures;
+- enables Maven stack traces on the final attempt;
+- distinguishes a curl/proxy mismatch from complete network failure in its final diagnostic.
 
 The cache warm-up remains mandatory because normal agent-phase internet is disabled. Allowing setup to succeed with an incomplete `~/.m2` cache would only move the same failure into the task itself.
 
-If setup still fails after all retries:
+After merging a setup-script change:
 
-1. Check whether the final output reports a failed Maven Central probe or a Maven resolution error.
-2. Ensure the environment uses the latest `develop` branch.
-3. Select **Reset cache** on the `sniffy` environment page. Codex also invalidates the cache automatically when setup or maintenance scripts change.
-4. Start the environment validation task again.
-5. For diagnosis, increase the `SNIFFY_MAVEN_WARMUP_ATTEMPTS` environment variable. Do not reduce it to zero or bypass cache warm-up while agent-phase internet is disabled.
+1. Ensure the environment uses the latest `develop` branch.
+2. Select **Reset cache** on the `sniffy` environment page.
+3. Start the environment validation task again.
+4. Confirm that setup prints `Configured Maven proxy HOST:PORT from the Cloud proxy environment.` before Maven dependency resolution.
+5. If Maven still fails, use the stack trace from the final attempt. Do not increase retry counts until the reported exception has been understood.
 
-The setup script installs the toolchain before warming dependencies, so repeated runs reuse already installed JDKs and Maven from the cached container whenever the cache is available.
+For local script validation without exposing real credentials, use a temporary `HOME` and a synthetic proxy URL:
+
+```bash
+HOME="$(mktemp -d)" \
+HTTPS_PROXY='http://user%40example:password@proxy.example:3128' \
+NO_PROXY='localhost,127.0.0.1,.example.org' \
+bash .codex/cloud/configure-maven-proxy.sh
+```
+
+Inspect the generated `~/.m2/settings.xml` only in the temporary directory. Never print a real Cloud proxy URL because it may contain credentials.


### PR DESCRIPTION
## Summary

Fix Codex Cloud environment setup by configuring Maven to use the proxy already exposed through `HTTPS_PROXY` / `HTTP_PROXY`.

## Root cause

The previous warm-up fix treated the failure as a transient Maven Central timeout. The new logs show otherwise:

- all JDK and Maven archives download successfully with `curl`;
- the direct Maven Central probe succeeds on every attempt;
- Maven fails deterministically on the first `maven-bundle-plugin` descriptor six times in a row.

`curl` reads the standard proxy environment variables automatically. Maven does not reliably translate those variables into its supported proxy configuration, so retries cannot change the outcome.

## Changes

- add `.codex/cloud/configure-maven-proxy.sh`;
- read upper- and lower-case `HTTPS_PROXY` / `HTTP_PROXY` values;
- parse optional percent-encoded credentials without logging them;
- convert `NO_PROXY` into Maven `nonProxyHosts` syntax;
- merge an active `codex-cloud-env-proxy` entry into `~/.m2/settings.xml` while preserving unrelated settings;
- protect generated settings with mode `0600`;
- configure Maven during both initial setup and cached-environment maintenance;
- make warm-up fail immediately when Cloud proxy variables exist but Maven settings are missing;
- reduce full-command retries from six to three and enable Maven stack traces on the final attempt;
- update troubleshooting guidance to distinguish proxy mismatch from genuine network failure.

## Validation

The proxy configuration script was validated with temporary HOME directories and synthetic proxy values:

- generated valid namespaced Maven settings;
- decoded percent-encoded username/password values;
- converted `.example.org` to `*.example.org` in `nonProxyHosts`;
- preserved existing `servers` and proxy definitions;
- remained idempotent across repeated execution;
- wrote `settings.xml` with mode `0600`;
- rejected invalid XML rather than overwriting it.

Shell syntax was checked for the new and modified scripts. The complete Cloud setup cannot be reproduced outside Codex Cloud because the real proxy environment is supplied by the platform.

## Cloud validation after merge

1. Reset the `sniffy` Codex Cloud environment cache.
2. Start the environment validation task again.
3. Confirm setup prints `Configured Maven proxy HOST:PORT from the Cloud proxy environment.` before Maven resolution.
4. Confirm the `maven-bundle-plugin` descriptor resolves and the cache warm-up proceeds.

Do not print the real proxy URL: it may contain credentials.