### PR TITLE
[codex] Install GitHub CLI in Cloud setup

### DIFF
--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -10,22 +10,70 @@ set -euo pipefail
 JDKS_DIR="${HOME}/.jdks"
 JDK8_HOME="${JDKS_DIR}/temurin-8"
 ENV_FILE="${HOME}/.sniffy-codex-env"
+GH_VERSION="2.96.0"
+GH_BIN_DIR="${HOME}/.local/bin"
+GH_INSTALL_DIR="${HOME}/.local/share/gh/${GH_VERSION}"
 
 case "$(uname -m)" in
-  x86_64) ADOPTIUM_ARCH="x64" ;;
-  aarch64|arm64) ADOPTIUM_ARCH="aarch64" ;;
+  x86_64)
+    ADOPTIUM_ARCH="x64"
+    GH_ARCH="amd64"
+    GH_SHA256="83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60"
+    ;;
+  aarch64|arm64)
+    ADOPTIUM_ARCH="aarch64"
+    GH_ARCH="arm64"
+    GH_SHA256="06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909"
+    ;;
   *)
     echo "Unsupported architecture: $(uname -m)" >&2
     exit 1
     ;;
 esac
 
-for command_name in curl tar find mise mvn; do
+for command_name in curl tar find install ln sha256sum mise mvn; do
   if ! command -v "${command_name}" >/dev/null 2>&1; then
     echo "Required command '${command_name}' is unavailable in the Codex image." >&2
     exit 1
   fi
 done
+
+install_github_cli() {
+  if [[ ! -x "${GH_INSTALL_DIR}/bin/gh" ]]; then
+    echo "Installing GitHub CLI ${GH_VERSION}..."
+    local archive asset extracted unpack
+    asset="gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz"
+    archive="$(mktemp)"
+    unpack="$(mktemp -d)"
+    trap 'rm -rf "${archive:-}" "${unpack:-}"' RETURN
+
+    curl --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${asset}" \
+      --output "${archive}"
+    printf '%s  %s\n' "${GH_SHA256}" "${archive}" | sha256sum --check --status
+
+    tar -xzf "${archive}" -C "${unpack}"
+    extracted="${unpack}/gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh"
+    if [[ ! -x "${extracted}" ]]; then
+      echo "Could not locate the extracted GitHub CLI binary." >&2
+      exit 1
+    fi
+
+    install -d "${GH_INSTALL_DIR}/bin"
+    install -m 0755 "${extracted}" "${GH_INSTALL_DIR}/bin/gh"
+    rm -rf "${archive}" "${unpack}"
+    trap - RETURN
+  else
+    echo "GitHub CLI ${GH_VERSION} already installed."
+  fi
+
+  install -d "${GH_BIN_DIR}"
+  ln -sfn "${GH_INSTALL_DIR}/bin/gh" "${GH_BIN_DIR}/gh"
+  export PATH="${GH_BIN_DIR}:${PATH}"
+  gh --version
+}
+
+install_github_cli
 
 configure_github_auth() {
   if [[ -z "${GH_TOKEN:-}" ]]; then
@@ -116,7 +164,7 @@ export SNIFFY_JDK17_HOME="${JDK17_HOME}"
 export SNIFFY_JDK21_HOME="${JDK21_HOME}"
 export SNIFFY_JDK25_HOME="${JDK25_HOME}"
 export JAVA_HOME="${JDK25_HOME}"
-export PATH="${JDK25_HOME}/bin:\${PATH}"
+export PATH="${JDK25_HOME}/bin:${GH_BIN_DIR}:\${PATH}"
 EOF_ENV
 
 for shell_file in "${HOME}/.bashrc" "${HOME}/.profile"; do

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -52,7 +52,7 @@ install_github_cli() {
       --output "${archive}"
     printf '%s  %s\n' "${GH_SHA256}" "${archive}" | sha256sum --check --status
 
-    tar -xzf "${archive}" -C "${unpack}"
+    tar --no-same-owner -xzf "${archive}" -C "${unpack}"
     extracted="${unpack}/gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh"
     if [[ ! -x "${extracted}" ]]; then
       echo "Could not locate the extracted GitHub CLI binary." >&2

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -35,7 +35,7 @@ The repository files cannot create an environment in another user's OpenAI accou
 
 7. Keep agent-phase internet disabled for ordinary implementation tasks. Enable limited internet only when a task explicitly requires current external documentation, vulnerability/advisory lookup, or dependency metadata that was not available during setup.
 8. Add a Codex environment secret named `GH_TOKEN` when Cloud tasks should push branches and create or update pull requests autonomously. Use a dedicated, revocable, fine-grained PAT scoped only to `sniffy/sniffy`, with the minimum required repository permissions: Metadata read, Contents read/write, Pull requests read/write, and Issues read/write. Add Actions permissions only when a task must operate workflow runs.
-9. The setup script consumes `GH_TOKEN` while secrets are available, stores it in GitHub CLI's host configuration, and configures Git to use GitHub CLI as its credential helper. This intentionally makes the PAT's authority available to the agent phase even though the `GH_TOKEN` environment variable itself is removed. Never use a broad personal or organization-wide token for this environment.
+9. The setup script first installs the pinned GitHub CLI release into `~/.local`, verifies its published SHA-256 checksum, then consumes `GH_TOKEN` while secrets are available, stores it in GitHub CLI's host configuration, and configures Git to use GitHub CLI as its credential helper. This intentionally makes the PAT's authority available to the agent phase even though the `GH_TOKEN` environment variable itself is removed. Never use a broad personal or organization-wide token for this environment.
 10. Codex invalidates the environment cache when the setup script or secrets change. Use **Reset cache** if the next task still uses stale credentials or an inconsistent cached toolchain.
 11. In Codex settings, enable code review for this repository. Automatic review may be enabled after the review rules in `AGENTS.md` have produced useful results on several test pull requests.
 
@@ -46,7 +46,7 @@ The setup phase has internet access and the agent phase follows the environment'
 Start a small cloud task on `develop` with this prompt:
 
 ```text
-Validate the Sniffy development environment only. Read AGENTS.md, report the active Java and Maven versions, verify GitHub authentication with `gh auth status --hostname github.com` and confirm push permission using `gh api repos/sniffy/sniffy --jq '.permissions.push'`, switch to JDK 8 and JDK 25 using .codex/cloud/use-jdk.sh, run git diff --check, and run one small focused Maven test without changing tracked files. Report every command and result. Do not create a branch or pull request.
+Validate the Sniffy development environment only. Read AGENTS.md, report the active Java and Maven versions, report `gh --version`, verify GitHub authentication with `gh auth status --hostname github.com` and confirm push permission using `gh api repos/sniffy/sniffy --jq '.permissions.push'`, switch to JDK 8 and JDK 25 using .codex/cloud/use-jdk.sh, run git diff --check, and run one small focused Maven test without changing tracked files. Report every command and result. Do not create a branch or pull request.
 ```
 
 For manual validation inside a shell:


### PR DESCRIPTION
## Problem

After #638 was merged and the Codex Cloud cache was reset, a fresh task for #637 stopped during setup:

```
GH_TOKEN is configured, but GitHub CLI (gh) is unavailable in the Codex image.
```

The authentication logic added by #638 therefore cannot run, and Codex cannot publish its branch or draft pull request.

## Design

- install the pinned GitHub CLI 2.96.0 under `~/.local/share/gh` without `sudo`
- expose it through `~/.local/bin/gh` and persist that path for the agent phase
- support the Cloud image architectures `x86_64` and `aarch64`
- verify each official release archive with its pinned SHA-256 before extraction
- use `tar --no-same-owner` so extraction works in an unprivileged container
- keep setup idempotent by reusing an already installed pinned binary
- document the installed CLI and validation output

This unblocks the autonomous implementation requested in #637. It does not implement the flaky-test fix itself.

## Compatibility and dependencies

No project dependency, Java source, public API, or runtime compatibility changes. The setup script adds one user-local prebuilt tool for supported Linux architectures. It relies only on commands already expected in the Cloud image and now checked explicitly.

## Verification

Passed:

- `bash -n .codex/cloud/setup.sh`
- real Linux AMD64 smoke test with `set -euo pipefail`: downloaded the official 2.96.0 archive, verified SHA-256, extracted it with `--no-same-owner`, and ran `gh --version`
- reviewed the complete diff against current `develop` after #638

Not run locally:

- live `GH_TOKEN` login, repository push-permission check, branch push, and PR creation; the secret exists only in Codex Cloud and must be validated there after merge and cache reset
- ARM64 execution; its official checksum is pinned, while execution is left to an ARM64 environment

## Remaining risks

GitHub CLI versions and checksums are intentionally pinned, so a future upgrade requires updating this script. A transient GitHub Releases outage can still fail a cold setup; retries are enabled, and cached environments reuse the installed binary.

Draft intentionally. Do not merge or enable auto-merge until reviewed.