### PR TITLE
deps: update Logback to 1.5.38

### DIFF
--- a/sniffy-integration-tests/sniffy-integration-tests-spring-boot/pom.xml
+++ b/sniffy-integration-tests/sniffy-integration-tests-spring-boot/pom.xml
@@ -32,12 +32,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.5.34</version>
+                <version>1.5.38</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.5.34</version>
+                <version>1.5.38</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>


### PR DESCRIPTION
Supersedes #629.

Updates `logback-core` and `logback-classic` together so the explicitly aligned Spring Boot 4 logging stack remains consistent. Dependabot proposed `logback-core` 1.5.35 only, but that release contains only a partial fix for CVE-2026-13006; 1.5.37 contains the definitive fix and 1.5.38 is the current patch release.