### PR TITLE
[codex] Persist GitHub auth from Cloud setup

### DIFF
--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -27,6 +27,39 @@ for command_name in curl tar find mise mvn; do
   fi
 done
 
+configure_github_auth() {
+  if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "GH_TOKEN is not configured; GitHub push and PR operations will be unavailable."
+    return
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "GH_TOKEN is configured, but GitHub CLI (gh) is unavailable in the Codex image." >&2
+    exit 1
+  fi
+
+  echo "Configuring persistent GitHub authentication for the agent phase..."
+  local github_token="${GH_TOKEN}"
+  unset GH_TOKEN
+
+  printf '%s\n' "${github_token}" |
+    gh auth login --hostname github.com --git-protocol https --with-token --insecure-storage
+  unset github_token
+
+  gh auth setup-git --hostname github.com
+
+  local can_push
+  can_push="$(gh api repos/sniffy/sniffy --jq '.permissions.push')"
+  if [[ "${can_push}" != "true" ]]; then
+    echo "GH_TOKEN authenticates successfully but does not grant push access to sniffy/sniffy." >&2
+    exit 1
+  fi
+
+  gh auth status --hostname github.com
+}
+
+configure_github_auth
+
 mkdir -p "${JDKS_DIR}" "${HOME}/.m2"
 
 install_jdk8() {

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -5,7 +5,7 @@ This document describes the one-time Codex Cloud setup for Sniffy and the operat
 ## 1. What is stored in the repository
 
 - `AGENTS.md` contains repository-wide engineering, autonomy, verification, and review rules.
-- `.codex/cloud/setup.sh` installs Maven and Temurin JDK 8, 11, 17, 21, and 25, writes Maven toolchains, persists the environment, and primes the Maven dependency cache.
+- `.codex/cloud/setup.sh` installs Maven and Temurin JDK 8, 11, 17, 21, and 25, writes Maven toolchains, persists the environment, configures GitHub authentication when the `GH_TOKEN` secret is present, and primes the Maven dependency cache.
 - `.codex/cloud/maintenance.sh` refreshes dependencies when a cached cloud environment is resumed on another branch.
 - `.codex/cloud/use-jdk.sh` switches the current shell between installed JDKs.
 - `.codex/local/run-issue.sh` prepares an issue branch and launches unattended local Codex in an isolated machine.
@@ -34,9 +34,10 @@ The repository files cannot create an environment in another user's OpenAI accou
    ```
 
 7. Keep agent-phase internet disabled for ordinary implementation tasks. Enable limited internet only when a task explicitly requires current external documentation, vulnerability/advisory lookup, or dependency metadata that was not available during setup.
-8. Do not add repository or Maven Central credentials: Sniffy is public and its normal build should use public dependencies. Add a secret only for a task that genuinely requires a private external service. Cloud secrets are intended for setup and are removed before the agent phase.
-9. Reset the environment cache after changing the setup or maintenance scripts, or when the cached toolchain becomes inconsistent.
-10. In Codex settings, enable code review for this repository. Automatic review may be enabled after the review rules in `AGENTS.md` have produced useful results on several test pull requests.
+8. Add a Codex environment secret named `GH_TOKEN` when Cloud tasks should push branches and create or update pull requests autonomously. Use a dedicated, revocable, fine-grained PAT scoped only to `sniffy/sniffy`, with the minimum required repository permissions: Metadata read, Contents read/write, Pull requests read/write, and Issues read/write. Add Actions permissions only when a task must operate workflow runs.
+9. The setup script consumes `GH_TOKEN` while secrets are available, stores it in GitHub CLI's host configuration, and configures Git to use GitHub CLI as its credential helper. This intentionally makes the PAT's authority available to the agent phase even though the `GH_TOKEN` environment variable itself is removed. Never use a broad personal or organization-wide token for this environment.
+10. Codex invalidates the environment cache when the setup script or secrets change. Use **Reset cache** if the next task still uses stale credentials or an inconsistent cached toolchain.
+11. In Codex settings, enable code review for this repository. Automatic review may be enabled after the review rules in `AGENTS.md` have produced useful results on several test pull requests.
 
 The setup phase has internet access and the agent phase follows the environment's configured internet policy. Cached environments may be reused, so the maintenance script must remain safe and idempotent.
 
@@ -45,7 +46,7 @@ The setup phase has internet access and the agent phase follows the environment'
 Start a small cloud task on `develop` with this prompt:
 
 ```text
-Validate the Sniffy development environment only. Read AGENTS.md, report the active Java and Maven versions, switch to JDK 8 and JDK 25 using .codex/cloud/use-jdk.sh, run git diff --check, and run one small focused Maven test without changing tracked files. Report every command and result. Do not create a pull request.
+Validate the Sniffy development environment only. Read AGENTS.md, report the active Java and Maven versions, verify GitHub authentication with `gh auth status --hostname github.com` and confirm push permission using `gh api repos/sniffy/sniffy --jq '.permissions.push'`, switch to JDK 8 and JDK 25 using .codex/cloud/use-jdk.sh, run git diff --check, and run one small focused Maven test without changing tracked files. Report every command and result. Do not create a branch or pull request.
 ```
 
 For manual validation inside a shell:


### PR DESCRIPTION
## Problem

Codex Cloud secrets are available only while the setup script runs and are removed before the agent phase. Adding a `GH_TOKEN` secret alone therefore does not let the agent push branches or create/update pull requests. This blocked autonomous delivery for #637: the agent could commit locally, but `git push` had no credentials.

## Change

- Consume `GH_TOKEN` during `.codex/cloud/setup.sh`.
- Feed the token to `gh auth login` over stdin and immediately unset the environment variable.
- Persist the credential in GitHub CLI's container-local host configuration and configure Git to use `gh` as its credential helper.
- Fail setup when the token authenticates but lacks push access to `sniffy/sniffy`.
- Keep the setup optional when `GH_TOKEN` is not configured.
- Document the required secret, minimum fine-grained PAT permissions, cache behavior, validation commands, and security trade-off.

The credential is intentionally persisted because the agent phase must use it after Codex removes setup secrets. It is never written to the repository or command-line arguments. The environment should use a dedicated, revocable, repository-scoped PAT; GitHub CLI stores it in the ephemeral/cached container with restricted file permissions.

## Verification

- `bash -n .codex/cloud/setup.sh`
- Reviewed the complete two-file diff.
- The real authentication flow must be validated by Codex Cloud after this PR is merged and the environment cache is rebuilt/invalidated.

## Rollout

After merging, reset the `sniffy` Codex Cloud environment cache if it is not invalidated automatically, run the documented no-change validation task, then re-dispatch #637.

Unblocks #637.