### PR TITLE
Generalize the local Codex worker setup

### DIFF
--- a/docs/local-codex-worker.md
+++ b/docs/local-codex-worker.md
@@ -1,8 +1,9 @@
 # Local Codex worker on a Windows virtual machine
 
-This runbook describes an always-on local worker for Sniffy that can execute privileged, long-running, or Docker-heavy
-tasks while remaining observable from the ChatGPT desktop and mobile apps. The security boundary is a disposable
-Windows virtual machine; the Codex agent and developer toolchain run in WSL2 inside that VM.
+This runbook describes an always-on local worker that can host Sniffy and other repositories, execute privileged,
+long-running, or Docker-heavy tasks, and remain observable from the ChatGPT desktop and mobile apps. The security
+boundary is a disposable Windows virtual machine; the Codex agent and developer toolchain run in WSL2 inside that VM.
+Sniffy is the first concrete project configuration, not the boundary of the worker.
 
 The design was last checked against the linked product documentation on 2026-07-16.
 
@@ -14,7 +15,7 @@ flowchart TD
     Phone["ChatGPT mobile<br/>Remote"] --> App["ChatGPT desktop app<br/>Codex + Scheduled"]
     VM --> App
     App --> WSL["Codex agent<br/>Ubuntu on WSL2"]
-    WSL --> Repo["Sniffy checkout<br/>Git + gh + Maven"]
+    WSL --> Repo["Project checkouts<br/>repo-specific tools"]
     WSL --> Docker["Docker Engine<br/>Playwright and services"]
 ```
 
@@ -25,10 +26,11 @@ The important choices are:
 - Configure the app's Codex agent to run in WSL2. Local setup scripts then run in WSL, so Bash, `curl`, Linux Docker,
   and the existing repository scripts work without Cygwin.
 - Treat the complete Windows VM as disposable and trusted by the agent. Full access inside the VM is acceptable only
-  because the VM has no access to host files, host credentials, or unrelated repositories.
+  because the VM has no access to host files, host credentials, or repositories outside the explicitly registered
+  worker portfolio.
 - Install Docker Engine inside WSL2. Containers are tools available to Codex, not the outer isolation boundary.
-- Use a dedicated GitHub identity and a short-lived, repository-scoped token. GitHub branch rules remain the final
-  write boundary.
+- Use a dedicated GitHub identity and short-lived, owner- and repository-scoped credentials. GitHub branch rules
+  remain the final write boundary.
 - Use a ChatGPT desktop app Scheduled task as the dispatcher. A shell script can launch `codex exec`, but that is a CLI
   run rather than a supported way to inject a new local task into the app UI.
 
@@ -39,8 +41,10 @@ artifacts, Docker, special networking, privileged tools, or long debugging sessi
 
 ### 2.1. Host
 
-The Hyper-V host must run Windows 11 Pro, Enterprise, or another edition that includes Hyper-V. Enable AMD-V/SVM in
-UEFI and enable Hyper-V from an elevated PowerShell session:
+The physical Hyper-V host must run Windows 11 Pro, Enterprise, or another edition that includes the full Hyper-V
+feature, as listed in Microsoft's [Hyper-V host requirements](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/host-hardware-requirements#operating-system-requirements).
+This host requirement does not require the Windows guest to use the same edition. Enable AMD-V/SVM in UEFI and enable
+Hyper-V from an elevated PowerShell session:
 
 ```powershell
 Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
@@ -74,14 +78,39 @@ surprises. Reduce Docker/WSL concurrency before assigning so much memory that th
 
 ### 2.3. Windows media and licensing
 
-Use the official [Windows 11 Enterprise 90-day evaluation](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-11-enterprise)
-for the initial build. It is free for evaluation but is not a permanent production license.
+Choose the guest edition separately from the physical host edition:
 
-The normal Windows installer also allows **I don't have a product key**, but an unactivated installation is not a free
-license. A host Windows license does not automatically license a second Windows instance in a VM. See
-[Activate Windows](https://support.microsoft.com/en-us/windows/activation/activate-windows) and the
+| Guest option | WSL2 | Full Hyper-V role | Licensing use |
+| --- | --- | --- | --- |
+| Windows 11 Enterprise Evaluation | Yes | Yes | Free, licensed 90-day evaluation; best for proving the setup |
+| Windows 11 Home | Yes | No | Smallest sufficient long-lived guest after assigning a valid Home license |
+| Windows 11 Pro | Yes | Yes | Also works, but its additional virtualization features are not required here |
+
+Windows 11 Home is technically sufficient for the worker guest. Microsoft explicitly supports WSL2 on
+[Windows 11 Home](https://learn.microsoft.com/en-us/windows/wsl/faq#is-wsl-2-available-on-windows-10-home-and-windows-11-home).
+WSL2 uses the **Virtual Machine Platform** subset of Hyper-V, which is available on all Windows desktop editions; it
+does not require the guest to expose the complete Hyper-V management role. Microsoft also supports
+[WSL2 inside a Hyper-V VM](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/nested-virtualization#run-wsl2-in-a-hyper-v-vm-running-nested-on-hyper-v)
+when nested virtualization is enabled. The physical host still needs Pro or Enterprise because it creates and runs the
+outer VM.
+
+For the first build, either use the official
+[Windows 11 Enterprise 90-day evaluation](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-11-enterprise) or
+download Microsoft's normal [multi-edition Windows 11 ISO](https://www.microsoft.com/en-us/software-download/windows11)
+and install Home. Treat the evaluation as disposable and plan to rebuild rather than assuming it can be converted
+in-place to Home later.
+
+The normal installer allows **I don't have a product key**, but an unactivated Home or Pro installation is not a free
+license. A host Windows license does not automatically license a second Windows instance in a VM. For a permanent
+licensed guest, assign a separate valid license that permits that VM. See [Activate
+Windows](https://support.microsoft.com/en-us/windows/activation/activate-windows) and the
 [Windows license terms](https://www.microsoft.com/en-us/useterms). Do not use activation bypasses or unofficial KMS
 services.
+
+If Microsoft's ISO page returns message code `715-123130` or says that anonymous or location-hiding technology is not
+allowed, retry from the normal unproxied connection without a VPN. On a Windows machine, the official **Create Windows
+11 Installation Media** option on the same download page can create an ISO instead. Do not substitute an unofficial
+mirror for a worker image that will hold credentials.
 
 ## 3. Create the Hyper-V VM
 
@@ -89,9 +118,9 @@ The Hyper-V Manager wizard is acceptable. The following elevated PowerShell exam
 the paths and switch name before running it:
 
 ```powershell
-$vmName = "SniffyCodexWorker"
-$vmRoot = "D:\VMs\SniffyCodexWorker"
-$isoPath = "D:\ISO\Windows11EnterpriseEvaluation.iso"
+$vmName = "CodexWorker"
+$vmRoot = "D:\VMs\CodexWorker"
+$isoPath = "D:\ISO\Windows11.iso"
 $switchName = "Default Switch"
 
 New-Item -ItemType Directory -Force -Path $vmRoot
@@ -151,7 +180,7 @@ wsl --list --verbose
 If WSL reports that virtualization is unavailable, stop the VM and re-run this command on the physical host:
 
 ```powershell
-Set-VMProcessor -VMName "SniffyCodexWorker" -ExposeVirtualizationExtensions $true
+Set-VMProcessor -VMName "CodexWorker" -ExposeVirtualizationExtensions $true
 ```
 
 Running WSL2 inside a Hyper-V VM is a supported nested-virtualization scenario. See Microsoft's
@@ -188,9 +217,11 @@ Then:
 1. Sign in to the ChatGPT desktop app using the same ChatGPT account and workspace as the mobile app.
 2. Open **Settings**, switch the Codex agent from Windows native to **WSL**, and restart the app. The restart is required.
 3. Set WSL as the integrated terminal unless PowerShell is specifically needed.
-4. Add the repository from `\\wsl$\Ubuntu-24.04\home\<worker>\src\sniffy`.
-5. Select **Set up Remote** in the sidebar and pair the phone using the displayed QR code.
-6. Enable launch at login and keep the Windows session signed in. Keep it unlocked when a task uses Computer Use.
+4. Add Sniffy from `\\wsl$\Ubuntu-24.04\home\<worker>\src\sniffy\sniffy` as the first local project.
+5. Add every later repository as a separate local project; do not point one app project at a directory containing
+   multiple repositories.
+6. Select **Set up Remote** in the sidebar and pair the phone using the displayed QR code.
+7. Enable launch at login and keep the Windows session signed in. Keep it unlocked when a task uses Computer Use.
 
 The current Windows app and WSL behavior are documented in [ChatGPT desktop app for
 Windows](https://learn.chatgpt.com/docs/windows/windows-app). Remote setup and host availability are documented in
@@ -205,7 +236,8 @@ For an unattended machine, decide explicitly how reboots are handled:
 ## 6. Provision the WSL developer environment
 
 Run all project tooling inside Ubuntu, not in native Windows. This avoids duplicate Git checkouts, path translation,
-file-watcher problems, and mixed Windows/Linux credentials.
+file-watcher problems, and mixed Windows/Linux credentials. Use `~/src/<owner>/<repository>` so repositories with the
+same name cannot collide.
 
 ### 6.1. Base packages
 
@@ -256,11 +288,11 @@ docker run --rm hello-world
 Membership in the `docker` group is effectively root access inside WSL. That is intentional only because the whole VM
 is dedicated to the worker. Docker Desktop is not required.
 
-### 6.3. Clone and bootstrap Sniffy
+### 6.3. Clone and bootstrap Sniffy as the first project
 
 ```bash
-mkdir -p ~/src
-cd ~/src
+mkdir -p ~/src/sniffy
+cd ~/src/sniffy
 git clone https://github.com/sniffy/sniffy.git
 cd sniffy
 git switch develop
@@ -391,9 +423,11 @@ branch protection. Preserve those outer controls:
 
 ### 9.1. Why Scheduled tasks are the dispatcher
 
-The supported app-native path is a [Scheduled task](https://learn.chatgpt.com/docs/automations) scoped to the local
-Sniffy project. It can run in a dedicated background worktree, appears in the app's **Scheduled** inbox, and remains
-visible through Remote while the machine and desktop app are running.
+The supported app-native path is a [Scheduled task](https://learn.chatgpt.com/docs/automations) scoped to one or more
+local app projects. A run can use a dedicated background worktree, appears in the app's **Scheduled** inbox, and remains
+visible through Remote while the machine and desktop app are running. Use separate Scheduled tasks by default when
+repositories have different prompts, queues, schedules, or credential owners. The app also supports assigning one
+generic Scheduled task to several projects when their workflow is truly identical.
 
 There is currently no documented stable shell API that creates a new local task inside the ChatGPT desktop app UI.
 `codex exec` and `.codex/local/run-issue.sh` remain useful CLI fallbacks, but a CLI run is not the same app task. The
@@ -495,17 +529,123 @@ blocker and smallest required decision. Never claim or implement more than one i
 The worker performs the issue directly in the Scheduled task. It must not call `.codex/local/run-issue.sh`, because that
 would launch a second, nested CLI agent and lose the app-native task lifecycle.
 
-## 10. Validation checklist
+## 10. Add repositories and organizations
 
-### 10.1. VM and WSL
+### 10.1. Keep one real trust boundary
+
+One VM may host several personal or open-source repositories when all of them belong to the same trust domain. Full
+access means a task running for one repository can technically read every checkout and credential profile in the VM.
+Separate WSL users, distributions, and `GH_CONFIG_DIR` values improve organization but are not security boundaries
+against the full-access agent.
+
+Use another outer VM for corporate repositories, client work, unknown third-party code, or any organization that must
+not share credentials with the personal worker. Do not put employer credentials in this VM.
+
+Use this checkout layout inside the shared WSL distribution:
+
+```text
+~/src/
+  sniffy/sniffy/
+  nefi/nefi/
+  kerb4j/kerb4j/
+```
+
+### 10.2. Create one app project per repository
+
+For each additional repository:
+
+1. Clone it into `~/src/<owner>/<repository>`.
+2. Add that checkout root as a separate local project in the ChatGPT desktop app.
+3. Add repository-specific `AGENTS.md`, setup, test, base-branch, and Definition-of-Ready instructions.
+4. Configure and smoke-test its local worktree environment.
+5. Copy the Scheduled task prompt and substitute the repository's values, or attach a tested generic task shared by
+   projects with the same queue contract.
+6. Run one manual no-op cycle and one disposable issue end to end before enabling its schedule.
+7. Stagger schedules so Maven, Docker, browsers, and multiple worktree setups do not all start together.
+
+A Scheduled task may be assigned to more than one local project, but each run must stay inside the project and worktree
+selected by the app. The generic prompt must derive repository-specific values from that checkout. Do not claim an
+arbitrary repository and then clone or change directory into it: that loses the clean lifecycle and makes mobile review
+misleading.
+
+An organization-owned GitHub Project may contain issues from several repositories in that organization. Give every
+repository its own app project and retain the `repo:<owner>/<repository>` query filter whether the schedule is shared
+or separate. The runs can share status names and the same Project number while always claiming only their own
+repository.
+
+Record these values for every project instead of hard-coding Sniffy assumptions into a common machine script:
+
+| Setting | Sniffy example | Per-project value |
+| --- | --- | --- |
+| Checkout | `~/src/sniffy/sniffy` | `~/src/<owner>/<repository>` |
+| GitHub repository | `sniffy/sniffy` | `<owner>/<repository>` |
+| Queue owner | `sniffy` | Organization that owns the Project |
+| Project number | `<PROJECT_NUMBER>` | Organization Project number |
+| Base branch | `develop` | Repository integration branch |
+| Readiness contract | `docs/codex-workflow.md` | Repository-owned instructions |
+| Worktree setup | `.codex/cloud/maintenance.sh` | Repository-owned local setup |
+| Ready/in-progress/review states | Sniffy Project options | Queue-specific option IDs and names |
+| Worker label and assignee | `agent:local`, machine account | Repository-specific values |
+
+Machine provisioning installs only shared capabilities such as WSL, Docker, Git, `gh`, `mise`, and common language
+runtimes. Each repository remains responsible for exact versions, setup commands, tests, and agent guidance.
+
+### 10.3. Scope credentials by resource owner
+
+A fine-grained PAT can access repositories owned by only
+[one user or organization](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens).
+Choose the credential layout from the actual ownership boundaries:
+
+| Repository portfolio | Recommended credential model |
+| --- | --- |
+| Several repositories in one organization | One dedicated machine account and one fine-grained PAT limited to selected repositories |
+| Repositories in several personal organizations | One fine-grained PAT and one `gh` profile per resource owner |
+| Many organizations or automated token rotation | A narrowly permissioned GitHub App installed only on selected repositories |
+| Different security or legal trust domains | Separate outer worker VMs and separate identities |
+
+Do not solve the multi-organization limitation by issuing one broad classic PAT. Store each owner profile outside every
+checkout, select it explicitly for that project's `gh` and Git commands, and test repository plus Project access before
+enabling the schedule. `GH_CONFIG_DIR` can keep the `gh` profiles separate, but the full-access agent can still read
+all profiles in the same VM; the separation prevents accidental credential selection, not deliberate cross-access.
+
+For a small hobby portfolio, start with one fine-grained PAT per owner. Move to a GitHub App only when installation
+tokens, centralized permission management, or rotation justify the additional bootstrap code.
+
+### 10.4. Parameterize the queue contract, not the VM
+
+Keep the Sniffy prompt in section 9 as a working example. A new repository changes the prompt values and repository
+instructions, not the Windows image. At minimum parameterize:
+
+```text
+OWNER
+REPOSITORY
+PROJECT_NUMBER
+BASE_BRANCH
+READINESS_DOCUMENT
+READY_STATUS
+IN_PROGRESS_STATUS
+REVIEW_STATUS
+BLOCKED_STATUS
+WORKER_ASSIGNEE
+WORKER_LABEL
+```
+
+Keep each organization's book of work in an organization-owned Project for the initial implementation. For multiple
+organizations, run the corresponding repository tasks against their owner's Project and credential profile. A future
+central coordinator may present a unified portfolio view, but it must not replace the app's per-repository task and
+worktree boundary.
+
+## 11. Validation checklist
+
+### 11.1. VM and WSL
 
 From the physical host:
 
 ```powershell
-Get-VM -Name "SniffyCodexWorker"
-Get-VMProcessor -VMName "SniffyCodexWorker" | Format-List Count,ExposeVirtualizationExtensions
-Get-VMMemory -VMName "SniffyCodexWorker"
-Get-VMTPM -VMName "SniffyCodexWorker"
+Get-VM -Name "CodexWorker"
+Get-VMProcessor -VMName "CodexWorker" | Format-List Count,ExposeVirtualizationExtensions
+Get-VMMemory -VMName "CodexWorker"
+Get-VMTPM -VMName "CodexWorker"
 ```
 
 Inside the Windows VM and WSL:
@@ -523,10 +663,10 @@ mise --version
 mvn -version
 ```
 
-### 10.2. Repository toolchains
+### 11.2. Repository toolchains
 
 ```bash
-cd ~/src/sniffy
+cd ~/src/sniffy/sniffy
 
 source .codex/cloud/use-jdk.sh 8
 mvn -version
@@ -540,12 +680,12 @@ git diff --check
 Run one small focused Maven test and one Docker smoke test. Do not treat a cache warm-up as proof that the full reactor
 passes.
 
-### 10.3. GitHub publication
+### 11.3. GitHub publication
 
 First run the reversible remote-ref validation prompt from `docs/codex-workflow.md`. Verify that the PAT can also read
 and update the organization Project. Delete the probe branch and confirm that no remote ref remains.
 
-### 10.4. App, Scheduled, and mobile
+### 11.4. App, Scheduled, and mobile
 
 1. Start a manual read-only task in the local WSL project and confirm commands execute in Linux.
 2. Create a disposable worktree task and confirm the local environment setup completes.
@@ -553,10 +693,13 @@ and update the organization Project. Delete the probe branch and confirm that no
 4. Run the worker prompt manually against a project view with no eligible issues; it must produce a no-op.
 5. Add one disposable ready issue, run the task once, and verify claim fields, branch, PR, and `Review` transition.
 6. Revoke or rotate the test PAT and confirm the old token no longer authenticates.
+7. For each additional repository, verify that its Scheduled task cannot claim an issue for another repository.
+8. For each additional resource owner, verify the selected credential profile can access only its intended repositories
+   and Project.
 
-Do not enable the recurring schedule until all six checks pass.
+Do not enable a recurring schedule until all applicable checks pass.
 
-## 11. Operations and recovery
+## 12. Operations and recovery
 
 - Keep Windows, WSL, the ChatGPT desktop app, Docker, `gh`, and toolchains updated during a defined maintenance window.
 - Review the first several Scheduled runs. Pause the schedule after unexpected claims, repeated no-op errors, or a
@@ -567,10 +710,10 @@ Do not enable the recurring schedule until all six checks pass.
 - On suspected compromise: stop the VM, revoke the PAT, disconnect Remote, invalidate active ChatGPT sessions if needed,
   and rebuild from the pre-credential checkpoint or clean media.
 - Do not restore an old credential-bearing checkpoint after revocation without rotating every secret it contains.
-- When the Windows evaluation approaches expiry, rebuild or license the guest; activation bypass is not part of this
-  design.
+- When an Enterprise Evaluation approaches expiry, rebuild or assign an appropriate licensed guest. A Home guest does
+  not expire after activation, but it still needs its own valid license. Activation bypass is not part of this design.
 
-## 12. Explicit non-goals
+## 13. Explicit non-goals
 
 - This runbook does not make unactivated Windows a licensed permanent installation.
 - It does not expose the physical host filesystem or Docker daemon to Codex.
@@ -578,4 +721,5 @@ Do not enable the recurring schedule until all six checks pass.
 - It does not require Docker Desktop or a Dev Container to contain the agent.
 - It does not use UI automation to click through the ChatGPT desktop app.
 - It does not make a multi-worker GitHub Project claim protocol safe.
-- It does not authorize the worker to merge pull requests, bypass branch rules, or manage unrelated repositories.
+- It does not authorize the worker to merge pull requests, bypass branch rules, or manage repositories outside the
+  explicitly registered portfolio.

--- a/docs/local-codex-worker.md
+++ b/docs/local-codex-worker.md
@@ -114,8 +114,21 @@ mirror for a worker image that will hold credentials.
 
 ## 3. Create the Hyper-V VM
 
-The Hyper-V Manager wizard is acceptable. The following elevated PowerShell example records the intended shape. Replace
-the paths and switch name before running it:
+The Hyper-V Manager wizard is acceptable. The following PowerShell path makes the intended VM shape reproducible.
+
+### 3.1. Save and run the creation script
+
+Open **Windows PowerShell as Administrator** on the physical host. Create a dedicated script directory and open a new
+script in Notepad:
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$HOME\\Documents\\CodexWorker"
+notepad.exe "$HOME\\Documents\\CodexWorker\\create-codex-worker.ps1"
+```
+
+Accept Notepad's prompt to create the file, paste the complete script below, replace the ISO, VM, and switch paths, then
+save and close Notepad. Starting Notepad with the full `.ps1` path avoids accidentally saving
+`create-codex-worker.ps1.txt`.
 
 ```powershell
 $vmName = "CodexWorker"
@@ -141,21 +154,55 @@ Set-VM -Name $vmName -AutomaticStartAction Start -AutomaticStopAction Save
 
 $dvd = Add-VMDvdDrive -VMName $vmName -Path $isoPath -Passthru
 Set-VMFirmware -VMName $vmName -FirstBootDevice $dvd
-Start-VM -Name $vmName
 ```
+
+The script deliberately creates the VM without starting it. In the same elevated PowerShell window, allow scripts only
+for that PowerShell process and execute the saved file:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+& "$HOME\\Documents\\CodexWorker\\create-codex-worker.ps1"
+```
+
+This does not weaken the permanent machine or user execution policy; closing the PowerShell window removes the
+process-scoped override. Do not use a machine-wide `Unrestricted` policy for this runbook.
 
 Windows 11 VMs require Generation 2, Secure Boot, a virtual TPM, at least 4 GB RAM, two virtual processors, and 64 GB
 storage. See [Windows 11 requirements: virtual machine
 support](https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements#virtual-machine-support).
 
+### 3.2. Open Hyper-V Manager and boot the ISO
+
+Open the manager from Start by searching for **Hyper-V Manager**, or run:
+
+```powershell
+virtmgmt.msc
+```
+
+In Hyper-V Manager:
+
+1. Select the local host in the left pane. If it is absent, use **Action > Connect to Server > Local computer**.
+2. Find **CodexWorker** in the center **Virtual Machines** pane.
+3. Right-click **CodexWorker**, select **Connect**, and leave the VMConnect console in the foreground.
+4. Click **Start** in VMConnect.
+5. Immediately click inside the console and press **Space** repeatedly until Windows Setup appears.
+
+An official Windows ISO briefly displays **Press any key to boot from CD or DVD**. One keypress is technically enough
+after VMConnect has keyboard focus, but repeated Space presses are a reliable way to acquire focus and catch the
+short prompt. If the Hyper-V UEFI boot summary appears instead, click **Restart now**, click inside the console, and
+repeat the Space presses. On later installer-initiated reboots, do **not** press a key; let the VM boot from its virtual
+disk instead of restarting setup from the ISO.
+
 During Windows setup:
 
-1. Create a dedicated local Windows account for the worker.
-2. Do not sign into GitHub, email, cloud drives, or password managers used on the host.
-3. Apply Windows Update and reboot until no important update remains.
-4. Disable sleep inside the guest. The host may still save the VM during shutdown.
-5. Do not enable shared host drives. Avoid clipboard and device redirection when using an enhanced session.
-6. Create a clean checkpoint before adding ChatGPT and GitHub credentials.
+1. Select Windows 11 Pro, not a regional `N` edition. Home supports WSL2, but Pro makes later RDP and administration
+   easier.
+2. Create a dedicated local Windows account for the worker.
+3. Do not sign into GitHub, email, cloud drives, or password managers used on the host.
+4. Apply Windows Update and reboot until no important update remains.
+5. Disable sleep inside the guest. The host may still save the VM during shutdown.
+6. Do not enable shared host drives. Avoid clipboard and device redirection when using an enhanced session.
+7. Create a clean checkpoint before adding ChatGPT and GitHub credentials.
 
 Checkpoints and VM exports made after login contain cached credentials. Store them only on an encrypted host volume and
 treat them as secrets.

--- a/docs/local-codex-worker.md
+++ b/docs/local-codex-worker.md
@@ -84,7 +84,7 @@ Choose the guest edition separately from the physical host edition:
 | --- | --- | --- | --- |
 | Windows 11 Enterprise Evaluation | Yes | Yes | Free, licensed 90-day evaluation; best for proving the setup |
 | Windows 11 Home | Yes | No | Smallest sufficient long-lived guest after assigning a valid Home license |
-| Windows 11 Pro | Yes | Yes | Also works, but its additional virtualization features are not required here |
+| Windows 11 Pro | Yes | Yes | Recommended here for RDP and easier administration after assigning a valid Pro license |
 
 Windows 11 Home is technically sufficient for the worker guest. Microsoft explicitly supports WSL2 on
 [Windows 11 Home](https://learn.microsoft.com/en-us/windows/wsl/faq#is-wsl-2-available-on-windows-10-home-and-windows-11-home).
@@ -97,8 +97,9 @@ outer VM.
 For the first build, either use the official
 [Windows 11 Enterprise 90-day evaluation](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-11-enterprise) or
 download Microsoft's normal [multi-edition Windows 11 ISO](https://www.microsoft.com/en-us/software-download/windows11)
-and install Home. Treat the evaluation as disposable and plan to rebuild rather than assuming it can be converted
-in-place to Home later.
+and install Pro. Home remains technically sufficient, but this runbook recommends Pro because accepting inbound RDP
+and using its administration tools are useful when operating an unattended worker. Treat the evaluation as disposable
+and plan to rebuild rather than assuming it can be converted in-place to Home or Pro later.
 
 The normal installer allows **I don't have a product key**, but an unactivated Home or Pro installation is not a free
 license. A host Windows license does not automatically license a second Windows instance in a VM. For a permanent
@@ -122,8 +123,8 @@ Open **Windows PowerShell as Administrator** on the physical host. Create a dedi
 script in Notepad:
 
 ```powershell
-New-Item -ItemType Directory -Force -Path "$HOME\\Documents\\CodexWorker"
-notepad.exe "$HOME\\Documents\\CodexWorker\\create-codex-worker.ps1"
+New-Item -ItemType Directory -Force -Path "$HOME\Documents\CodexWorker"
+notepad.exe "$HOME\Documents\CodexWorker\create-codex-worker.ps1"
 ```
 
 Accept Notepad's prompt to create the file, paste the complete script below, replace the ISO, VM, and switch paths, then
@@ -161,7 +162,7 @@ for that PowerShell process and execute the saved file:
 
 ```powershell
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-& "$HOME\\Documents\\CodexWorker\\create-codex-worker.ps1"
+& "$HOME\Documents\CodexWorker\create-codex-worker.ps1"
 ```
 
 This does not weaken the permanent machine or user execution policy; closing the PowerShell window removes the

--- a/docs/local-codex-worker.md
+++ b/docs/local-codex-worker.md
@@ -119,23 +119,35 @@ The Hyper-V Manager wizard is acceptable. The following PowerShell path makes th
 
 ### 3.1. Save and run the creation script
 
-Open **Windows PowerShell as Administrator** on the physical host. Create a dedicated script directory and open a new
-script in Notepad:
+Use the stable naming pattern `bedrin-worker-<number>`: the first VM and its Windows hostname are
+`bedrin-worker-1`, and a later independent worker becomes `bedrin-worker-2`. Keep every worker under
+`C:\work\vms\<vm-name>` and keep the reusable installation image at `C:\work\iso\windows.iso`.
+
+Open **Windows PowerShell as Administrator** on the physical host. Create the VM storage directory and open the reusable
+creation script in Notepad:
 
 ```powershell
-New-Item -ItemType Directory -Force -Path "$HOME\Documents\CodexWorker"
-notepad.exe "$HOME\Documents\CodexWorker\create-codex-worker.ps1"
+New-Item -ItemType Directory -Force -Path "C:\work\vms"
+notepad.exe "C:\work\vms\create-bedrin-worker.ps1"
 ```
 
-Accept Notepad's prompt to create the file, paste the complete script below, replace the ISO, VM, and switch paths, then
-save and close Notepad. Starting Notepad with the full `.ps1` path avoids accidentally saving
-`create-codex-worker.ps1.txt`.
+Accept Notepad's prompt to create the file, paste the complete script below, and save and close Notepad. Starting
+Notepad with the full `.ps1` path avoids accidentally saving `create-bedrin-worker.ps1.txt`.
 
 ```powershell
-$vmName = "CodexWorker"
-$vmRoot = "D:\VMs\CodexWorker"
-$isoPath = "D:\ISO\Windows11.iso"
+param(
+  [ValidateRange(1, 99)]
+  [int] $WorkerNumber = 1
+)
+
+$vmName = "bedrin-worker-$WorkerNumber"
+$vmRoot = Join-Path "C:\work\vms" $vmName
+$isoPath = "C:\work\iso\windows.iso"
 $switchName = "Default Switch"
+
+if (-not (Test-Path -LiteralPath $isoPath -PathType Leaf)) {
+  throw "Windows ISO not found: $isoPath"
+}
 
 New-Item -ItemType Directory -Force -Path $vmRoot
 New-VM `
@@ -162,11 +174,13 @@ for that PowerShell process and execute the saved file:
 
 ```powershell
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-& "$HOME\Documents\CodexWorker\create-codex-worker.ps1"
+& "C:\work\vms\create-bedrin-worker.ps1" -WorkerNumber 1
 ```
 
-This does not weaken the permanent machine or user execution policy; closing the PowerShell window removes the
-process-scoped override. Do not use a machine-wide `Unrestricted` policy for this runbook.
+This creates `bedrin-worker-1` under `C:\work\vms\bedrin-worker-1`. To create the second worker later, run the
+same script with `-WorkerNumber 2`; do not clone a credential-bearing first VM. The process-scoped override does not
+weaken the permanent machine or user execution policy and disappears when the PowerShell window closes. Do not use a
+machine-wide `Unrestricted` policy for this runbook.
 
 Windows 11 VMs require Generation 2, Secure Boot, a virtual TPM, at least 4 GB RAM, two virtual processors, and 64 GB
 storage. See [Windows 11 requirements: virtual machine
@@ -183,8 +197,8 @@ virtmgmt.msc
 In Hyper-V Manager:
 
 1. Select the local host in the left pane. If it is absent, use **Action > Connect to Server > Local computer**.
-2. Find **CodexWorker** in the center **Virtual Machines** pane.
-3. Right-click **CodexWorker**, select **Connect**, and leave the VMConnect console in the foreground.
+2. Find **bedrin-worker-1** in the center **Virtual Machines** pane.
+3. Right-click **bedrin-worker-1**, select **Connect**, and leave the VMConnect console in the foreground.
 4. Click **Start** in VMConnect.
 5. Immediately click inside the console and press **Space** repeatedly until Windows Setup appears.
 
@@ -198,12 +212,23 @@ During Windows setup:
 
 1. Select Windows 11 Pro, not a regional `N` edition. Home supports WSL2, but Pro makes later RDP and administration
    easier.
-2. Create a dedicated local Windows account for the worker.
-3. Do not sign into GitHub, email, cloud drives, or password managers used on the host.
-4. Apply Windows Update and reboot until no important update remains.
-5. Disable sleep inside the guest. The host may still save the VM during shutdown.
-6. Do not enable shared host drives. Avoid clipboard and device redirection when using an enhanced session.
-7. Create a clean checkpoint before adding ChatGPT and GitHub credentials.
+2. Give Windows the same device name as the Hyper-V VM: `bedrin-worker-1`. Use `bedrin-worker-2` for the later
+   second worker.
+3. To create a local account during Windows 11 Pro OOBE, choose **Set up for work or school**, then
+   **Sign-in options > Domain join instead**. Despite the label, this path creates a local account and does not require
+   joining a domain.
+4. If that option is absent or OOBE has already passed it, finish setup with a dedicated temporary Microsoft account,
+   then use **Settings > Accounts > Your info > Sign in with a local account instead**. Microsoft documents this
+   conversion in [Change from a Microsoft account to a local
+   account](https://support.microsoft.com/en-US/accounts-billing/manage/change-from-a-local-account-to-a-microsoft-account-in-windows).
+   Remove the temporary identity from **Email & accounts** and unlink OneDrive afterward.
+5. Use a dedicated local Windows username such as `worker` and set a strong non-empty password because RDP will need
+   it. Do not use a personal or employer Microsoft account for this VM.
+6. Do not sign into GitHub, email, cloud drives, or password managers used on the host.
+7. Apply Windows Update and reboot until no important update remains.
+8. Disable sleep inside the guest. The host may still save the VM during shutdown.
+9. Do not enable shared host drives. Avoid clipboard and device redirection when using an enhanced session.
+10. Create a clean checkpoint before adding ChatGPT and GitHub credentials.
 
 Checkpoints and VM exports made after login contain cached credentials. Store them only on an encrypted host volume and
 treat them as secrets.
@@ -228,7 +253,7 @@ wsl --list --verbose
 If WSL reports that virtualization is unavailable, stop the VM and re-run this command on the physical host:
 
 ```powershell
-Set-VMProcessor -VMName "CodexWorker" -ExposeVirtualizationExtensions $true
+Set-VMProcessor -VMName "bedrin-worker-1" -ExposeVirtualizationExtensions $true
 ```
 
 Running WSL2 inside a Hyper-V VM is a supported nested-virtualization scenario. See Microsoft's
@@ -690,10 +715,10 @@ worktree boundary.
 From the physical host:
 
 ```powershell
-Get-VM -Name "CodexWorker"
-Get-VMProcessor -VMName "CodexWorker" | Format-List Count,ExposeVirtualizationExtensions
-Get-VMMemory -VMName "CodexWorker"
-Get-VMTPM -VMName "CodexWorker"
+Get-VM -Name "bedrin-worker-1"
+Get-VMProcessor -VMName "bedrin-worker-1" | Format-List Count,ExposeVirtualizationExtensions
+Get-VMMemory -VMName "bedrin-worker-1"
+Get-VMTPM -VMName "bedrin-worker-1"
 ```
 
 Inside the Windows VM and WSL:


### PR DESCRIPTION
## What changed

- generalize the Windows VM from a Sniffy-only worker into a shared personal Codex worker with one app project per repository
- document separate and shared Scheduled task layouts, repository-specific queue parameters, checkout conventions, and trust boundaries
- describe multi-organization credentials: one fine-grained PAT/profile per resource owner, with a GitHub App as the scaling path
- document Windows 11 Home as a sufficient guest for WSL2 while retaining Windows Pro/Enterprise as the physical Hyper-V host requirement
- distinguish Enterprise Evaluation, licensed Home/Pro, and technically installable but unlicensed Windows
- add official ISO alternatives and troubleshooting for Microsoft download error 715-123130
- rename the example VM and paths from Sniffy-specific to generic values
- document how to save and run the PowerShell provisioning script with a process-scoped execution-policy override
- document how to open Hyper-V Manager, connect before first power-on, focus VMConnect, and catch the ISO boot prompt
- use the numbered `bedrin-worker-1` naming convention and the `C:\work\vms` / `C:\work\iso\windows.iso` storage layout
- document the Windows 11 Pro local-account OOBE path and the post-setup conversion fallback

## Why

The first runbook correctly described the Sniffy proof of concept but made the VM, guest edition, repository layout, and scheduler sound more Sniffy-specific than the architecture requires. The worker should host several personal repositories and organizations without hiding the credential and isolation consequences. Windows 11 Home also provides WSL2 and is sufficient inside the VM, so Enterprise Evaluation is not the only technical guest option.

## Compatibility and risk

This is documentation-only and changes no product code, workflow, dependency, or public API.

A shared full-access VM is still one trust boundary: every task can technically read every checkout and credential profile in it. Corporate or otherwise separated work requires another outer VM. Windows Home still needs its own valid license for permanent licensed use, and the physical host still needs a Windows edition that includes Hyper-V.

The multi-project Scheduled task layout and Windows Home plus nested WSL2 path should be smoke-tested on the target Ryzen/Hyper-V machine before schedules are enabled.

No authoritative GitHub issue exists for this documentation follow-up.

## Validation

- `markdownlint-cli2` with MD013 disabled to match repository line-width style: passed with 0 errors
- `git diff --no-index --check`: no whitespace errors
- verified balanced fenced code blocks and ordered headings
- checked Windows Home WSL2, nested WSL2, Hyper-V host editions, and ISO creation against current Microsoft documentation
- checked one-to-many local project scheduling against the current Codex manual
- verified all four PR commits change only `docs/local-codex-worker.md`
- verified the remote file blob exactly matches the validated local content

## Published head

`1970514ba15c10eaf95acd505c82714751efdafd`
