### PR TITLE
deps: migrate Bouncy Castle tests to jdk18on 1.84

### DIFF
--- a/sniffy-compatibility-tests/sniffy-compatibility-tests-decrypt-tls-nio/pom.xml
+++ b/sniffy-compatibility-tests/sniffy-compatibility-tests-decrypt-tls-nio/pom.xml
@@ -28,18 +28,18 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bctls-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId> <!-- TODO: test without it as well -->
-            <artifactId>bcprov-debug-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bcprov-debug-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-bc-after-sniffy/pom.xml
+++ b/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-bc-after-sniffy/pom.xml
@@ -42,18 +42,18 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bctls-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId> <!-- TODO: test without it as well -->
-            <artifactId>bcprov-debug-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bcprov-debug-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-bc-common/pom.xml
+++ b/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-bc-common/pom.xml
@@ -15,13 +15,13 @@
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bctls-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
     </dependencies>
 </project>

--- a/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-bc/pom.xml
+++ b/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-bc/pom.xml
@@ -32,18 +32,18 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bctls-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId> <!-- TODO: test without it as well -->
-            <artifactId>bcprov-debug-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bcprov-debug-jdk18on</artifactId>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/sniffy-module-tls/pom.xml
+++ b/sniffy-module-tls/pom.xml
@@ -35,14 +35,14 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bctls-jdk18on</artifactId>
+            <version>1.84</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.68</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.84</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Fixes the Dependabot security update failure for `org.bouncycastle:bcpkix-jdk15on`.

The `-jdk15on` artifact line ended at 1.70, so Dependabot cannot express the required migration as a normal version bump. This PR migrates all matching Sniffy TLS and compatibility-test dependencies together:

- `bctls-jdk15on` → `bctls-jdk18on`
- `bcpkix-jdk15on` → `bcpkix-jdk18on`
- `bcprov-debug-jdk15on` → `bcprov-debug-jdk18on`
- version `1.68` → `1.84`

The `jdk18on` distribution retains the Java 8+ runtime baseline. FIPS dependencies are intentionally unchanged.

Validation: full GitHub Actions PR matrix, including JDK 8, IBM J9, CodeQL, macOS/Windows/Linux and emulated architectures.