### PR TITLE
Bound Vert.x TLS integration test

### DIFF
--- a/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-vertx/src/test/java/io/sniffy/tls/DecryptLocalhostHttpsTrafficVertXTest.java
+++ b/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-vertx/src/test/java/io/sniffy/tls/DecryptLocalhostHttpsTrafficVertXTest.java
@@ -28,9 +28,9 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.sniffy.socket.NetworkPacket.convertNetworkPacketsToString;
 import static org.junit.Assert.*;
@@ -77,41 +77,62 @@ public class DecryptLocalhostHttpsTrafficVertXTest {
     }
 
     @SuppressWarnings("CharsetObjectCanBeUsed")
-    @Test
+    @Test(timeout = 60000)
     public void testLocalhostHttpsTraffic() throws Exception {
 
         try (Spy<?> spy = Sniffy.spy(SpyConfiguration.builder().captureNetworkTraffic(true).captureStackTraces(true).build())) {
 
             Vertx vertx = Vertx.vertx();
-            HttpRequest<Buffer> httpRequest = WebClient.create(vertx)
-                    .get(port, "localhost", "/")
-                    .ssl(true)
-                    .expect(ResponsePredicate.SC_OK);
+            WebClient webClient = WebClient.create(vertx);
+            Throwable failure = null;
+            try {
+                HttpRequest<Buffer> httpRequest = webClient
+                        .get(port, "localhost", "/")
+                        .ssl(true)
+                        .expect(ResponsePredicate.SC_OK);
 
-            CyclicBarrier cb = new CyclicBarrier(2);
+                CountDownLatch requestComplete = new CountDownLatch(1);
+                AtomicReference<Throwable> asyncFailure = new AtomicReference<Throwable>();
 
-            AtomicBoolean success = new AtomicBoolean(false);
+                httpRequest.send(asyncResult -> {
+                    try {
+                        LOG.debug("HTTP Request complete; received result " + asyncResult + "; succeeded=" + asyncResult.succeeded());
+                        if (asyncResult.failed()) {
+                            Throwable cause = asyncResult.cause();
+                            if (null == cause) {
+                                cause = new AssertionError("Vert.x HTTP request failed without a cause");
+                            }
+                            asyncFailure.set(cause);
+                        }
+                    } catch (Throwable e) {
+                        asyncFailure.compareAndSet(null, e);
+                    } finally {
+                        requestComplete.countDown();
+                    }
+                });
 
-            httpRequest.send(asyncResult -> {
-                LOG.debug("HTTP Request complete; received result " + asyncResult + "; succeeded=" + asyncResult.succeeded());
-                if (asyncResult.failed()) {
-                    asyncResult.cause().printStackTrace();
-                    System.err.println(asyncResult.result().bodyAsString());
+                assertTrue("Timed out waiting for Vert.x HTTPS request completion", requestComplete.await(30, TimeUnit.SECONDS));
+
+                Throwable asyncThrowable = asyncFailure.get();
+                if (null != asyncThrowable) {
+                    throw ExceptionUtil.throwException(asyncThrowable);
                 }
-                success.set(asyncResult.succeeded());
-                try {
-                    cb.await();
-                } catch (InterruptedException | BrokenBarrierException e) {
-                    throw ExceptionUtil.throwException(e);
+
+                {
+                    Map<SocketMetaData, List<NetworkPacket>> networkTraffic = spy.getNetworkTraffic(
+                            Threads.ANY,
+                            AddressMatchers.exactAddressMatcher("localhost:" + port),
+                            GroupingOptions.builder().
+                                    groupByConnection(false).
+                                    groupByStackTrace(false).
+                                    groupByThread(false).
+                                    build()
+                    );
+
+                    assertEquals(1, networkTraffic.size());
                 }
-            });
 
-            cb.await();
-
-            assertTrue(success.get());
-
-            {
-                Map<SocketMetaData, List<NetworkPacket>> networkTraffic = spy.getNetworkTraffic(
+                Map<SocketMetaData, List<NetworkPacket>> decryptedNetworkTraffic = spy.getDecryptedNetworkTraffic(
                         Threads.ANY,
                         AddressMatchers.exactAddressMatcher("localhost:" + port),
                         GroupingOptions.builder().
@@ -121,42 +142,83 @@ public class DecryptLocalhostHttpsTrafficVertXTest {
                                 build()
                 );
 
-                assertEquals(1, networkTraffic.size());
+                assertEquals(1, decryptedNetworkTraffic.size());
+
+                Map.Entry<SocketMetaData, List<NetworkPacket>> entry = decryptedNetworkTraffic.entrySet().iterator().next();
+
+                assertNotNull(entry);
+                assertNotNull(entry.getKey());
+                assertNotNull(entry.getValue());
+
+                assertEquals("Expected 2 packets, but instead got " + convertNetworkPacketsToString(entry.getValue()), 2, entry.getValue().size());
+
+                NetworkPacket request = entry.getValue().get(0);
+                NetworkPacket response = entry.getValue().get(1);
+
+                //noinspection SimplifiableAssertion
+                assertEquals(true, request.isSent());
+                //noinspection SimplifiableAssertion
+                assertEquals(false, response.isSent());
+
+                assertTrue(new String(request.getBytes(), Charset.forName("US-ASCII")).toLowerCase(Locale.ROOT).contains("host: localhost"));
+                assertTrue(new String(response.getBytes(), Charset.forName("US-ASCII")).contains("200"));
+
+            } catch (Throwable e) {
+                failure = e;
+                throw ExceptionUtil.throwException(e);
+            } finally {
+                failure = closeWebClient(webClient, failure);
+                failure = closeVertx(vertx, failure);
+                if (null != failure) {
+                    throw ExceptionUtil.throwException(failure);
+                }
             }
-
-            Map<SocketMetaData, List<NetworkPacket>> decryptedNetworkTraffic = spy.getDecryptedNetworkTraffic(
-                    Threads.ANY,
-                    AddressMatchers.exactAddressMatcher("localhost:" + port),
-                    GroupingOptions.builder().
-                            groupByConnection(false).
-                            groupByStackTrace(false).
-                            groupByThread(false).
-                            build()
-            );
-
-            assertEquals(1, decryptedNetworkTraffic.size());
-
-            Map.Entry<SocketMetaData, List<NetworkPacket>> entry = decryptedNetworkTraffic.entrySet().iterator().next();
-
-            assertNotNull(entry);
-            assertNotNull(entry.getKey());
-            assertNotNull(entry.getValue());
-
-            assertEquals("Expected 2 packets, but instead got " + convertNetworkPacketsToString(entry.getValue()), 2, entry.getValue().size());
-
-            NetworkPacket request = entry.getValue().get(0);
-            NetworkPacket response = entry.getValue().get(1);
-
-            //noinspection SimplifiableAssertion
-            assertEquals(true, request.isSent());
-            //noinspection SimplifiableAssertion
-            assertEquals(false, response.isSent());
-
-            assertTrue(new String(request.getBytes(), Charset.forName("US-ASCII")).toLowerCase(Locale.ROOT).contains("host: localhost"));
-            assertTrue(new String(response.getBytes(), Charset.forName("US-ASCII")).contains("200"));
 
         }
 
+    }
+
+    private static Throwable closeWebClient(WebClient webClient, Throwable failure) {
+        try {
+            webClient.close();
+        } catch (Throwable e) {
+            failure = addSuppressed(failure, e);
+        }
+        return failure;
+    }
+
+    private static Throwable closeVertx(Vertx vertx, Throwable failure) {
+        final CountDownLatch vertxClosed = new CountDownLatch(1);
+        final AtomicReference<Throwable> closeFailure = new AtomicReference<Throwable>();
+        try {
+            vertx.close(asyncResult -> {
+                try {
+                    if (asyncResult.failed()) {
+                        closeFailure.set(asyncResult.cause());
+                    }
+                } finally {
+                    vertxClosed.countDown();
+                }
+            });
+            if (!vertxClosed.await(30, TimeUnit.SECONDS)) {
+                closeFailure.compareAndSet(null, new AssertionError("Timed out waiting for Vert.x shutdown"));
+            }
+        } catch (Throwable e) {
+            closeFailure.compareAndSet(null, e);
+        }
+        Throwable closeThrowable = closeFailure.get();
+        if (null != closeThrowable) {
+            failure = addSuppressed(failure, closeThrowable);
+        }
+        return failure;
+    }
+
+    private static Throwable addSuppressed(Throwable failure, Throwable suppressed) {
+        if (null == failure) {
+            return suppressed;
+        }
+        failure.addSuppressed(suppressed);
+        return failure;
     }
 
 }

--- a/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-vertx/src/test/java/io/sniffy/tls/DecryptLocalhostHttpsTrafficVertXTest.java
+++ b/sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-vertx/src/test/java/io/sniffy/tls/DecryptLocalhostHttpsTrafficVertXTest.java
@@ -83,9 +83,10 @@ public class DecryptLocalhostHttpsTrafficVertXTest {
         try (Spy<?> spy = Sniffy.spy(SpyConfiguration.builder().captureNetworkTraffic(true).captureStackTraces(true).build())) {
 
             Vertx vertx = Vertx.vertx();
-            WebClient webClient = WebClient.create(vertx);
+            WebClient webClient = null;
             Throwable failure = null;
             try {
+                webClient = WebClient.create(vertx);
                 HttpRequest<Buffer> httpRequest = webClient
                         .get(port, "localhost", "/")
                         .ssl(true)
@@ -179,10 +180,12 @@ public class DecryptLocalhostHttpsTrafficVertXTest {
     }
 
     private static Throwable closeWebClient(WebClient webClient, Throwable failure) {
-        try {
-            webClient.close();
-        } catch (Throwable e) {
-            failure = addSuppressed(failure, e);
+        if (null != webClient) {
+            try {
+                webClient.close();
+            } catch (Throwable e) {
+                failure = addSuppressed(failure, e);
+            }
         }
         return failure;
     }


### PR DESCRIPTION
## Problem

Fixes #637. The Vert.x TLS integration test used a two-party CyclicBarrier, so an async failure or callback exception could leave the JUnit thread waiting indefinitely.

## Design

- Replace barrier coordination with CountDownLatch plus AtomicReference<Throwable>.
- Ensure the callback always releases the test thread from a finally block.
- Avoid dereferencing asyncResult.result() when the Vert.x request failed.
- Propagate asyncResult.cause() back to the JUnit thread as the primary failure.
- Add explicit bounded request and Vert.x shutdown waits plus a last-resort JUnit timeout.
- Close WebClient and Vertx on every path, preserving the primary failure and suppressing cleanup failures.

## Compatibility impact

Java 8-compatible test-only change. No production code, public API, or dependency changes.

## Checks

- PASS: real agent-phase publication probe: pushed and deleted agent/codex-auth-check-fc46289afc0d; final ls-remote returned no ref.
- PASS: source .codex/cloud/use-jdk.sh 25 && java -version && mvn -pl sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-vertx -am test -Dgpg.skip=true -Dtest=DecryptLocalhostHttpsTrafficVertXTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
- WARN: source .codex/cloud/use-jdk.sh 8 && java -version && mvn -pl sniffy-integration-tests/sniffy-integration-tests-decrypt-tls-vertx -am test -Dgpg.skip=true -Dtest=DecryptLocalhostHttpsTrafficVertXTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false failed with existing JDK 8 TLS NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer; the updated test failed promptly with the original async SSLHandshakeException instead of hanging.
- PASS: git diff --check

## Checks not run

Full CI reactor was not run; focused issue verification was run locally and remaining matrix coverage is left to GitHub Actions.

## Dependency changes

None.

## Remaining risks

The existing JDK 8 TLS ByteBuffer covariant-return issue still prevents the focused Vert.x TLS test from passing locally on JDK 8.