### PR TITLE
[codex] Make Cloud delivery state verifiable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,12 @@ constraints for their subtrees.
   material decisions in the pull request. Stop only for a real blocker such as missing credentials, unavailable external
   infrastructure, destructive ambiguity, or mutually incompatible acceptance criteria.
 - Complete the task end to end when permissions allow: implement, add or update tests, run applicable checks, review the
-  diff, commit, push, and update or open a draft pull request. Never merge a pull request unless the task explicitly says
-  to do so.
+  diff, commit, push, and update or open a pull request. Use a draft while implementation or locally applicable
+  verification is still in progress; unless the task explicitly requires a draft handoff, mark it ready for review after
+  the implementation and those checks are complete. Never merge a pull request unless the task explicitly says to do so.
+- Treat GitHub remote state as the publication source of truth. A local branch, local commit, `make_pr` metadata, or a
+  final summary does not prove delivery. Before reporting publication, verify a resolvable remote branch, full commit SHA,
+  pull-request URL, base/head branches, draft state, and head SHA through GitHub.
 - Preserve unrelated user changes. Do not reset, clean, force-push, rebase shared branches, or rewrite history unless the
   issue explicitly requires it. Prefer a new `agent/<short-description>` branch from `develop` for new work.
 
@@ -51,9 +55,13 @@ constraints for their subtrees.
 
 ## Pull requests
 
-- Keep pull requests draft until the implementation and locally applicable verification are complete.
+- Keep pull requests draft only while implementation or locally applicable verification is incomplete. Unless the task
+  explicitly requires a draft handoff, mark the pull request ready for review after both are complete and remote
+  publication has been verified.
+- Cloud checkouts may not have an `origin` remote. Use an explicit repository URL or configure the intended remote rather
+  than treating a missing remote as successful local completion.
 - The pull request description must explain the problem, design, compatibility impact, tests executed, checks not run,
-  dependency changes, and remaining risks. Link the authoritative issue.
+  dependency changes, and remaining risks. Link the authoritative issue and include the exact published head SHA.
 - Do not hide limitations. If the environment cannot run a platform-, JDK-, or credential-dependent check, say exactly
   what is missing and leave CI to perform that check.
 

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -150,6 +150,7 @@ Reply on the issue and pull request with exact resolvable URLs, the full SHA, an
 remains, stop without repeatedly rebuilding the same change and report the exact command/output plus the smallest
 permission or decision needed.
 ```
+
 ## 7. Operating model
 
 ### Product Owner — Dmitry

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -109,21 +109,47 @@ The script requires authenticated `gh`, a clean working tree, and an installed C
 
 ## 6. Starting and following up cloud work
 
-1. Refine the issue with the autonomous task template.
-2. Select the `sniffy` environment and the intended base branch in Codex Cloud, then reference the issue as the authoritative specification.
-3. For complex architectural work, select the strongest available coding model and Extra High reasoning. For small mechanical tasks, use the default reasoning level unless deeper analysis is needed.
-4. Ask for implementation, validation, and a draft pull request—not merely a plan.
-5. Review the cloud task summary, commands, tests, and diff.
-6. Use a follow-up task for bounded corrections.
-7. On a Codex-created pull request, a comment such as `@codex fix the CI failures` starts another cloud task with that pull request as context when the GitHub integration has permission.
-8. Request a high-signal review with `@codex review`, or rely on automatic reviews after they have been enabled.
+1. Refine the issue with the autonomous task template and make the issue thread the authoritative dispatch record.
+2. Start implementation from a top-level issue comment containing `@codex`. Record the comment URL and do not describe
+   the task as started until the Codex connector reacts or posts a task link. A mention inside a submitted GitHub review
+   is not a reliable task trigger. Pull-request comment triggers additionally depend on Codex code review being enabled;
+   use the authoritative issue thread as the fallback for implementation and correction tasks.
+3. Select the `sniffy` environment and current `develop`. For complex architectural work, select the strongest available
+   coding model and High or Extra High reasoning.
+4. Ask for implementation, validation, actual GitHub publication, and a ready-for-review handoff—not merely a plan,
+   local commit, `make_pr` call, or draft that remains draft after the work is complete.
+5. Require the agent to push the branch, create or update the intended pull request, and verify the remote branch, full
+   commit SHA, pull-request URL, base/head branches, draft state, and head SHA through `git ls-remote`, `gh api`, and
+   `gh pr view` before reporting success. A dry-run push is not publication.
+6. Treat Codex Cloud UI metadata as informative rather than authoritative. A pull request created directly with `gh`
+   may not appear as attached in the Cloud UI; the resolvable GitHub branch, commit, and pull-request URLs are the source
+   of truth. Link the Cloud task from the issue and link the issue/task from the pull request whenever possible.
+7. Review the complete remote diff, issue acceptance criteria, `AGENTS.md`, comments, review threads, and every relevant
+   CI job. Do not approve from an agent summary alone.
+8. For bounded corrections, leave precise review feedback and dispatch a new top-level `@codex` comment on the
+   authoritative issue that links the existing pull request, branch, review, and required checks. Use a pull-request
+   comment only after its trigger is known to work.
+9. Request a high-signal review with `@codex review`, or rely on automatic reviews after they have been enabled.
 
 A standard dispatch prompt is:
 
 ```text
-Implement the complete linked issue autonomously. Read AGENTS.md and the entire issue thread first; the issue is authoritative. Make ordinary engineering decisions yourself using the most conservative maintainable option. Implement the change, add or update tests and documentation, run all checks available in the environment, review the final diff, and open a draft pull request linked to the issue. Do not stop for a plan or ask for routine clarification. If a genuine blocker remains, leave the repository clean and report the exact blocker and the smallest decision or permission needed.
-```
+@codex Implement the complete linked issue autonomously from current develop. Read AGENTS.md, docs/codex-workflow.md,
+and the entire issue thread first; the issue is authoritative. Make ordinary conservative engineering decisions without
+asking for routine clarification. Implement the change, add or update tests and documentation, run every applicable
+focused and repository check, and review the final diff.
 
+Use a new agent/<short-description> branch unless the issue names an existing pull-request branch. Publish real GitHub
+state: push the branch, create or update the intended pull request, and verify the remote branch, full commit SHA,
+pull-request URL, base/head branches, draft state, and head SHA with git ls-remote, gh api, and gh pr view. Do not treat a
+local commit, make_pr metadata, or a Cloud summary as publication. Use a draft while work is incomplete, then mark the
+pull request ready for review after implementation and locally applicable verification are complete unless this issue
+explicitly requires it to remain draft. Do not merge or enable auto-merge.
+
+Reply on the issue and pull request with exact resolvable URLs, the full SHA, and exact check results. If a genuine blocker
+remains, stop without repeatedly rebuilding the same change and report the exact command/output plus the smallest
+permission or decision needed.
+```
 ## 7. Operating model
 
 ### Product Owner — Dmitry
@@ -137,7 +163,10 @@ Implement the complete linked issue autonomously. Read AGENTS.md and the entire 
 - owns the book of work in GitHub Projects and issues;
 - converts discussions into issues with explicit requirements, non-goals, acceptance criteria, and validation;
 - selects Cloud, unattended local Codex, or human-led execution;
-- dispatches ready tasks and tracks blockers, CI, reviews, and follow-ups;
+- dispatches ready tasks and tracks the trigger reaction/task link, remote branch, pull request, blockers, CI, reviews,
+  and follow-ups;
+- distinguishes dispatched, working, locally complete, published, ready for review, approved, and merged states; never
+  infers one state from another or from an agent summary;
 - reviews implementation and architecture against the issue and `AGENTS.md`;
 - keeps project status and issue descriptions current;
 - prepares a weekly retrospective.
@@ -183,9 +212,15 @@ The delivery lead reviews:
 - documentation and migration impact;
 - accidental generated files or unrelated edits.
 
-A task is done only when required checks pass, known limitations are documented, review findings are resolved or accepted explicitly, and the issue/project state is updated.
+A task is done only when the implementation is published and remotely verified, the pull request has reached the
+requested review state, required checks pass, known limitations are documented, review findings are resolved or accepted
+explicitly, and the issue/project state is updated.
 
-## 10. Weekly retrospective
+## 10. Incident retrospectives
+
+- [Issue #637 / PR #643: Codex Cloud delivery and publication](retrospectives/2026-07-16-codex-cloud-issue-637.md)
+
+## 11. Weekly retrospective
 
 The weekly retrospective should cover:
 

--- a/docs/retrospectives/2026-07-16-codex-cloud-issue-637.md
+++ b/docs/retrospectives/2026-07-16-codex-cloud-issue-637.md
@@ -18,11 +18,11 @@ The code outcome was good, but delivery took repeated attempts because task disp
 
 ## What went wrong
 
-1. **Dispatch was declared before it was observable.** Creating an issue or intending to delegate work was treated as if Codex had started. A task is dispatched only after a real top-level @codex trigger has a connector reaction or task link.
-2. **Local completion was confused with publication.** Several tasks reported local branches, commits, or make_pr metadata as if GitHub had received them. The branches, commits, and pull requests did not resolve remotely.
+1. **Dispatch was declared before it was observable.** Creating an issue or intending to delegate work was treated as if Codex had started. A task is dispatched only after a real top-level `@codex` trigger has a connector reaction or task link.
+2. **Local completion was confused with publication.** Several tasks reported local branches, commits, or `make_pr` metadata as if GitHub had received them. The branches, commits, and pull requests did not resolve remotely.
 3. **Publication prerequisites were discovered serially.** The image lacked gh; secrets disappeared after setup; the checkout had no origin; the fine-grained PAT required organization approval; agent internet initially blocked write methods; and a dry-run push produced false confidence. Each gap caused another full task attempt.
 4. **Completed work was repeatedly recreated.** When publication failed, follow-up prompts sometimes rebuilt the implementation instead of first recovering the latest workspace/commit or stopping after a failed write probe.
-5. **The review follow-up used the wrong trigger surface.** An @codex mention inside REQUEST_CHANGES did not start a task. A top-level PR comment also did not trigger while repository code review integration was unavailable. The top-level issue comment was the proven fallback.
+5. **The review follow-up used the wrong trigger surface.** An `@codex` mention inside REQUEST_CHANGES did not start a task. A top-level PR comment also did not trigger while repository code review integration was unavailable. The top-level issue comment was the proven fallback.
 6. **Cloud UI and GitHub state diverged.** A PR created directly with gh can be valid on GitHub while the Codex Cloud UI still says no PR was created for the task. The UI association is useful metadata, not proof of publication.
 7. **The handoff stopped at draft.** After implementation and locally applicable checks were complete, the PR remained draft. Normal autonomous delivery should use draft during work and mark ready for review at handoff unless the task explicitly requests a draft result.
 8. **Monitoring and status language were too optimistic.** Status updates sometimes said an agent was working, a PR existed, or delivery was complete before remote evidence supported those claims.
@@ -51,7 +51,7 @@ The code outcome was good, but delivery took repeated attempts because task disp
 - If publication access is uncertain, perform one reversible real remote-ref round trip before implementation. Stop on failure instead of rebuilding the change.
 - Recover an existing workspace/commit when possible; do not recreate completed work merely because publication failed.
 - Use an explicit repository URL when origin is absent.
-- Push and verify real GitHub state. make_pr metadata and local PR descriptions are not publication.
+- Push and verify real GitHub state. `make_pr` metadata and local PR descriptions are not publication.
 - Create/update the PR as draft while work is incomplete; mark it ready for review after implementation and locally applicable verification finish unless told to keep it draft.
 - Report exact command results and exact resolvable URLs. Link the task, issue, branch, commit, and PR.
 

--- a/docs/retrospectives/2026-07-16-codex-cloud-issue-637.md
+++ b/docs/retrospectives/2026-07-16-codex-cloud-issue-637.md
@@ -1,0 +1,75 @@
+# Codex Cloud delivery retrospective: issue #637
+
+**Date:** 2026-07-16  
+**Scope:** [issue #637](https://github.com/sniffy/sniffy/issues/637), [PR #643](https://github.com/sniffy/sniffy/pull/643)
+
+## Outcome
+
+The Vert.x TLS test was stabilized and published in PR #643. The final implementation preserved the original asynchronous failure, bounded request and shutdown waits, and made WebClient/Vert.x cleanup lifecycle-safe. The complete 24-job matrix passed, including the original failing Windows Server 2025 + JDK 25 entry, and the PR was approved.
+
+The code outcome was good, but delivery took repeated attempts because task dispatch, Cloud-local completion, GitHub publication, review state, and final approval were treated as if they were the same state.
+
+## What went well
+
+- Issue #637 contained a completed diagnosis, explicit non-goals, and testable acceptance criteria. This kept the fix focused and prevented retries, sleeps, weakened assertions, or unrelated TLS changes.
+- Repository review guidance exposed a real cleanup edge case before approval: WebClient construction initially occurred outside the scope that guaranteed Vert.x cleanup.
+- The final review checked the complete diff, issue, AGENTS.md, review state, all 24 jobs, and the actual Windows/JDK 25 test log rather than relying on the agent summary.
+- The GitHub environment now has a dedicated token, persistent gh authentication, explicit agent-network write access, and a reversible publication probe.
+
+## What went wrong
+
+1. **Dispatch was declared before it was observable.** Creating an issue or intending to delegate work was treated as if Codex had started. A task is dispatched only after a real top-level @codex trigger has a connector reaction or task link.
+2. **Local completion was confused with publication.** Several tasks reported local branches, commits, or make_pr metadata as if GitHub had received them. The branches, commits, and pull requests did not resolve remotely.
+3. **Publication prerequisites were discovered serially.** The image lacked gh; secrets disappeared after setup; the checkout had no origin; the fine-grained PAT required organization approval; agent internet initially blocked write methods; and a dry-run push produced false confidence. Each gap caused another full task attempt.
+4. **Completed work was repeatedly recreated.** When publication failed, follow-up prompts sometimes rebuilt the implementation instead of first recovering the latest workspace/commit or stopping after a failed write probe.
+5. **The review follow-up used the wrong trigger surface.** An @codex mention inside REQUEST_CHANGES did not start a task. A top-level PR comment also did not trigger while repository code review integration was unavailable. The top-level issue comment was the proven fallback.
+6. **Cloud UI and GitHub state diverged.** A PR created directly with gh can be valid on GitHub while the Codex Cloud UI still says no PR was created for the task. The UI association is useful metadata, not proof of publication.
+7. **The handoff stopped at draft.** After implementation and locally applicable checks were complete, the PR remained draft. Normal autonomous delivery should use draft during work and mark ready for review at handoff unless the task explicitly requests a draft result.
+8. **Monitoring and status language were too optimistic.** Status updates sometimes said an agent was working, a PR existed, or delivery was complete before remote evidence supported those claims.
+
+## Root causes
+
+- No explicit delivery state machine separated dispatched, working, locally complete, published, ready for review, approved, and merged.
+- Completion criteria emphasized implementation and tests but did not require remote branch/commit/PR verification and the final draft-to-ready transition.
+- Environment validation checked role metadata and dry-run behavior before an actual reversible write round trip was available.
+- Trigger behavior differed between issue comments, formal reviews, and PR comments, but the workflow did not name a reliable fallback.
+
+## Corrective actions
+
+### Delivery lead
+
+- Record the trigger comment and wait for a connector reaction or task link before reporting that work started.
+- Track each delivery state independently. Never infer publication from a local commit or infer readiness/approval from publication.
+- Require resolvable branch, full SHA, PR URL, base/head refs, draft state, and matching head SHA before reporting publication.
+- Review the remote diff and CI, not the Cloud summary. Inspect relevant job logs, especially the matrix entry that motivated the issue.
+- Use the authoritative issue thread for correction dispatch when PR triggers are unavailable.
+- Keep monitoring until the requested terminal state, then disable monitoring.
+
+### Codex Cloud task
+
+- Start from current develop and read AGENTS.md, docs/codex-workflow.md, and the complete issue thread.
+- If publication access is uncertain, perform one reversible real remote-ref round trip before implementation. Stop on failure instead of rebuilding the change.
+- Recover an existing workspace/commit when possible; do not recreate completed work merely because publication failed.
+- Use an explicit repository URL when origin is absent.
+- Push and verify real GitHub state. make_pr metadata and local PR descriptions are not publication.
+- Create/update the PR as draft while work is incomplete; mark it ready for review after implementation and locally applicable verification finish unless told to keep it draft.
+- Report exact command results and exact resolvable URLs. Link the task, issue, branch, commit, and PR.
+
+### Environment
+
+- Keep gh installation, persistent authentication, token scope/organization approval, write-enabled agent network policy, and the reversible publication validation documented and tested.
+- Reset the Cloud cache after setup-script, secret, or environment-policy changes.
+
+## State model
+
+1. **Ready for agent:** authoritative issue and acceptance criteria are complete.
+2. **Dispatched:** a top-level trigger exists and Codex has reacted or posted a task link.
+3. **Working:** the task is running; no publication claim yet.
+4. **Published:** remote branch, full commit, and PR resolve and the PR head matches.
+5. **Ready for review:** implementation and locally applicable checks are complete and the PR is no longer draft unless a draft handoff was explicitly requested.
+6. **Approved:** remote diff, comments, review threads, and required CI have been reviewed successfully.
+7. **Done:** merged or deliberately closed, with issue/project state updated.
+
+## Follow-up
+
+The mandatory rules are encoded in AGENTS.md and the operational dispatch/review checklist is maintained in docs/codex-workflow.md. Future retrospectives should update those files when a new repeated failure mode appears.


### PR DESCRIPTION
## What changed

- record the issue #637 / PR #643 Codex Cloud delivery retrospective;
- require remote branch, commit, and pull-request evidence before publication is reported;
- define reliable issue-based dispatch and correction triggers;
- separate draft work-in-progress from a ready-for-review handoff;
- document the Cloud UI versus direct `gh` publication caveat;
- add an explicit delivery state model for ChatGPT/Codex orchestration.

## Why

The implementation eventually succeeded, but repeated attempts confused task dispatch, local completion, GitHub publication, review readiness, approval, and merge state. Authentication, network policy, missing remotes, trigger behavior, and `make_pr` metadata were discovered one failure at a time.

This change turns those lessons into durable agent rules and an operational checklist instead of leaving them only in chat history.

## Impact

Documentation and agent instructions only. No runtime, build, dependency, or public API changes.

## Checks

- reviewed all three changed Markdown files against the #637 timeline;
- verified the new rules do not weaken existing Java, lifecycle, CI, or review requirements;
- verified the branch and commits are published on GitHub;
- tests not run because this is documentation-only.

Follow-up to #637 and #643.