### PR TITLE
Document Codex task preflight and review convergence

### DIFF
--- a/.github/ISSUE_TEMPLATE/codex-task.yml
+++ b/.github/ISSUE_TEMPLATE/codex-task.yml
@@ -37,6 +37,25 @@ body:
       label: Non-goals
       description: Explicitly exclude tempting adjacent work.
   - type: textarea
+    id: risk_proof
+    attributes:
+      label: Risk, architecture, and proof matrix
+      description: For each requirement or high-risk lifecycle/compatibility case, state the module/API boundary and the exact test, CI job, or inspection that will prove it. Mark non-applicable risk axes explicitly.
+      placeholder: |
+        | Requirement or risk | Allowed module/API boundary | Proof |
+        | --- | --- | --- |
+        | Java 8 production artifact | production module only; no newer APIs | focused Java 8 test + bytecode contract |
+        | partial setup failure | no global/core redesign | named launcher test proving body did not run and cleanup completed |
+    validations:
+      required: true
+  - type: textarea
+    id: delivery
+    attributes:
+      label: Delivery topology and checkpoints
+      description: State base/head branches, whether an existing PR must be reused, who creates the PR, draft/ready rules, publication proof, and any internal implementation checkpoints. Use one PR unless slices are independently mergeable.
+    validations:
+      required: true
+  - type: textarea
     id: acceptance
     attributes:
       label: Acceptance criteria
@@ -71,6 +90,10 @@ body:
       label: Autonomous readiness
       options:
         - label: Product and compatibility decisions are explicit.
+          required: true
+        - label: Module/API scope boundaries and any global-state or lifecycle decisions are explicit.
+          required: true
+        - label: Every acceptance criterion is mapped to an executable or inspectable proof.
           required: true
         - label: Acceptance criteria are testable.
           required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,16 @@ constraints for their subtrees.
 - The Codex Cloud environment is described in `docs/codex-workflow.md`. Use `source .codex/cloud/use-jdk.sh <version>`
   to switch among the installed JDK 8, 11, 17, 21, and 25 toolchains.
 - Run focused tests for the changed behavior first.
+- After switching JDKs in the same worktree, run `clean` before the first Maven build under the new JDK or use an
+  isolated checkout/output directory. Never treat `target/` classes compiled by another JDK as evidence for the current
+  runtime; Maven incremental compilation can otherwise reuse bytecode linked to APIs or covariant method descriptors
+  that do not exist on Java 8.
+- For a Java 8 artifact compiled on a newer JDK, `source`/`target` bytecode levels alone are insufficient. Run the
+  configured Java 8 API-signature check during `verify` and, for compatibility-sensitive changes, execute the same
+  modern-JDK-built artifact on a real Java 8 runtime without recompiling it there.
+- Run independent validation obligations as separate commands with individually visible exit statuses. Do not combine
+  multiple JDK/module checks into one opaque long-running chain. A manual interruption is not a result; if a command is
+  intentionally time-bounded, use an explicit timeout, report that timeout, and leave the complete reactor result to CI.
 - Treat every acceptance criterion as an evidence obligation. Verify that its focused test is discovered and executed
   in the test report; compiled tests, unused fixtures, skipped modules, and an overall green CI result are not proof.
 - For NIO changes, run `mvn -pl sniffy-module-nio -am clean test` on Java 8 and the current development JDK.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ constraints for their subtrees.
 - Preserve unrelated user changes. Do not reset, clean, force-push, rebase shared branches, or rewrite history unless the
   issue explicitly requires it. Prefer a new `agent/<short-description>` branch from `develop` for new work.
 
+- Before editing a task that combines two or more high-risk axes—new public APIs or artifacts, global mutable state,
+  resource lifecycle/failure composition, multiple JDK/framework versions, or cross-reactor module placement—confirm
+  that the issue contains a short design preflight: scope boundaries, module ownership, a failure/lifecycle matrix, and
+  an acceptance-criterion-to-proof matrix. If a material product or public-API decision is unresolved or contradictory,
+  stop before implementation and report that decision instead of inventing a broad compatibility layer.
+
 ## Compatibility and scope
 
 - Preserve Java 8 source, bytecode, and runtime compatibility unless a task explicitly changes the supported baseline.
@@ -42,6 +48,8 @@ constraints for their subtrees.
 - The Codex Cloud environment is described in `docs/codex-workflow.md`. Use `source .codex/cloud/use-jdk.sh <version>`
   to switch among the installed JDK 8, 11, 17, 21, and 25 toolchains.
 - Run focused tests for the changed behavior first.
+- Treat every acceptance criterion as an evidence obligation. Verify that its focused test is discovered and executed
+  in the test report; compiled tests, unused fixtures, skipped modules, and an overall green CI result are not proof.
 - For NIO changes, run `mvn -pl sniffy-module-nio -am clean test` on Java 8 and the current development JDK.
 - For TLS changes, run `mvn -pl sniffy-module-tls -am clean test` on Java 8 and the current development JDK.
 - For cross-module or release-facing changes, run
@@ -52,6 +60,9 @@ constraints for their subtrees.
 ## Pull requests
 
 - Keep pull requests draft until the implementation and locally applicable verification are complete.
+- When credentials and the delivery contract permit it, create the pull request using the authenticated agent account
+  rather than asking a human to create it manually. This preserves formal human review and Request Changes capability.
+  Independently verify that the remote branch SHA and pull request head SHA match before handoff.
 - The pull request description must explain the problem, design, compatibility impact, tests executed, checks not run,
   dependency changes, and remaining risks. Link the authoritative issue.
 - Do not hide limitations. If the environment cannot run a platform-, JDK-, or credential-dependent check, say exactly
@@ -61,6 +72,8 @@ constraints for their subtrees.
 
 - Prioritize correctness, compatibility, resource safety, concurrency, public API stability, and test integrity over
   formatting preferences.
+- Review the complete acceptance-to-proof matrix on the first pass. Avoid serially discovering independent missing
+  requirements across multiple fix cycles when they could be reported together.
 - Flag tests that were weakened, made timing-dependent, skipped, or retried to conceal a failure.
 - Flag accidental Java baseline increases, use of newer JDK APIs in Java 8 artifacts, and unintentional dependency or
   public API changes.

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -74,6 +74,50 @@ An issue is ready when it states:
 
 The issue must not delegate unresolved product decisions to Codex. Implementation choices may remain open when a conservative, maintainable answer can be derived from the repository.
 
+
+## 4.1. Complex-task design and proof preflight
+
+A task needs a preflight before implementation when it combines two or more of these risk axes:
+
+- a new published artifact or public API;
+- global mutable state, concurrency, resource ownership, or cleanup;
+- failure composition where primary and suppressed exceptions matter;
+- multiple JDK, framework, engine, or platform versions;
+- cross-reactor module placement or a test-only compatibility consumer;
+- migration or compatibility requirements that can conflict with existing behavior.
+
+The preflight is a short addition to the authoritative issue, not a speculative design document. It must resolve:
+
+1. **Scope boundary:** which modules and APIs may change, and which tempting adjacent redesigns are excluded.
+2. **Architecture ownership:** where production code, test-only consumers, compatibility checks, and documentation belong.
+3. **Lifecycle/failure matrix:** success, user failure, framework failure, partial setup, cleanup failure, and combined failure.
+4. **Compatibility matrix:** the exact built artifact, runtime/JDK/framework combinations, and whether sources are rebuilt or the same artifact is consumed.
+5. **Acceptance-to-proof matrix:** every criterion mapped to a focused test, CI job, static inspection, or explicitly documented manual check.
+6. **Delivery topology:** base/head branch, existing or new PR, PR author identity, draft/ready transition, and publication verification.
+
+If the preflight exposes a product decision—especially whether to add a public/core API or preserve unrelated global
+state—the delivery lead resolves it before dispatch. Codex should not infer such a decision from a cleanup requirement.
+
+A green build is evidence only for tests that were actually discovered and executed. The proof matrix must name the
+test class or CI job and later be checked against Surefire/CI output.
+
+## 4.2. Slicing complex work without creating micro-PR overhead
+
+Split work into separate issues or pull requests only when the slices are independently useful, reviewable, and
+mergeable. Do not create a PR per test or per callback merely to make the task look smaller.
+
+For a cohesive cross-cutting feature, prefer one draft PR with explicit implementation checkpoints:
+
+1. module/artifact skeleton and compatibility boundary;
+2. production lifecycle and happy-path tests;
+3. failure/cleanup matrix and regression tests;
+4. cross-version consumer and reactor/CI wiring;
+5. documentation, final proof-matrix audit, and ready-for-review handoff.
+
+A short read-only design/refinement task before implementation is often cheaper than multiple review/fix loops. For a
+feature that combines global state, failure composition, and multiple runtime versions, use that refinement step even
+when the final implementation remains one PR.
+
 ## 5. Routing tasks
 
 ### Use Codex Cloud by default when
@@ -109,20 +153,42 @@ The script requires authenticated `gh`, a clean working tree, and an installed C
 
 ## 6. Starting and following up cloud work
 
-1. Refine the issue with the autonomous task template.
+1. Refine the issue with the autonomous task template. For a complex task, complete the design/proof preflight and review it before dispatch.
 2. Select the `sniffy` environment and the intended base branch in Codex Cloud, then reference the issue as the authoritative specification.
 3. For complex architectural work, select the strongest available coding model and Extra High reasoning. For small mechanical tasks, use the default reasoning level unless deeper analysis is needed.
 4. Ask for implementation, validation, and a draft pull request—not merely a plan.
-5. Review the cloud task summary, commands, tests, and diff.
-6. Use a follow-up task for bounded corrections.
+5. Review the cloud task summary, commands, tests, complete diff, and the acceptance-to-proof matrix in one pass. Confirm named tests were actually executed.
+6. Use a follow-up task for bounded corrections. If review changes architecture or product scope, first update the authoritative issue and mark conflicting older guidance as superseded.
 7. On a Codex-created pull request, a comment such as `@codex fix the CI failures` starts another cloud task with that pull request as context when the GitHub integration has permission.
 8. Request a high-signal review with `@codex review`, or rely on automatic reviews after they have been enabled.
 
 A standard dispatch prompt is:
 
 ```text
-Implement the complete linked issue autonomously. Read AGENTS.md and the entire issue thread first; the issue is authoritative. Make ordinary engineering decisions yourself using the most conservative maintainable option. Implement the change, add or update tests and documentation, run all checks available in the environment, review the final diff, and open a draft pull request linked to the issue. Do not stop for a plan or ask for routine clarification. If a genuine blocker remains, leave the repository clean and report the exact blocker and the smallest decision or permission needed.
+Implement the complete linked issue autonomously. Read AGENTS.md and the entire issue thread first; the issue is authoritative. Make ordinary engineering decisions yourself using the most conservative maintainable option. Implement the change, add or update tests and documentation, run all checks available in the environment, review the final diff, and open a draft pull request linked to the issue. Do not stop for a plan or ask for routine clarification. Before editing, turn every acceptance criterion into a proof matrix and identify any unresolved scope, public-API, global-state, lifecycle, module-placement, or compatibility decision. Do not implement through a material ambiguity. During handoff, report which focused test or CI job proves each criterion, confirm those tests actually executed, verify the real remote branch and PR head SHA match, and create the PR using the authenticated agent account when authorized so the human reviewer retains formal review capability. If a genuine blocker remains, leave the repository clean and report the exact blocker and the smallest decision or permission needed.
 ```
+
+### Review convergence and escalation
+
+The first review should be comprehensive: inspect the full diff, all acceptance criteria, test discovery/execution,
+module boundaries, compatibility evidence, documentation, and CI. Report independent findings together.
+
+After each follow-up, review the new delta and re-run the full proof matrix. Do not assume an older green run covers a
+new head.
+
+Use a **two-substantive-round rule**: after two review/fix rounds, or immediately after an architectural/product-scope
+reversal, stop issuing another narrow patch prompt. Re-baseline the authoritative issue, collapse or mark superseded
+guidance, and choose one of:
+
+- one fresh comprehensive Cloud task against the current remote head;
+- unattended local Codex on the same branch when persistent artifacts, long builds, or repeated debugging matter;
+- a human decision/design pass before further coding.
+
+Switching to local Codex can reduce cold-start and task-window friction, but it does not repair an ambiguous
+specification. The preflight and proof matrix remain mandatory for both routes.
+
+When possible, let the dedicated agent identity create the PR. A human-owned PR can prevent the same human account from
+submitting a formal Request Changes review, reducing review state to convention-based comments.
 
 ## 7. Operating model
 
@@ -196,6 +262,7 @@ The weekly retrospective should cover:
 - CI failures, escaped defects, and repeated review findings;
 - tasks that required human clarification and how to improve their issue specification;
 - changes needed in `AGENTS.md`, setup scripts, templates, or the test matrix;
+- number of substantive review/fix rounds, whether the two-round re-baseline rule was triggered, and why;
 - the next week's top priorities and capacity risks.
 
 The retrospective should result in concrete issue/template/instruction changes, not only a narrative summary.

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -59,6 +59,26 @@ source .codex/cloud/use-jdk.sh 25
 mvn -version
 ```
 
+### Cross-JDK and time-bounded validation
+
+Switching `JAVA_HOME` does not invalidate Maven outputs. When two JDKs are used in one worktree, the first Maven command
+under each newly selected JDK must include `clean`, or the runs must use isolated checkouts/output directories. Otherwise
+a Java 8 run can reuse `target/` classes compiled by a newer JDK and fail with misleading linkage errors such as a
+covariant `ByteBuffer.position(int)` or `limit(int)` descriptor that Java 8 does not provide.
+
+For Java 8 artifacts, distinguish three separate proofs:
+
+1. a clean compile and focused test on real JDK 8;
+2. a modern-JDK `verify` run that executes the configured Java 8 API-signature check;
+3. for compatibility-sensitive code, execution on real JDK 8 of the same artifact built on the modern JDK, without
+   recompiling that artifact under JDK 8.
+
+Run focused Jupiter, JUnit 6 consumer, JUnit 4 regression, and diff checks as separate commands. Give an intentionally
+bounded command its own explicit timeout and report the timeout exit status. Do not manually interrupt a combined command
+and present the earlier parts as one completed validation result. If the full reactor cannot finish within the Cloud task
+window, report the focused results separately and make the corresponding GitHub Actions run the authoritative full-reactor
+proof.
+
 ## 4. Definition of Ready for autonomous work
 
 An issue is ready when it states:

--- a/docs/retrospectives/2026-07-issue-238-junit-jupiter.md
+++ b/docs/retrospectives/2026-07-issue-238-junit-jupiter.md
@@ -1,0 +1,139 @@
+# Retrospective: issue #238 JUnit Jupiter delivery
+
+Date: 2026-07-16
+
+Related work:
+
+- issue [#238](https://github.com/sniffy/sniffy/issues/238);
+- pull request [#633](https://github.com/sniffy/sniffy/pull/633);
+- follow-up [#646](https://github.com/sniffy/sniffy/issues/646) for a framework-neutral reversible socket-blocking scope.
+
+This is an intermediate process retrospective. PR #633 was still in its review/fix cycle when this document was
+written. The goal is to improve future autonomous delivery, not to assign blame for an unfinished implementation.
+
+## What happened
+
+The work passed through three distinct phases:
+
+1. **Delivery infrastructure failures.** Early Codex Cloud tasks produced local commits and completion summaries but no
+   resolvable GitHub branch or pull request. Missing GitHub CLI setup, credential persistence, token approval, agent
+   network write methods, and PR publication made implementation results effectively ephemeral. PRs #638 and #639 and
+   the reversible remote-ref probe addressed this class of failure.
+2. **Architecture and product-scope churn.** Once a real PR existed, the issue simultaneously required
+   `ConnectionsRegistry` restoration, JUnit 4 compatibility, resource safety, and no broad public-API redesign. The
+   phrase "restore ConnectionsRegistry" did not define whether it meant clearing the JUnit-owned wildcard or
+   reconstructing unrelated application state. Codex chose a generic snapshot/replay implementation. Review then found
+   persistence corruption, incomplete best-effort restoration, and resurrection of application-closed connections.
+   The product decision was eventually corrected: whole-registry snapshotting is outside the Jupiter feature and is
+   tracked separately in #646.
+3. **Incomplete proof of an otherwise converging implementation.** Later heads compiled and passed CI, but review found
+   missing combinations, unused launcher fixtures, and a JUnit 6 consumer placed in a servlet-specific profile. Green CI
+   proved the tests that ran; it did not prove that every acceptance criterion had an executing test.
+
+These phases should not be counted as one undifferentiated "Codex needed many tries." They have different remedies.
+
+## What went well
+
+- The GitHub-visible branch and PR eventually became the only accepted delivery evidence.
+- The issue was expanded into an authoritative specification with compatibility, lifecycle, failure, documentation, and
+  publication requirements.
+- Review correctly prioritized application resource safety over instrumentation convenience.
+- Java 8 production compatibility and real JUnit 6 consumption of the same JUnit-5-built artifact became explicit and
+  observable in CI.
+- When the snapshot design was recognized as a separate product concern, it was removed rather than polished further
+  inside the wrong feature.
+- Monitoring checked remote SHA, PR state, complete diff, and CI logs rather than trusting bot summaries.
+
+## Why the review/fix loop was long
+
+### 1. The task was broad in risk axes, not merely large in lines of code
+
+The feature combined a new published artifact, Jupiter lifecycle ordering, global connectivity state, partial setup and
+cleanup failures, primary/suppressed exceptions, legacy annotations, Java 8 bytecode, JUnit 5 and JUnit 6, reactor
+placement, documentation, and GitHub delivery. A normal prose issue can mention all of these without showing their
+interactions.
+
+### 2. The initial specification contained a material ambiguity
+
+"Restore ConnectionsRegistry" was interpreted as preserving the entire registry. That interpretation conflicted with
+the smaller JUnit 4 behavior and with the non-goal of a broad core redesign. The delivery lead should have resolved this
+before coding. A longer prompt repeating both statements would not have helped; the contradiction needed a product
+decision.
+
+### 3. Architecture ownership was decided too late
+
+The production Jupiter artifact belongs in `sniffy-test`, while the JUnit 6 consumer is test-only infrastructure and
+belongs in `sniffy-integration-tests`. The original task did not make that distinction explicit, so the first placement
+was reasonable but wrong for the desired reactor structure.
+
+### 4. Acceptance criteria were not converted into a proof matrix
+
+The issue had a long test list, but there was no table mapping each criterion and failure combination to a named test and
+CI job. This allowed dead fixtures and untested combinations to coexist with a green build.
+
+### 5. Review was adversarial but incremental
+
+Each review found a real problem, but several independent coverage gaps could have been reported together if the first
+review had audited a single acceptance-to-proof matrix. Serial comments increased latency and gave each cold-start
+follow-up a growing, partially superseded thread to interpret.
+
+### 6. GitHub comments became a second specification
+
+Some older comments required increasingly sophisticated snapshot restoration; the later authoritative issue excluded
+that design. Even when the issue says it is authoritative, a new Cloud task reads the thread and must reconcile
+conflicting history. Scope changes should update the issue first and explicitly mark older guidance as superseded.
+
+### 7. PR ownership weakened formal review state
+
+The human-owned PR prevented the same authenticated human account from submitting a formal Request Changes review.
+Blocking comments worked by convention, but future agent work should normally create the PR using the dedicated agent
+identity so human review state is represented by GitHub.
+
+## Would micro-subtasks have helped?
+
+Not as the default. A PR for every annotation, callback, or test would add merge and integration overhead without
+removing the hardest interactions.
+
+The better shape is:
+
+- a short **read-only design/proof preflight** before coding;
+- one cohesive draft PR;
+- staged checkpoints inside that PR for module skeleton, lifecycle behavior, failure matrix, cross-version consumer,
+  and documentation;
+- separate issues/PRs only for independently mergeable architecture, such as the framework-neutral socket-blocking
+  scope now tracked in #646.
+
+JUnit 6 compatibility could have been a separate PR, but keeping it in the same PR is reasonable once the production
+artifact boundary and same-artifact proof are explicit.
+
+## Cloud Codex versus local Codex
+
+Cloud Codex was not intrinsically unable to implement the feature. After credentials and agent-network policy were
+fixed, it repeatedly pushed working commits and ran useful focused tests.
+
+Cloud amplified two problems:
+
+- each GitHub `@codex` follow-up was effectively a cold-start task whose durable context was the issue, PR, and comments;
+- long full-reactor runs exceeded the task window, making persistent local artifacts less convenient.
+
+Unattended local Codex in an isolated VM would likely reduce cold-start and long-build friction, but it would still have
+implemented an ambiguous registry-restoration requirement. The primary fix is better refinement; routing is secondary.
+
+For future work, re-route to persistent local Codex after two substantive review/fix rounds or immediately after a major
+architecture reversal.
+
+## Process changes adopted
+
+1. Add a mandatory complex-task preflight for high-risk combinations.
+2. Require an acceptance-to-proof matrix with named tests/jobs and verify actual test execution.
+3. Resolve public/core API and global-state decisions before implementation.
+4. Distinguish production modules from test-only compatibility consumers during refinement.
+5. Keep cohesive work in one PR with internal checkpoints; avoid arbitrary micro-PRs.
+6. Re-baseline after two substantive fix rounds instead of stacking another narrow prompt.
+7. Update the authoritative issue before dispatch when scope changes, and mark conflicting older guidance as superseded.
+8. Prefer agent-authored PRs so human formal review remains available.
+9. Require one comprehensive first review against the same proof matrix.
+10. Treat remote branch/PR SHA and actual GitHub state—not local commits, metadata, or summaries—as delivery evidence.
+
+The durable rules from this retrospective live in `AGENTS.md`, `docs/codex-workflow.md`, and the autonomous task issue
+template. This document preserves why those rules exist.


### PR DESCRIPTION
## What changed

- adds an intermediate retrospective for issue #238 / PR #633 that separates publication failures, specification ambiguity, and missing proof coverage;
- adds a complex-task design/proof preflight to `docs/codex-workflow.md`;
- documents cohesive-PR checkpoints instead of arbitrary micro-PR splitting;
- adds a two-substantive-review-round re-baseline rule and Cloud-to-local escalation guidance;
- requires an acceptance-to-proof matrix, verified test discovery/execution, delivery topology, and agent-authored PRs where possible;
- updates `AGENTS.md` and the autonomous issue template so the durable lessons are automatically applied to future agent work;
- requires a clean or isolated Maven build after every JDK switch, separates Java 8 build/runtime/API-linkage proof, and forbids opaque manually interrupted validation chains.

## Why

PR #633 entered a long review/fix loop for three different reasons:

1. early Cloud results were not actually published to GitHub;
2. the specification contained a material conflict around whole-registry restoration versus avoiding a broad core redesign;
3. later green builds did not prove all acceptance combinations because some fixtures were unused or missing.

A longer implementation prompt alone would not solve these. The workflow now requires architecture boundaries and evidence to be resolved before code, while keeping cohesive features in one PR unless slices are independently mergeable.

## Validation

- fetched all four files back from the remote branch and verified exact content;
- parsed `.github/ISSUE_TEMPLATE/codex-task.yml` successfully with PyYAML;
- documentation/instruction-only change; no Maven execution required;
- fetched the updated `AGENTS.md` and `docs/codex-workflow.md` from the remote branch after both commits.

## Scope

This PR does not change or merge PR #633 and does not alter production code. It records the process improvement while the feature review continues.

Related: #238, #633, #646.