### PR TITLE
[codex] Fix Cloud push probe without origin remote

### DIFF
--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -100,7 +100,7 @@ configure_github_auth() {
   auth_login="$(gh api user --jq '.login')"
   probe_branch="agent/codex-auth-check-$(git rev-parse --short=12 HEAD)"
 
-  if ! push_error="$(git push --dry-run --porcelain origin "HEAD:refs/heads/${probe_branch}" 2>&1)"; then
+  if ! push_error="$(git push --dry-run --porcelain https://github.com/sniffy/sniffy.git "HEAD:refs/heads/${probe_branch}" 2>&1)"; then
     echo "GH_TOKEN authenticates as ${auth_login}, but GitHub rejected a dry-run push to sniffy/sniffy:" >&2
     printf '%s\n' "${push_error}" >&2
     echo "The repository .permissions.push flag only describes the account role; token permissions can be narrower." >&2

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -46,7 +46,7 @@ The setup phase has internet access and the agent phase follows the environment'
 Start a small cloud task on `develop` with this prompt:
 
 ```text
-Validate the Sniffy development environment only. Read AGENTS.md, report the active Java and Maven versions, report `gh --version`, verify GitHub authentication with `gh auth status --hostname github.com`, and confirm effective write authorization with `git push --dry-run --porcelain origin "HEAD:refs/heads/agent/codex-auth-check-$(git rev-parse --short=12 HEAD)"`. The dry run must not create a remote ref. Switch to JDK 8 and JDK 25 using .codex/cloud/use-jdk.sh, run git diff --check, and run one small focused Maven test without changing tracked files. Report every command and result. Do not create a branch or pull request.
+Validate the Sniffy development environment only. Read AGENTS.md, report the active Java and Maven versions, report `gh --version`, verify GitHub authentication with `gh auth status --hostname github.com`, and confirm effective write authorization with `git push --dry-run --porcelain https://github.com/sniffy/sniffy.git "HEAD:refs/heads/agent/codex-auth-check-$(git rev-parse --short=12 HEAD)"`. The dry run must not create a remote ref. Switch to JDK 8 and JDK 25 using .codex/cloud/use-jdk.sh, run git diff --check, and run one small focused Maven test without changing tracked files. Report every command and result. Do not create a branch or pull request.
 ```
 
 For manual validation inside a shell:


### PR DESCRIPTION
## Problem

The effective push-permission probe added by #640 assumes the Codex setup checkout already has a Git remote named `origin`. In the actual setup phase it does not, so the setup failed locally before contacting GitHub:

```
fatal: 'origin' does not appear to be a git repository
```

This means the newly approved `GH_TOKEN` was never tested.

## Fix

Use the repository's explicit HTTPS URL, `https://github.com/sniffy/sniffy.git`, for the non-mutating dry-run push. GitHub CLI's configured credential helper applies to the `github.com` URL, while the check no longer depends on checkout remote metadata that is unavailable during setup.

Update the documented validation command to use the same remote-independent URL.

## Compatibility and scope

No Java, dependency, production, or public API changes. The push probe remains a dry run and does not create a remote ref.

## Verification

- `bash -n .codex/cloud/setup.sh`
- complete diff review against current `develop`
- exactly two one-line substitutions; no other files changed

Live authorization will be verified by the next Codex Cloud setup using the approved environment token.

Draft intentionally. Do not merge or enable auto-merge until reviewed.