### PR TITLE
Document visual evidence and Codex review dispatch requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,22 @@ constraints for their subtrees.
   audit, and Playwright for UI changes. Review `npm run dev` playground pages and visual diffs before updating baselines.
 - Storybook's MCP addon is optional for local exploration. CI and tests must never require an external AI or MCP service.
 
+### Visual evidence contract
+
+- This contract applies to frontend and UI changes, not backend-only or documentation-only changes. For every intentionally
+  changed visual surface, attach before and after screenshots covering representative desktop and mobile viewports where
+  applicable, every affected light/dark theme, and important interaction states.
+- For a visual-neutral refactor, attach identical before and after screenshots or link directly to downloadable visual-test
+  artifacts that prove the baseline did not change.
+- Identify the application, route or story, viewport, browser, theme, and state in each filename or caption so reviewers
+  can map every image to the surface it proves.
+- If a screenshot test fails only in a particular environment, reproduce it against both the exact base SHA and head SHA
+  in that environment and attach or link the resulting diff. Never update a visual baseline unless the visual change is
+  intentional and explicitly approved.
+- If Codex Cloud cannot embed screenshots directly, run Playwright in the supported CI environment, upload the visual
+  outputs as downloadable artifacts, and link those artifacts from the pull request. Lack of local GUI access alone does
+  not satisfy the visual-evidence requirement.
+
 ## Pull requests
 
 - Keep pull requests draft only while implementation or locally applicable verification is incomplete. Unless the task
@@ -93,6 +109,13 @@ constraints for their subtrees.
   dependency changes, and remaining risks. Link the authoritative issue and include the exact published head SHA.
 - Do not hide limitations. If the environment cannot run a platform-, JDK-, or credential-dependent check, say exactly
   what is missing and leave CI to perform that check.
+- A `REQUEST_CHANGES` review does not dispatch or resume Codex Cloud. Whenever a maintainer expects an agent to continue
+  after review, the maintainer must also post a separate, explicit `@codex` follow-up comment that summarizes every
+  blocking review item and tells the agent not to merge.
+- After that dispatch comment, schedule a status check for 15 minutes later and a second check 15 minutes after the first;
+  if the work is still incomplete, continue monitoring hourly. Do not mark the task as actively being fixed merely
+  because a review was submitted: verify that the explicit dispatch comment exists and that the agent has acknowledged
+  it or pushed a new commit. This dispatch and monitoring contract applies to every agent-authored pull request.
 
 ## Review guidelines
 


### PR DESCRIPTION
## Problem

Frontend/UI pull requests need a single evidence contract that lets reviewers verify intended visual changes and visual-neutral refactors. Maintainers also need an explicit dispatch workflow because a `REQUEST_CHANGES` review alone does not resume Codex Cloud.

Closes https://github.com/sniffy/sniffy/issues/677

## Design

- Add one repository-wide visual-evidence contract under the existing frontend instructions.
- Require before/after coverage for changed surfaces and artifact proof for visual-neutral work.
- Define exact base-vs-head reproduction, baseline approval, evidence labeling, and the Codex Cloud artifact fallback.
- Add a repository-wide review follow-up contract requiring an explicit `@codex` dispatch comment, blocking-item summary, no-merge instruction, and 15/15-minute then hourly monitoring.

## Compatibility impact

Documentation-only change. No production code, public API, dependency, Java baseline, or generated resource changes.

## Tests executed

- `git diff --check` — passed.

## Checks not run

Build and test suites were not run because this change only updates repository agent instructions.

## Dependency changes

None.

## Remaining risks

The workflow depends on maintainers scheduling and performing the documented follow-up checks.

Published head SHA: `3f1032083731655d49247f06acd0aedc7f4117d1`
