### PR TITLE
[infra] Publish PR screenshots through Cloudinary

### DIFF
--- a/.agents/skills/publish-pr-screenshots/SKILL.md
+++ b/.agents/skills/publish-pr-screenshots/SKILL.md
@@ -36,7 +36,13 @@ A process-level environment variable takes precedence over the same variable in 
 
 The configured preset owns the Cloudinary asset folder, allowed formats, file-size limit, unique naming, and overwrite policy. `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`, the Cloudinary product-environment ID, and a separate asset-folder variable are not used by this skill.
 
-For Codex Cloud, enable agent internet access and allow:
+For Codex Cloud, run `bash .codex/cloud/setup.sh` before the agent phase. Setup selects the repository-supported Node 24 runtime and persists `NODE_USE_ENV_PROXY=1` so Node fetch uses the Codex Cloud environment proxy. Invoke the publisher through the repository-owned wrapper:
+
+```bash
+.agents/skills/publish-pr-screenshots/scripts/codex-cloud-publish-pr-screenshots.sh --help
+```
+
+Then enable agent internet access and allow:
 
 | Domain | Methods | Purpose |
 | --- | --- | --- |
@@ -54,8 +60,7 @@ See [Cloudinary setup](references/cloudinary-setup.md) for local and cloud examp
 Use this after the relevant visual tests pass and the new baselines have been inspected and intentionally approved.
 
 ```bash
-node --env-file-if-exists=.env.local \
-  .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
+.agents/skills/publish-pr-screenshots/scripts/codex-cloud-publish-pr-screenshots.sh \
   baselines --repo sniffy/sniffy --pr <number>
 ```
 
@@ -81,8 +86,7 @@ If the block is absent, the script appends it. It rejects malformed or duplicate
 Use this to make useful browser-test failure PNGs visible directly in a PR comment:
 
 ```bash
-node --env-file-if-exists=.env.local \
-  .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
+.agents/skills/publish-pr-screenshots/scripts/codex-cloud-publish-pr-screenshots.sh \
   diagnostics --repo sniffy/sniffy --pr <number> \
   --heading "WebKit compact-trigger failure" \
   --file path/to/expected.png \

--- a/.agents/skills/publish-pr-screenshots/SKILL.md
+++ b/.agents/skills/publish-pr-screenshots/SKILL.md
@@ -24,6 +24,16 @@ CLOUDINARY_UPLOAD_PRESET
 
 Do not commit their values. The upload preset name is not a cryptographic secret, but anyone who obtains it may be able to consume the restricted preset, so keep it in environment configuration and rotate it if abused.
 
+For local work, copy `.env.local.example` to ignored `.env.local`, fill in the two values, and invoke Node with the repository-local env file:
+
+```bash
+cp .env.local.example .env.local
+node --env-file=.env.local \
+  .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs --help
+```
+
+A process-level environment variable takes precedence over the same variable in `.env.local`. Do not add the real values to `.env.local.example`.
+
 The configured preset owns the Cloudinary asset folder, allowed formats, file-size limit, unique naming, and overwrite policy. `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`, the Cloudinary product-environment ID, and a separate asset-folder variable are not used by this skill.
 
 For Codex Cloud, enable agent internet access and allow:
@@ -44,7 +54,8 @@ See [Cloudinary setup](references/cloudinary-setup.md) for local and cloud examp
 Use this after the relevant visual tests pass and the new baselines have been inspected and intentionally approved.
 
 ```bash
-node .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
+node --env-file-if-exists=.env.local \
+  .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
   baselines --repo sniffy/sniffy --pr <number>
 ```
 
@@ -70,7 +81,8 @@ If the block is absent, the script appends it. It rejects malformed or duplicate
 Use this to make useful browser-test failure PNGs visible directly in a PR comment:
 
 ```bash
-node .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
+node --env-file-if-exists=.env.local \
+  .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
   diagnostics --repo sniffy/sniffy --pr <number> \
   --heading "WebKit compact-trigger failure" \
   --file path/to/expected.png \

--- a/.agents/skills/publish-pr-screenshots/SKILL.md
+++ b/.agents/skills/publish-pr-screenshots/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: publish-pr-screenshots
+description: Publish reviewed Sniffy UI visual baselines or explicitly selected Playwright failure screenshots to Cloudinary, then update the matching GitHub pull request description or add a diagnostic comment. Use after visual review or when browser-test screenshots need to be visible directly in a PR.
+---
+
+# Publish PR screenshots
+
+Use the bundled script rather than calling Cloudinary or editing the PR body ad hoc:
+
+```bash
+node .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs --help
+```
+
+The workflow uses an unsigned, restricted Cloudinary upload preset. It never needs a Cloudinary API secret and must not mark a pull request ready, enable auto-merge, or merge.
+
+## Required configuration
+
+Set these variables in both local Codex and the Codex Cloud environment:
+
+```text
+CLOUDINARY_CLOUD_NAME
+CLOUDINARY_UPLOAD_PRESET
+```
+
+Do not commit their values. The upload preset name is not a cryptographic secret, but anyone who obtains it may be able to consume the restricted preset, so keep it in environment configuration and rotate it if abused.
+
+The configured preset owns the Cloudinary asset folder, allowed formats, file-size limit, unique naming, and overwrite policy. `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`, the Cloudinary product-environment ID, and a separate asset-folder variable are not used by this skill.
+
+For Codex Cloud, enable agent internet access and allow:
+
+| Domain | Methods | Purpose |
+| --- | --- | --- |
+| `api.cloudinary.com` | `POST` | Upload PNG files with the unsigned preset. |
+| `res.cloudinary.com` | `GET`, `HEAD` | Verify each returned CDN URL before editing GitHub. |
+| `api.github.com` | `GET`, `POST`, `PATCH` | Resolve the PR and edit its body or create a comment through `gh`. |
+| `github.com` | `GET`, `HEAD` | Resolve repository and commit links used by `gh` and generated Markdown. |
+
+GitHub authentication must already be available to `gh`. Follow `docs/codex-workflow.md` for `GH_TOKEN` persistence and GitHub agent-internet policy.
+
+See [Cloudinary setup](references/cloudinary-setup.md) for local and cloud examples.
+
+## Mode: reviewed baselines
+
+Use this after the relevant visual tests pass and the new baselines have been inspected and intentionally approved.
+
+```bash
+node .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
+  baselines --repo sniffy/sniffy --pr <number>
+```
+
+Without `--file`, the script publishes changed PNG files under:
+
+```text
+sniffy-ui/tests/e2e/visual-baselines/
+```
+
+Explicit files may be selected by repeating `--file`, but baseline mode still restricts them to that directory.
+
+Baseline mode requires a clean worktree. It replaces only the PR-description block between:
+
+```text
+<!-- sniffy-ui-screenshots:start -->
+<!-- sniffy-ui-screenshots:end -->
+```
+
+If the block is absent, the script appends it. It rejects malformed or duplicate markers.
+
+## Mode: failure diagnostics
+
+Use this to make useful browser-test failure PNGs visible directly in a PR comment:
+
+```bash
+node .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
+  diagnostics --repo sniffy/sniffy --pr <number> \
+  --heading "WebKit compact-trigger failure" \
+  --file path/to/expected.png \
+  --file path/to/actual.png \
+  --file path/to/diff.png
+```
+
+Diagnostics mode requires explicitly selected `--file` arguments. Inspect every image before upload. Useful inputs include Playwright expected, actual, diff, and `test-failed-*.png` screenshots.
+
+Do not automatically upload a whole `test-results` directory. Playwright traces, HAR files, HTML reports, logs, archives, request payloads, credentials, user data, or private infrastructure details are outside this PNG-only skill and must remain GitHub artifacts unless separately inspected and approved.
+
+## Safety and publication checks
+
+The script must complete these checks before changing GitHub:
+
+1. Resolve the repository and open PR with `gh`.
+2. Verify local `HEAD` exactly matches the remote PR head SHA.
+3. Accept only non-empty PNG files inside the repository, no larger than 10 MiB.
+4. Upload all selected files through the unsigned preset.
+5. Require Cloudinary HTTPS URLs under the configured cloud name.
+6. Verify every returned URL responds as an image.
+7. Only then update the marked PR-description section or create the diagnostic comment.
+
+Cloudinary uploads are not transactional. If a later upload or GitHub update fails, already uploaded assets may remain unused; report every successfully returned URL so they can be inspected or removed manually.
+
+Use `--dry-run` to validate PR resolution, head SHA, paths, and file selection without uploading or editing GitHub.
+
+## Verification
+
+Run the focused tests after changing this skill:
+
+```bash
+node --test .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.test.mjs
+```

--- a/.agents/skills/publish-pr-screenshots/references/cloudinary-setup.md
+++ b/.agents/skills/publish-pr-screenshots/references/cloudinary-setup.md
@@ -4,12 +4,36 @@ The skill uses unsigned uploads. Only the cloud name and restricted upload prese
 
 ## Local Codex
 
-Configure the variables outside the repository, for example in a private shell profile, `direnv`, or a password-manager-backed environment:
+The recommended repository-local setup is an ignored `.env.local` file:
 
 ```bash
-export CLOUDINARY_CLOUD_NAME='<cloud-name>'
-export CLOUDINARY_UPLOAD_PRESET='<restricted-unsigned-preset>'
+cp .env.local.example .env.local
 ```
+
+Fill in only:
+
+```text
+CLOUDINARY_CLOUD_NAME=<cloud-name>
+CLOUDINARY_UPLOAD_PRESET=<restricted-unsigned-preset>
+```
+
+Then run the publisher with Node's built-in env-file support:
+
+```bash
+node --env-file=.env.local \
+  .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs --help
+```
+
+For commands that should still work when `.env.local` is absent, use:
+
+```bash
+node --env-file-if-exists=.env.local \
+  .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs --help
+```
+
+`.env.local` is ignored by Git. Never put real values in `.env.local.example`.
+
+A shell profile, `direnv`, or a password-manager-backed environment is also valid. Variables already exported by the shell take precedence over values loaded from the env file.
 
 Verify the local GitHub CLI session separately:
 

--- a/.agents/skills/publish-pr-screenshots/references/cloudinary-setup.md
+++ b/.agents/skills/publish-pr-screenshots/references/cloudinary-setup.md
@@ -1,0 +1,62 @@
+# Cloudinary configuration for PR screenshots
+
+The skill uses unsigned uploads. Only the cloud name and restricted upload preset are required during the agent phase.
+
+## Local Codex
+
+Configure the variables outside the repository, for example in a private shell profile, `direnv`, or a password-manager-backed environment:
+
+```bash
+export CLOUDINARY_CLOUD_NAME='<cloud-name>'
+export CLOUDINARY_UPLOAD_PRESET='<restricted-unsigned-preset>'
+```
+
+Verify the local GitHub CLI session separately:
+
+```bash
+gh auth status --hostname github.com
+```
+
+No Cloudinary MCP server is required. The skill deliberately uses the same Node script and HTTP API in local and cloud environments.
+
+## Codex Cloud
+
+Add these as environment variables available to the agent phase:
+
+```text
+CLOUDINARY_CLOUD_NAME
+CLOUDINARY_UPLOAD_PRESET
+```
+
+Do not rely on a setup-only secret for the upload preset, because Codex Cloud removes setup secrets before the agent phase. Keep the preset narrowly restricted in Cloudinary and rotate it if it becomes public or abused.
+
+Enable agent internet access with this minimum allowlist:
+
+```text
+api.cloudinary.com       POST
+res.cloudinary.com       GET, HEAD
+api.github.com           GET, POST, PATCH
+github.com               GET, HEAD
+```
+
+The repository's existing Codex GitHub publication flow may require broader GitHub methods; keep the GitHub policy in `docs/codex-workflow.md` authoritative.
+
+## Cloudinary preset
+
+Configure the unsigned preset in Cloudinary with at least:
+
+- asset folder dedicated to PR screenshots;
+- PNG allowed and unrelated formats rejected;
+- a conservative maximum file size;
+- unique filenames enabled;
+- overwrite disabled;
+- no eager transformations or webhooks required for this workflow.
+
+The following values are not needed by the publishing script:
+
+- Cloudinary API key;
+- Cloudinary API secret;
+- product-environment ID;
+- asset-folder environment variable.
+
+The asset folder is controlled by the preset itself.

--- a/.agents/skills/publish-pr-screenshots/references/cloudinary-setup.md
+++ b/.agents/skills/publish-pr-screenshots/references/cloudinary-setup.md
@@ -54,6 +54,12 @@ CLOUDINARY_UPLOAD_PRESET
 
 Do not rely on a setup-only secret for the upload preset, because Codex Cloud removes setup secrets before the agent phase. Keep the preset narrowly restricted in Cloudinary and rotate it if it becomes public or abused.
 
+Run `bash .codex/cloud/setup.sh` before the agent phase. The setup script installs/selects Node.js 24.15.0 for repository tooling and persists `NODE_USE_ENV_PROXY=1`, which makes Node fetch use the Codex Cloud HTTP(S) proxy. In the agent phase, invoke the publisher through:
+
+```bash
+.agents/skills/publish-pr-screenshots/scripts/codex-cloud-publish-pr-screenshots.sh --help
+```
+
 Enable agent internet access with this minimum allowlist:
 
 ```text

--- a/.agents/skills/publish-pr-screenshots/scripts/codex-cloud-publish-pr-screenshots.sh
+++ b/.agents/skills/publish-pr-screenshots/scripts/codex-cloud-publish-pr-screenshots.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repository-owned Codex Cloud entrypoint for the PR screenshot publisher.
+# The setup script persists Node 24 and proxy-aware fetch configuration here.
+if [[ -f "${HOME}/.sniffy-codex-env" ]]; then
+  # shellcheck disable=SC1090
+  source "${HOME}/.sniffy-codex-env"
+fi
+
+export NODE_USE_ENV_PROXY="${NODE_USE_ENV_PROXY:-1}"
+
+node_version="$(node -p 'process.versions.node')"
+case "${node_version}" in
+  24.*) ;;
+  *)
+    echo "publish-pr-screenshots requires Node.js 24.x in Codex Cloud; found ${node_version}. Run bash .codex/cloud/setup.sh first." >&2
+    exit 1
+    ;;
+esac
+
+exec node --env-file-if-exists=.env.local \
+  .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs \
+  "$@"

--- a/.agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs
+++ b/.agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, extname, isAbsolute, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const SCREENSHOT_SECTION_START = '<!-- sniffy-ui-screenshots:start -->';
+export const SCREENSHOT_SECTION_END = '<!-- sniffy-ui-screenshots:end -->';
+export const BASELINE_DIRECTORY = 'sniffy-ui/tests/e2e/visual-baselines';
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+export function parseArgs(argv) {
+  const options = {
+    mode: 'baselines',
+    files: [],
+    pr: undefined,
+    repo: undefined,
+    heading: undefined,
+    dryRun: false,
+    help: false,
+  };
+  const args = [...argv];
+  if (args[0] && !args[0].startsWith('-')) options.mode = args.shift();
+  if (!['baselines', 'diagnostics'].includes(options.mode)) {
+    throw new Error(`Unknown mode: ${options.mode}`);
+  }
+  while (args.length > 0) {
+    const argument = args.shift();
+    switch (argument) {
+      case '--file': {
+        const value = args.shift();
+        if (!value) throw new Error('--file requires a path');
+        options.files.push(value);
+        break;
+      }
+      case '--pr': {
+        const value = args.shift();
+        if (!value || !/^\d+$/.test(value)) throw new Error('--pr requires a numeric pull request number');
+        options.pr = Number(value);
+        break;
+      }
+      case '--repo': {
+        const value = args.shift();
+        if (!value || !/^[^/\s]+\/[^/\s]+$/.test(value)) {
+          throw new Error('--repo requires owner/name');
+        }
+        options.repo = value;
+        break;
+      }
+      case '--heading': {
+        const value = args.shift();
+        if (!value) throw new Error('--heading requires text');
+        options.heading = value;
+        break;
+      }
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (options.mode === 'diagnostics' && options.files.length === 0 && !options.help) {
+    throw new Error('diagnostics mode requires at least one explicit --file');
+  }
+  return options;
+}
+
+function usage() {
+  return `Usage:
+  publish-pr-screenshots.mjs baselines [--pr NUMBER] [--repo OWNER/NAME] [--file PNG]... [--dry-run]
+  publish-pr-screenshots.mjs diagnostics --file PNG [--file PNG]... [--pr NUMBER] [--repo OWNER/NAME] [--heading TEXT] [--dry-run]
+
+Modes:
+  baselines    Upload reviewed changed PNG baselines and replace the marked PR-description section.
+  diagnostics  Upload explicitly selected failure PNGs and create a PR comment.
+`;
+}
+
+function run(command, args, { cwd, input } = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => (stdout += chunk));
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.on('error', rejectPromise);
+    child.on('close', (code) => {
+      if (code === 0) resolvePromise(stdout.trim());
+      else {
+        rejectPromise(
+          new Error(`${command} ${args.join(' ')} failed with exit code ${code}: ${stderr.trim()}`),
+        );
+      }
+    });
+    if (input !== undefined) child.stdin.end(input);
+    else child.stdin.end();
+  });
+}
+
+export function normalizeRepositoryPath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+export function assertAllowedRepositoryPath(repositoryPath, mode) {
+  const normalized = normalizeRepositoryPath(repositoryPath);
+  if (!normalized || isAbsolute(normalized) || normalized === '..' || normalized.startsWith('../')) {
+    throw new Error(`Screenshot must be inside the repository: ${repositoryPath}`);
+  }
+  if (extname(normalized).toLowerCase() !== '.png') {
+    throw new Error(`Only PNG screenshots are supported: ${repositoryPath}`);
+  }
+  if (mode === 'baselines' && !normalized.startsWith(`${BASELINE_DIRECTORY}/`)) {
+    throw new Error(`Baseline screenshots must be under ${BASELINE_DIRECTORY}: ${repositoryPath}`);
+  }
+  return normalized;
+}
+
+async function inspectScreenshot(repositoryRoot, repositoryPath, mode) {
+  const normalized = assertAllowedRepositoryPath(repositoryPath, mode);
+  const absolute = await realpath(resolve(repositoryRoot, normalized));
+  const inside = relative(repositoryRoot, absolute);
+  if (!inside || inside === '..' || inside.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)) {
+    throw new Error(`Screenshot resolves outside the repository: ${repositoryPath}`);
+  }
+  const metadata = await stat(absolute);
+  if (!metadata.isFile()) throw new Error(`Screenshot is not a file: ${repositoryPath}`);
+  if (metadata.size === 0) throw new Error(`Screenshot is empty: ${repositoryPath}`);
+  if (metadata.size > MAX_IMAGE_BYTES) {
+    throw new Error(`Screenshot exceeds the 10 MiB publishing limit: ${repositoryPath}`);
+  }
+  return { repositoryPath: normalizeRepositoryPath(inside), absolute, size: metadata.size };
+}
+
+function humanizeFilename(path) {
+  return basename(path, extname(path))
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export function buildScreenshotMarkdown({ mode, uploads, repo, sha, heading }) {
+  const shortSha = sha.slice(0, 12);
+  const title = heading ?? (mode === 'baselines' ? 'Reviewed UI screenshots' : 'Browser-test diagnostics');
+  const lines = [
+    mode === 'baselines' ? `## ${title}` : `### ${title}`,
+    '',
+    `Head: [\`${shortSha}\`](https://github.com/${repo}/commit/${sha})`,
+    '',
+  ];
+  for (const upload of uploads) {
+    lines.push(
+      `**${humanizeFilename(upload.repositoryPath)}**`,
+      '',
+      `![${humanizeFilename(upload.repositoryPath)}](${upload.secureUrl})`,
+      '',
+    );
+  }
+  return lines.join('\n').trimEnd();
+}
+
+export function replaceMarkedSection(body, section) {
+  const startCount = body.split(SCREENSHOT_SECTION_START).length - 1;
+  const endCount = body.split(SCREENSHOT_SECTION_END).length - 1;
+  if (startCount !== endCount || startCount > 1) {
+    throw new Error('PR description contains malformed or duplicate screenshot markers');
+  }
+  const marked = `${SCREENSHOT_SECTION_START}\n${section.trim()}\n${SCREENSHOT_SECTION_END}`;
+  if (startCount === 0) return `${body.trimEnd()}\n\n${marked}\n`;
+  const start = body.indexOf(SCREENSHOT_SECTION_START);
+  const end = body.indexOf(SCREENSHOT_SECTION_END, start);
+  if (end < start) throw new Error('PR screenshot end marker precedes the start marker');
+  return `${body.slice(0, start)}${marked}${body.slice(end + SCREENSHOT_SECTION_END.length)}`;
+}
+
+async function resolveRepository(options, repositoryRoot) {
+  if (options.repo) return options.repo;
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
+  return run('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+    cwd: repositoryRoot,
+  });
+}
+
+async function resolvePullRequest(options, repositoryRoot, repo) {
+  const target = options.pr ? String(options.pr) : '';
+  const json = await run(
+    'gh',
+    [
+      'pr',
+      'view',
+      ...(target ? [target] : []),
+      '--repo',
+      repo,
+      '--json',
+      'number,url,state,isDraft,body,headRefName,headRefOid,baseRefName,baseRefOid',
+    ],
+    { cwd: repositoryRoot },
+  );
+  const pullRequest = JSON.parse(json);
+  if (pullRequest.state !== 'OPEN') throw new Error(`Pull request #${pullRequest.number} is not open`);
+  return pullRequest;
+}
+
+async function changedBaselineFiles(repositoryRoot, baseSha, headSha) {
+  const output = await run(
+    'git',
+    ['diff', '--name-only', `${baseSha}...${headSha}`, '--', `${BASELINE_DIRECTORY}/*.png`],
+    { cwd: repositoryRoot },
+  );
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+async function uploadScreenshot(screenshot, cloudName, uploadPreset) {
+  const bytes = await readFile(screenshot.absolute);
+  const form = new FormData();
+  form.set('upload_preset', uploadPreset);
+  form.set('file', new Blob([bytes], { type: 'image/png' }), basename(screenshot.repositoryPath));
+  const endpoint = `https://api.cloudinary.com/v1_1/${encodeURIComponent(cloudName)}/image/upload`;
+  const response = await fetch(endpoint, { method: 'POST', body: form });
+  const payload = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    const detail = payload?.error?.message ?? `HTTP ${response.status}`;
+    throw new Error(`Cloudinary upload failed for ${screenshot.repositoryPath}: ${detail}`);
+  }
+  const secureUrl = payload?.secure_url;
+  if (
+    typeof secureUrl !== 'string' ||
+    !secureUrl.startsWith(`https://res.cloudinary.com/${cloudName}/image/upload/`)
+  ) {
+    throw new Error(`Cloudinary returned an unexpected secure_url for ${screenshot.repositoryPath}`);
+  }
+  return {
+    repositoryPath: screenshot.repositoryPath,
+    secureUrl,
+    assetId: payload.asset_id,
+    publicId: payload.public_id,
+  };
+}
+
+async function verifyPublishedUrl(url) {
+  let response = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+  if (!response.ok) {
+    response = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      headers: { Range: 'bytes=0-0' },
+    });
+  }
+  if (!response.ok) throw new Error(`Published screenshot is not reachable: ${url}`);
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.startsWith('image/')) {
+    throw new Error(`Published screenshot returned unexpected content type ${contentType}: ${url}`);
+  }
+}
+
+async function writeTemporaryMarkdown(markdown, callback) {
+  const directory = await mkdtemp(resolve(tmpdir(), 'sniffy-pr-screenshots-'));
+  const file = resolve(directory, 'body.md');
+  try {
+    await writeFile(file, markdown, 'utf8');
+    return await callback(file);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  const repositoryRoot = await realpath(await run('git', ['rev-parse', '--show-toplevel']));
+  const repo = await resolveRepository(options, repositoryRoot);
+  const pullRequest = await resolvePullRequest(options, repositoryRoot, repo);
+  const localHead = await run('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot });
+  if (localHead !== pullRequest.headRefOid) {
+    throw new Error(
+      `Local HEAD ${localHead} does not match PR #${pullRequest.number} head ${pullRequest.headRefOid}`,
+    );
+  }
+  if (options.mode === 'baselines') {
+    const status = await run('git', ['status', '--porcelain'], { cwd: repositoryRoot });
+    if (status) throw new Error('baselines mode requires a clean working tree');
+  }
+
+  let paths = options.files;
+  if (options.mode === 'baselines' && paths.length === 0) {
+    paths = await changedBaselineFiles(repositoryRoot, pullRequest.baseRefOid, localHead);
+  }
+  if (paths.length === 0) {
+    throw new Error('No screenshots selected; pass --file explicitly or change a reviewed visual baseline');
+  }
+  paths = [...new Set(paths.map(normalizeRepositoryPath))];
+  const screenshots = [];
+  for (const path of paths) screenshots.push(await inspectScreenshot(repositoryRoot, path, options.mode));
+
+  console.log(`PR: ${pullRequest.url}`);
+  console.log(`Head: ${localHead}`);
+  for (const screenshot of screenshots) {
+    console.log(`Selected: ${screenshot.repositoryPath} (${screenshot.size} bytes)`);
+  }
+  if (options.dryRun) {
+    console.log('Dry run complete; no screenshots uploaded and no pull request content changed.');
+    return;
+  }
+
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+  const uploadPreset = process.env.CLOUDINARY_UPLOAD_PRESET;
+  if (!cloudName || !uploadPreset) {
+    throw new Error('CLOUDINARY_CLOUD_NAME and CLOUDINARY_UPLOAD_PRESET are required');
+  }
+
+  const uploads = [];
+  for (const screenshot of screenshots) {
+    const upload = await uploadScreenshot(screenshot, cloudName, uploadPreset);
+    await verifyPublishedUrl(upload.secureUrl);
+    uploads.push(upload);
+    console.log(`Uploaded: ${upload.repositoryPath} -> ${upload.secureUrl}`);
+  }
+  const markdown = buildScreenshotMarkdown({
+    mode: options.mode,
+    uploads,
+    repo,
+    sha: localHead,
+    heading: options.heading,
+  });
+
+  if (options.mode === 'baselines') {
+    const updatedBody = replaceMarkedSection(pullRequest.body ?? '', markdown);
+    await writeTemporaryMarkdown(updatedBody, (file) =>
+      run('gh', ['pr', 'edit', String(pullRequest.number), '--repo', repo, '--body-file', file], {
+        cwd: repositoryRoot,
+      }),
+    );
+    console.log(`Updated screenshot section in ${pullRequest.url}`);
+  } else {
+    await writeTemporaryMarkdown(markdown, (file) =>
+      run('gh', ['pr', 'comment', String(pullRequest.number), '--repo', repo, '--body-file', file], {
+        cwd: repositoryRoot,
+      }),
+    );
+    console.log(`Added diagnostic screenshot comment to ${pullRequest.url}`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/.agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs
+++ b/.agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.mjs
@@ -128,13 +128,15 @@ export function assertAllowedRepositoryPath(repositoryPath, mode) {
   return normalized;
 }
 
-async function inspectScreenshot(repositoryRoot, repositoryPath, mode) {
+export async function inspectScreenshot(repositoryRoot, repositoryPath, mode) {
   const normalized = assertAllowedRepositoryPath(repositoryPath, mode);
   const absolute = await realpath(resolve(repositoryRoot, normalized));
   const inside = relative(repositoryRoot, absolute);
   if (!inside || inside === '..' || inside.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)) {
     throw new Error(`Screenshot resolves outside the repository: ${repositoryPath}`);
   }
+  const canonicalRepositoryPath = normalizeRepositoryPath(inside);
+  assertAllowedRepositoryPath(canonicalRepositoryPath, mode);
   const metadata = await stat(absolute);
   if (!metadata.isFile()) throw new Error(`Screenshot is not a file: ${repositoryPath}`);
   if (metadata.size === 0) throw new Error(`Screenshot is empty: ${repositoryPath}`);

--- a/.agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.test.mjs
+++ b/.agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.test.mjs
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
 import {
   BASELINE_DIRECTORY,
   SCREENSHOT_SECTION_END,
   SCREENSHOT_SECTION_START,
   assertAllowedRepositoryPath,
   buildScreenshotMarkdown,
+  inspectScreenshot,
   normalizeRepositoryPath,
   parseArgs,
   replaceMarkedSection,
@@ -61,6 +65,29 @@ test('restricts baselines to the reviewed baseline directory', () => {
     /inside the repository/,
   );
   assert.throws(() => assertAllowedRepositoryPath('trace.zip', 'diagnostics'), /Only PNG/);
+});
+
+test('rejects baseline files that escape after filesystem resolution', async () => {
+  const repositoryRoot = await mkdtemp(resolve(tmpdir(), 'sniffy-pr-screenshots-test-'));
+  await mkdir(resolve(repositoryRoot, BASELINE_DIRECTORY), { recursive: true });
+  await mkdir(resolve(repositoryRoot, 'sniffy-documentation/src/main/asciidoc/images'), {
+    recursive: true,
+  });
+  const escapedPath =
+    `${BASELINE_DIRECTORY}/../../../../sniffy-documentation/src/main/asciidoc/images/agent-ui.png`;
+  try {
+    await writeFile(
+      resolve(repositoryRoot, 'sniffy-documentation/src/main/asciidoc/images/agent-ui.png'),
+      'png',
+    );
+
+    await assert.rejects(
+      () => inspectScreenshot(repositoryRoot, escapedPath, 'baselines'),
+      /must be under/,
+    );
+  } finally {
+    await rm(repositoryRoot, { recursive: true, force: true });
+  }
 });
 
 test('appends a screenshot section when markers are absent', () => {

--- a/.agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.test.mjs
+++ b/.agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  BASELINE_DIRECTORY,
+  SCREENSHOT_SECTION_END,
+  SCREENSHOT_SECTION_START,
+  assertAllowedRepositoryPath,
+  buildScreenshotMarkdown,
+  normalizeRepositoryPath,
+  parseArgs,
+  replaceMarkedSection,
+} from './publish-pr-screenshots.mjs';
+
+test('parses baseline publishing arguments', () => {
+  assert.deepEqual(
+    parseArgs([
+      'baselines',
+      '--pr',
+      '634',
+      '--repo',
+      'sniffy/sniffy',
+      '--file',
+      'one.png',
+      '--dry-run',
+    ]),
+    {
+      mode: 'baselines',
+      files: ['one.png'],
+      pr: 634,
+      repo: 'sniffy/sniffy',
+      heading: undefined,
+      dryRun: true,
+      help: false,
+    },
+  );
+});
+
+test('requires explicit diagnostic screenshots', () => {
+  assert.throws(() => parseArgs(['diagnostics']), /requires at least one explicit --file/);
+});
+
+test('normalizes Windows repository paths', () => {
+  assert.equal(normalizeRepositoryPath('.\\sniffy-ui\\image.png'), 'sniffy-ui/image.png');
+});
+
+test('restricts baselines to the reviewed baseline directory', () => {
+  assert.equal(
+    assertAllowedRepositoryPath(`${BASELINE_DIRECTORY}/profiler.png`, 'baselines'),
+    `${BASELINE_DIRECTORY}/profiler.png`,
+  );
+  assert.throws(
+    () => assertAllowedRepositoryPath('test-results/failure.png', 'baselines'),
+    /must be under/,
+  );
+  assert.equal(
+    assertAllowedRepositoryPath('test-results/failure.png', 'diagnostics'),
+    'test-results/failure.png',
+  );
+  assert.throws(
+    () => assertAllowedRepositoryPath('../secret.png', 'diagnostics'),
+    /inside the repository/,
+  );
+  assert.throws(() => assertAllowedRepositoryPath('trace.zip', 'diagnostics'), /Only PNG/);
+});
+
+test('appends a screenshot section when markers are absent', () => {
+  const result = replaceMarkedSection('Existing body', '## Screenshots\n\ncontent');
+  assert.match(result, /Existing body/);
+  assert.match(result, new RegExp(SCREENSHOT_SECTION_START));
+  assert.match(result, /## Screenshots/);
+  assert.match(result, new RegExp(SCREENSHOT_SECTION_END));
+});
+
+test('replaces only the marked screenshot section', () => {
+  const body = `Before\n\n${SCREENSHOT_SECTION_START}\nold\n${SCREENSHOT_SECTION_END}\n\nAfter`;
+  const result = replaceMarkedSection(body, 'new');
+  assert.equal(
+    result,
+    `Before\n\n${SCREENSHOT_SECTION_START}\nnew\n${SCREENSHOT_SECTION_END}\n\nAfter`,
+  );
+});
+
+test('rejects malformed marker pairs', () => {
+  assert.throws(
+    () => replaceMarkedSection(`Body\n${SCREENSHOT_SECTION_START}`, 'new'),
+    /malformed/,
+  );
+});
+
+test('builds baseline and diagnostic markdown with immutable head references', () => {
+  const input = {
+    uploads: [
+      {
+        repositoryPath: `${BASELINE_DIRECTORY}/pinned-widget.png`,
+        secureUrl: 'https://res.cloudinary.com/demo/image/upload/example.png',
+      },
+    ],
+    repo: 'sniffy/sniffy',
+    sha: '0123456789abcdef0123456789abcdef01234567',
+  };
+  const baseline = buildScreenshotMarkdown({ mode: 'baselines', ...input });
+  assert.match(baseline, /^## Reviewed UI screenshots/);
+  assert.match(baseline, /Pinned Widget/);
+  assert.match(baseline, /0123456789ab/);
+  const diagnostic = buildScreenshotMarkdown({
+    mode: 'diagnostics',
+    heading: 'WebKit failure',
+    ...input,
+  });
+  assert.match(diagnostic, /^### WebKit failure/);
+});

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -11,6 +11,7 @@ JDKS_DIR="${HOME}/.jdks"
 JDK8_HOME="${JDKS_DIR}/temurin-8"
 ENV_FILE="${HOME}/.sniffy-codex-env"
 GH_VERSION="2.96.0"
+NODE_VERSION="24.15.0"
 GH_BIN_DIR="${HOME}/.local/bin"
 GH_INSTALL_DIR="${HOME}/.local/share/gh/${GH_VERSION}"
 
@@ -118,6 +119,15 @@ configure_github_auth
 
 mkdir -p "${JDKS_DIR}" "${HOME}/.m2"
 
+install_node24() {
+  if ! mise where "node@${NODE_VERSION}" >/dev/null 2>&1; then
+    echo "Installing Node.js ${NODE_VERSION} for Sniffy frontend and Codex Cloud tooling..."
+    mise install "node@${NODE_VERSION}"
+  else
+    echo "Node.js ${NODE_VERSION} already installed."
+  fi
+}
+
 install_jdk8() {
   if [[ -x "${JDK8_HOME}/bin/java" ]]; then
     echo "Temurin JDK 8 already installed."
@@ -158,7 +168,10 @@ builtin_jdk_home() {
   printf '%s\n' "${home}"
 }
 
+install_node24
 install_jdk8
+
+NODE24_HOME="$(mise where "node@${NODE_VERSION}")"
 
 JDK11_HOME="$(builtin_jdk_home 11)"
 JDK17_HOME="$(builtin_jdk_home 17)"
@@ -172,7 +185,8 @@ export SNIFFY_JDK17_HOME="${JDK17_HOME}"
 export SNIFFY_JDK21_HOME="${JDK21_HOME}"
 export SNIFFY_JDK25_HOME="${JDK25_HOME}"
 export JAVA_HOME="${JDK25_HOME}"
-export PATH="${JDK25_HOME}/bin:${GH_BIN_DIR}:\${PATH}"
+export PATH="${NODE24_HOME}/bin:${JDK25_HOME}/bin:${GH_BIN_DIR}:\${PATH}"
+export NODE_USE_ENV_PROXY="1"
 EOF_ENV
 
 for shell_file in "${HOME}/.bashrc" "${HOME}/.profile"; do
@@ -203,6 +217,7 @@ EOF_TOOLCHAINS
 printf 'Using Codex-provided Maven: %s\n' "$(command -v mvn)"
 java -version
 mvn -version
+node -v
 
 bash .codex/cloud/warm-maven-cache.sh
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+# Copy this file to .env.local and fill in the values from the Cloudinary console.
+# .env.local is ignored by Git.
+CLOUDINARY_CLOUD_NAME=your-cloud-name
+CLOUDINARY_UPLOAD_PRESET=your-restricted-unsigned-preset

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
 
+.env.local
+
 target
 
 *.iml


### PR DESCRIPTION
## Problem

UI pull requests need screenshots visible directly in the PR, but Codex local and Cloud cannot rely on GitHub's undocumented browser attachment flow. Downloadable Actions artifacts are useful, but they are a poor primary review surface.

## Design

This adds a repo-local `publish-pr-screenshots` skill with one deterministic Node script shared by local Codex and Codex Cloud. No Cloudinary MCP server is required.

The script supports two explicit modes:

- `baselines`: uploads reviewed changed PNG baselines from `sniffy-ui/tests/e2e/visual-baselines/` and replaces only a marked section in the PR description;
- `diagnostics`: uploads explicitly selected Playwright expected/actual/diff/failure PNGs and creates a PR comment.

Before changing GitHub it verifies the open PR, exact local/remote head SHA match, repository-contained PNG paths, a 10 MiB size limit, Cloudinary HTTPS URLs, and CDN reachability. Traces, HAR files, HTML reports, archives, logs, credentials, and arbitrary directories are deliberately outside this PNG-only workflow.

## Cloudinary and Codex configuration

Required in both local Codex and the Codex Cloud **agent phase**:

```text
CLOUDINARY_CLOUD_NAME
CLOUDINARY_UPLOAD_PRESET
```

The actual values are intentionally not committed. The configured unsigned preset owns the `sniffy/pr-screenshots` asset folder, PNG restrictions, unique naming, size limit, and overwrite policy.

Not required by this workflow:

```text
CLOUDINARY_API_KEY
CLOUDINARY_API_SECRET
Cloudinary product-environment ID
separate asset-folder variable
```

Minimum Codex Cloud agent-internet allowlist:

| Domain | Methods | Purpose |
| --- | --- | --- |
| `api.cloudinary.com` | `POST` | unsigned PNG upload |
| `res.cloudinary.com` | `GET`, `HEAD` | verify returned CDN URLs |
| `api.github.com` | `GET`, `POST`, `PATCH` | resolve/edit/comment on the PR through `gh` |
| `github.com` | `GET`, `HEAD` | repository and commit links |

The existing GitHub publication setup and `GH_TOKEN` persistence remain governed by `docs/codex-workflow.md`.

## Usage

```bash
.agents/skills/publish-pr-screenshots/scripts/codex-cloud-publish-pr-screenshots.sh \
  baselines --repo sniffy/sniffy --pr <number>

.agents/skills/publish-pr-screenshots/scripts/codex-cloud-publish-pr-screenshots.sh \
  diagnostics --repo sniffy/sniffy --pr <number> \
  --heading "WebKit failure" \
  --file path/to/expected.png \
  --file path/to/actual.png \
  --file path/to/diff.png
```

`--dry-run` validates PR resolution, SHA matching, and file selection without uploads or GitHub writes.

## Verification

```text
node --test .agents/skills/publish-pr-screenshots/scripts/publish-pr-screenshots.test.mjs
PASS: 9/9
```

The focused tests cover argument parsing, explicit diagnostic selection, Windows-path normalization, baseline path restrictions, canonical filesystem escape rejection, traversal/non-PNG rejection, marker append/replace/malformed handling, and generated Markdown.

Live Codex Cloud publication has been exercised through the repository-owned wrapper after setup selected Node 24.15.0 and enabled `NODE_USE_ENV_PROXY=1`. The focused flow successfully uploaded a diagnostic screenshot, verified the returned Cloudinary CDN URL, and replaced the marked baseline screenshot section in this PR description.

## Compatibility and dependencies

- Node built-ins only; no new npm dependency.
- Requires Node 24 as used by the Sniffy frontend/Codex environment.
- No production Java, Maven, frontend bundle, or CI behavior changes.
- Cloudinary uploads are non-transactional; successfully uploaded images can remain unused if a later upload or GitHub edit fails, and the script prints every returned URL.

Published head: `def19ce894745d659609b645662ce96c6bb53914`

This PR is ready for review per GitHub metadata. It does not enable auto-merge or merge.

<!-- sniffy-ui-screenshots:start -->
## Reviewed UI screenshots

Head: [`def19ce89474`](https://github.com/sniffy/sniffy/commit/def19ce894745d659609b645662ce96c6bb53914)

**Pinned Widget**

![Pinned Widget](https://res.cloudinary.com/tuz039hw/image/upload/v1784386114/dhhkj9pngc8urlrr778z.png)
<!-- sniffy-ui-screenshots:end -->
