### PR TITLE
Add tagged source snippet inclusion for MDX documentation

### DIFF
--- a/sniffy-ui/apps/site/docs/index.mdx
+++ b/sniffy-ui/apps/site/docs/index.mdx
@@ -5,4 +5,6 @@ title: Sniffy documentation
 
 This minimal route reserves the home of the current stable documentation.
 
+[See a tagged source snippet from the repository](./source-snippets/).
+
 [Return to the website home page](/).

--- a/sniffy-ui/apps/site/docs/source-snippets.mdx
+++ b/sniffy-ui/apps/site/docs/source-snippets.mdx
@@ -1,0 +1,29 @@
+---
+title: Tagged source snippets
+---
+
+Use the build-time `SourceSnippet` element to keep examples linked to tested repository sources:
+
+```mdx
+<SourceSnippet
+  file="sniffy-core/src/test/java/io/sniffy/CoreApiExampleTest.java"
+  region="testVerifyApi"
+  language="java"
+/>
+```
+
+The file path is relative to the repository root. The region matches an AsciiDoc-style
+`tag::name[]` / `end::name[]` pair, and the language is passed to the generated syntax-highlighted
+listing.
+
+<SourceSnippet
+  file="sniffy-core/src/test/java/io/sniffy/CoreApiExampleTest.java"
+  region="testVerifyApi"
+  language="java"
+/>
+
+Snippet extraction normalizes line endings, removes blank boundary lines, and strips the smallest
+shared indentation from non-blank lines. The site build fails with the source and region in the
+error when a path escapes the repository, a file or tag is missing, or tag markers are duplicate,
+ambiguous, or malformed. Source files are read only while the site is built; the generated site
+does not fetch source code at runtime.

--- a/sniffy-ui/apps/site/docusaurus.config.ts
+++ b/sniffy-ui/apps/site/docusaurus.config.ts
@@ -1,5 +1,11 @@
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import sourceSnippetRemarkPlugin from './src/source-snippets';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
 const config: Config = {
   title: 'Sniffy',
@@ -19,6 +25,7 @@ const config: Config = {
           routeBasePath: 'docs',
           sidebarPath: false,
           lastVersion: 'current',
+          remarkPlugins: [[sourceSnippetRemarkPlugin, { repositoryRoot }]],
           versions: {
             current: {
               label: 'Current',

--- a/sniffy-ui/apps/site/src/site.test.ts
+++ b/sniffy-ui/apps/site/src/site.test.ts
@@ -42,7 +42,7 @@ describe('@sniffy/site workspace contract', () => {
       'build:site': 'npm run build --workspace @sniffy/site',
       'dev:site': 'npm run start --workspace @sniffy/site',
       'test:site':
-        'npm run build:site && vitest run --project unit apps/site/src/site.test.ts && npm test --workspace @sniffy/site',
+        'npm run build:site && vitest run --project unit apps/site/src/site.test.ts apps/site/src/source-snippets.test.ts && npm test --workspace @sniffy/site',
     });
     expect(sitePackageJson.scripts).toMatchObject({
       start: 'docusaurus start',

--- a/sniffy-ui/apps/site/src/source-snippets.test.ts
+++ b/sniffy-ui/apps/site/src/source-snippets.test.ts
@@ -1,0 +1,226 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import sourceSnippetRemarkPlugin, { dedentSnippet, extractSourceSnippet } from './source-snippets';
+
+const temporaryDirectories: string[] = [];
+
+function temporaryRepository(): string {
+  const repository = mkdtempSync(join(tmpdir(), 'sniffy-source-snippets-'));
+  temporaryDirectories.push(repository);
+  return repository;
+}
+
+function writeSource(repository: string, file: string, source: string): void {
+  const target = join(repository, file);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, source);
+}
+
+function errorPrefix(file: string, region: string): string {
+  return `Source snippet "${file}" region "${region}":`;
+}
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+});
+
+describe('extractSourceSnippet', () => {
+  it('extracts an AsciiDoc-tagged region and dedents it predictably', () => {
+    const repositoryRoot = temporaryRepository();
+    writeSource(
+      repositoryRoot,
+      'Example.java',
+      [
+        'class Example {',
+        '    // tag::example[]',
+        '        first();',
+        '',
+        '          second();',
+        '    // end::example[]',
+        '}',
+      ].join('\r\n'),
+    );
+
+    expect(
+      extractSourceSnippet({
+        repositoryRoot,
+        file: 'Example.java',
+        region: 'example',
+      }),
+    ).toBe(['first();', '', '  second();'].join('\n'));
+  });
+
+  it('supports properly nested regions while omitting their marker lines', () => {
+    const repositoryRoot = temporaryRepository();
+    writeSource(
+      repositoryRoot,
+      'Nested.java',
+      [
+        '// tag::outer[]',
+        '  before();',
+        '  // tag::inner[]',
+        '    inside();',
+        '  // end::inner[]',
+        '  after();',
+        '// end::outer[]',
+      ].join('\n'),
+    );
+
+    expect(
+      extractSourceSnippet({
+        repositoryRoot,
+        file: 'Nested.java',
+        region: 'outer',
+      }),
+    ).toBe(['before();', '  inside();', 'after();'].join('\n'));
+  });
+
+  it.each([
+    {
+      name: 'duplicate tags',
+      source: ['// tag::sample[]', '// end::sample[]', '// tag::sample[]'].join('\n'),
+      message: 'duplicate tag "sample"',
+    },
+    {
+      name: 'mismatched nesting',
+      source: ['// tag::outer[]', '// tag::inner[]', '// end::outer[]'].join('\n'),
+      message: 'malformed nesting',
+    },
+    {
+      name: 'unclosed tags',
+      source: '// tag::sample[]\nvalue();',
+      message: 'tag "sample" opened at line 1 is not closed',
+    },
+    {
+      name: 'unexpected end tags',
+      source: '// end::sample[]',
+      message: 'unexpected end tag "sample"',
+    },
+    {
+      name: 'malformed markers',
+      source: '// tag::sample[\nvalue();',
+      message: 'malformed tag marker',
+    },
+  ])('rejects $name with source, region, and line context', ({ source, message }) => {
+    const repositoryRoot = temporaryRepository();
+    writeSource(repositoryRoot, 'Broken.java', source);
+
+    expect(() =>
+      extractSourceSnippet({
+        repositoryRoot,
+        file: 'Broken.java',
+        region: 'sample',
+      }),
+    ).toThrow(expect.objectContaining({ message: expect.stringContaining(message) }));
+    expect(() =>
+      extractSourceSnippet({
+        repositoryRoot,
+        file: 'Broken.java',
+        region: 'sample',
+      }),
+    ).toThrow(errorPrefix('Broken.java', 'sample'));
+  });
+
+  it('reports missing files and missing regions precisely', () => {
+    const repositoryRoot = temporaryRepository();
+    writeSource(repositoryRoot, 'Example.java', '// tag::present[]\nvalue();\n// end::present[]');
+
+    expect(() =>
+      extractSourceSnippet({ repositoryRoot, file: 'Missing.java', region: 'sample' }),
+    ).toThrow(`${errorPrefix('Missing.java', 'sample')} source file does not exist`);
+    expect(() =>
+      extractSourceSnippet({ repositoryRoot, file: 'Example.java', region: 'missing' }),
+    ).toThrow(`${errorPrefix('Example.java', 'missing')} tag "missing" was not found`);
+  });
+
+  it('rejects lexical and symlink traversal outside the repository', () => {
+    const container = temporaryRepository();
+    const repositoryRoot = join(container, 'repository');
+    const outside = join(container, 'outside');
+    mkdirSync(repositoryRoot);
+    mkdirSync(outside);
+    writeSource(outside, 'Secret.java', '// tag::secret[]\nsecret();\n// end::secret[]');
+    symlinkSync(
+      outside,
+      join(repositoryRoot, 'linked'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+
+    expect(() =>
+      extractSourceSnippet({
+        repositoryRoot,
+        file: '../outside/Secret.java',
+        region: 'secret',
+      }),
+    ).toThrow(`${errorPrefix('../outside/Secret.java', 'secret')} path escapes`);
+    expect(() =>
+      extractSourceSnippet({
+        repositoryRoot,
+        file: 'linked/Secret.java',
+        region: 'secret',
+      }),
+    ).toThrow(`${errorPrefix('linked/Secret.java', 'secret')} resolved path escapes`);
+  });
+});
+
+describe('sourceSnippetRemarkPlugin', () => {
+  it('turns the MDX component into a syntax-highlighted code node', () => {
+    const repositoryRoot = temporaryRepository();
+    writeSource(repositoryRoot, 'Example.java', '// tag::sample[]\n  value();\n// end::sample[]');
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'SourceSnippet',
+          attributes: [
+            { type: 'mdxJsxAttribute', name: 'file', value: 'Example.java' },
+            { type: 'mdxJsxAttribute', name: 'region', value: 'sample' },
+            { type: 'mdxJsxAttribute', name: 'language', value: 'java' },
+          ],
+          children: [],
+        },
+      ],
+    };
+
+    sourceSnippetRemarkPlugin({ repositoryRoot })(tree);
+
+    expect(tree.children[0]).toEqual({
+      type: 'code',
+      lang: 'java',
+      value: 'value();',
+    });
+  });
+
+  it('requires static file, region, and language attributes', () => {
+    const repositoryRoot = temporaryRepository();
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'SourceSnippet',
+          attributes: [
+            { type: 'mdxJsxAttribute', name: 'file', value: 'Example.java' },
+            { type: 'mdxJsxAttribute', name: 'region', value: 'sample' },
+          ],
+          children: [],
+        },
+      ],
+    };
+
+    expect(() => sourceSnippetRemarkPlugin({ repositoryRoot })(tree)).toThrow(
+      `${errorPrefix('Example.java', 'sample')} SourceSnippet requires one static non-empty "language" attribute`,
+    );
+  });
+});
+
+describe('dedentSnippet', () => {
+  it('trims blank boundaries while preserving internal blank lines', () => {
+    expect(dedentSnippet('\n\talpha();\n\n\tbeta();\n')).toBe('alpha();\n\nbeta();');
+  });
+});

--- a/sniffy-ui/apps/site/src/source-snippets.ts
+++ b/sniffy-ui/apps/site/src/source-snippets.ts
@@ -1,0 +1,249 @@
+import { readFileSync, realpathSync } from 'node:fs';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+
+const componentName = 'SourceSnippet';
+const validMarker = /\b(tag|end)::([A-Za-z0-9][A-Za-z0-9_.-]*)\[\]/g;
+const markerPrefix = /\b(?:tag|end)::/g;
+const hasMarkerPrefix = /\b(?:tag|end)::/;
+
+export interface SourceSnippetOptions {
+  repositoryRoot: string;
+}
+
+export interface SourceSnippetRequest extends SourceSnippetOptions {
+  file: string;
+  region: string;
+}
+
+interface Region {
+  end: number;
+  start: number;
+}
+
+interface OpenRegion {
+  line: number;
+  name: string;
+}
+
+interface MdxAttribute {
+  name?: string;
+  type: string;
+  value?: unknown;
+}
+
+interface SyntaxNode {
+  attributes?: MdxAttribute[];
+  children?: SyntaxNode[];
+  lang?: string;
+  name?: string;
+  type: string;
+  value?: string;
+}
+
+function snippetError(file: string, region: string, detail: string): Error {
+  return new Error(`Source snippet "${file}" region "${region}": ${detail}`);
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === '' ||
+    (!isAbsolute(pathFromRoot) && pathFromRoot !== '..' && !pathFromRoot.startsWith(`..${sep}`))
+  );
+}
+
+export function dedentSnippet(source: string): string {
+  const lines = source.replace(/\r\n?/g, '\n').split('\n');
+
+  while (lines.length > 0 && lines[0].trim() === '') {
+    lines.shift();
+  }
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+
+  const nonBlankLines = lines.filter((line) => line.trim() !== '');
+  if (nonBlankLines.length === 0) {
+    return '';
+  }
+
+  const indentation = Math.min(...nonBlankLines.map((line) => line.match(/^[\t ]*/)![0].length));
+
+  return lines.map((line) => (line.trim() === '' ? '' : line.slice(indentation))).join('\n');
+}
+
+function parseRegions(
+  source: string,
+  file: string,
+  requestedRegion: string,
+): { lines: string[]; regions: Map<string, Region> } {
+  const lines = source.replace(/\r\n?/g, '\n').split('\n');
+  const regions = new Map<string, Region>();
+  const openedNames = new Map<string, number>();
+  const stack: OpenRegion[] = [];
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+    const prefixes = [...line.matchAll(markerPrefix)];
+    const markers = [...line.matchAll(validMarker)];
+
+    if (prefixes.length === 0) {
+      return;
+    }
+    if (prefixes.length !== 1 || markers.length !== 1) {
+      throw snippetError(
+        file,
+        requestedRegion,
+        `malformed tag marker at line ${lineNumber}; expected exactly one tag::name[] or end::name[] marker`,
+      );
+    }
+
+    const [, kind, name] = markers[0];
+    if (kind === 'tag') {
+      const previousLine = openedNames.get(name);
+      if (previousLine !== undefined) {
+        throw snippetError(
+          file,
+          requestedRegion,
+          `duplicate tag "${name}" at line ${lineNumber}; first defined at line ${previousLine}`,
+        );
+      }
+      openedNames.set(name, lineNumber);
+      stack.push({ line: index, name });
+      return;
+    }
+
+    const current = stack.at(-1);
+    if (current === undefined) {
+      throw snippetError(
+        file,
+        requestedRegion,
+        `unexpected end tag "${name}" at line ${lineNumber}`,
+      );
+    }
+    if (current.name !== name) {
+      throw snippetError(
+        file,
+        requestedRegion,
+        `malformed nesting at line ${lineNumber}; expected end::${current.name}[] before end::${name}[]`,
+      );
+    }
+
+    stack.pop();
+    regions.set(name, { start: current.line + 1, end: index });
+  });
+
+  const unclosed = stack.at(-1);
+  if (unclosed !== undefined) {
+    throw snippetError(
+      file,
+      requestedRegion,
+      `tag "${unclosed.name}" opened at line ${unclosed.line + 1} is not closed`,
+    );
+  }
+
+  return { lines, regions };
+}
+
+export function extractSourceSnippet(request: SourceSnippetRequest): string {
+  const { file, region } = request;
+  let repositoryRoot: string;
+
+  try {
+    repositoryRoot = realpathSync(request.repositoryRoot);
+  } catch {
+    throw snippetError(file, region, `repository root "${request.repositoryRoot}" is unavailable`);
+  }
+
+  if (file.trim() === '' || isAbsolute(file)) {
+    throw snippetError(file, region, 'source must be a non-empty repository-relative path');
+  }
+
+  const candidate = resolve(repositoryRoot, file);
+  if (!isInside(repositoryRoot, candidate)) {
+    throw snippetError(file, region, 'path escapes the repository root');
+  }
+
+  let sourcePath: string;
+  try {
+    sourcePath = realpathSync(candidate);
+  } catch {
+    throw snippetError(file, region, 'source file does not exist or cannot be resolved');
+  }
+  if (!isInside(repositoryRoot, sourcePath)) {
+    throw snippetError(file, region, 'resolved path escapes the repository root');
+  }
+
+  let source: string;
+  try {
+    source = readFileSync(sourcePath, 'utf8');
+  } catch {
+    throw snippetError(file, region, 'source file cannot be read');
+  }
+
+  const { lines, regions } = parseRegions(source, file, region);
+  const selected = regions.get(region);
+  if (selected === undefined) {
+    throw snippetError(file, region, `tag "${region}" was not found`);
+  }
+
+  const content = lines
+    .slice(selected.start, selected.end)
+    .filter((line) => !hasMarkerPrefix.test(line))
+    .join('\n');
+  return dedentSnippet(content);
+}
+
+function staticAttribute(node: SyntaxNode, name: string, file: string, region: string): string {
+  const matching = (node.attributes ?? []).filter(
+    (attribute) => attribute.type === 'mdxJsxAttribute' && attribute.name === name,
+  );
+  if (matching.length !== 1 || typeof matching[0].value !== 'string' || matching[0].value === '') {
+    throw snippetError(
+      file,
+      region,
+      `${componentName} requires one static non-empty "${name}" attribute`,
+    );
+  }
+  return matching[0].value;
+}
+
+function transformNode(node: SyntaxNode, options: SourceSnippetOptions): void {
+  if (node.type === 'mdxJsxFlowElement' && node.name === componentName) {
+    const provisionalFile =
+      typeof node.attributes?.find((attribute) => attribute.name === 'file')?.value === 'string'
+        ? String(node.attributes?.find((attribute) => attribute.name === 'file')?.value)
+        : '<missing>';
+    const provisionalRegion =
+      typeof node.attributes?.find((attribute) => attribute.name === 'region')?.value === 'string'
+        ? String(node.attributes?.find((attribute) => attribute.name === 'region')?.value)
+        : '<missing>';
+    const file = staticAttribute(node, 'file', provisionalFile, provisionalRegion);
+    const region = staticAttribute(node, 'region', file, provisionalRegion);
+    const language = staticAttribute(node, 'language', file, region);
+
+    if ((node.children ?? []).length > 0) {
+      throw snippetError(file, region, `${componentName} must be self-closing`);
+    }
+
+    node.type = 'code';
+    node.lang = language;
+    node.value = extractSourceSnippet({ ...options, file, region });
+    delete node.attributes;
+    delete node.children;
+    delete node.name;
+    return;
+  }
+
+  node.children?.forEach((child) => transformNode(child, options));
+}
+
+export default function sourceSnippetRemarkPlugin(options: SourceSnippetOptions) {
+  if (typeof options?.repositoryRoot !== 'string' || options.repositoryRoot === '') {
+    throw new Error('Source snippet plugin requires a repositoryRoot option');
+  }
+
+  return (tree: SyntaxNode): void => {
+    transformNode(tree, options);
+  };
+}

--- a/sniffy-ui/apps/site/tests/routes.spec.ts
+++ b/sniffy-ui/apps/site/tests/routes.spec.ts
@@ -20,6 +20,16 @@ test('the minimal current documentation renders at /docs/', async ({ page }) => 
   await expect(page.getByRole('heading', { level: 1, name: 'Sniffy documentation' })).toBeVisible();
 });
 
+test('a tagged Java region renders as a syntax-highlighted listing', async ({ page }) => {
+  const response = await page.goto('/docs/source-snippets/');
+
+  expect(response?.status()).toBe(200);
+  const snippet = page.locator('.prism-code.language-java').filter({ hasText: 'Sniffy.spy()' });
+  await expect(snippet).toBeVisible();
+  await expect(snippet).toContainText('SqlQueries.atMostOneQuery()');
+  await expect(snippet).not.toContainText('tag::testVerifyApi');
+});
+
 for (const route of ['/blog/', '/docs/next/', '/docs/3.1/']) {
   test(`${route} remains reserved and disabled`, async ({ page }) => {
     const response = await page.goto(route);

--- a/sniffy-ui/package.json
+++ b/sniffy-ui/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint . && prettier --check .",
     "typecheck": "tsc -b",
     "test": "vitest run",
-    "test:site": "npm run build:site && vitest run --project unit apps/site/src/site.test.ts && npm test --workspace @sniffy/site",
+    "test:site": "npm run build:site && vitest run --project unit apps/site/src/site.test.ts apps/site/src/source-snippets.test.ts && npm test --workspace @sniffy/site",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:update": "playwright test --project=chromium-visual --update-snapshots",


### PR DESCRIPTION
Closes #660.

## Problem

The MDX documentation site needs to embed authoritative examples from tagged repository sources without copying code or fetching it at runtime.

Published head SHA: `1b1f834e9f1f793fb854e3ef8ad2e6774abc90b0`

## Design

- Adds a build-time remark transform for `<SourceSnippet file="…" region="…" language="…" />`.
- Resolves lexical and real paths against the repository root, rejecting absolute paths, traversal, and symlink escapes.
- Parses AsciiDoc-style `tag::name[]` / `end::name[]` markers with strict duplicate, malformed-marker, and nesting validation.
- Normalizes line endings, trims blank boundaries, dedents by the smallest shared indentation, and emits a normal MDX code node for Docusaurus/Prism highlighting.
- Adds a focused documentation page backed by the existing tested `CoreApiExampleTest.java` region and links it from `/docs/`.
- Keeps the pipeline build-time only and changes no profiler/agent generated resources.

## Compatibility and scope

No dependencies, Java APIs, runtime code, remote fetching, bulk documentation migration, or deployment behavior changed. Existing AsciiDoc tags remain valid inputs. The site test command now includes the focused extraction suite.

## Verification

Run from `sniffy-ui` with Node 24.18.0 / npm 11.16.0:

- `npm ci` — passed; 1,664 packages installed, 18 moderate findings.
- `npx vitest run --project unit apps/site/src/source-snippets.test.ts` — passed, 12/12.
- `npm run test:site` — passed: production site build, 18/18 unit/contract tests, 6/6 Chromium route tests.
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `npm run test` — passed, 71/71.
- `npm run storybook:build` — passed.
- `npm run build` — passed.
- `npm run check:generated` — passed; all 7 generated resources reproduced exactly.
- `npm run check:bundle` — passed.
- `npm audit --audit-level=high` — passed (exit 0); 18 moderate Docusaurus development-chain findings remain with no compatible fix.
- `npx playwright test --project=chromium --project=firefox --project=webkit` — passed, 60/60.
- `git diff --check` — passed.

The Chromium visual project retains the existing WSL-only profiler mismatch: baseline 328x50 versus actual 329x50. The exact visual test was run against base `13fb4e904d9e6bd8f96ebceaa12eb6cb98d1604b` and head `1b1f834e9f1f793fb854e3ef8ad2e6774abc90b0`; both actual PNGs share SHA-256 `e893f54ffde0536263316634987c4799c3e14ec9a862ff2c611ec170bfda8e13`, and both diff PNGs share `7311a222c31df8d2f6f3150e9adeeba842b8ef8774a3a7d8c9b28e141b39da23`. No baseline changed.

## Visual evidence

Review-only base/head captures were generated for `/docs/` and `/docs/source-snippets/` at 1440x900 and 390x844 in Chromium dark mode. They are not committed. Binary attachment upload is not available through the authenticated GitHub API used to create this PR; the captures will be added in a PR comment if the logged-in browser upload path is available.

## Remaining risk

The parser intentionally rejects duplicate region names and improperly nested markers anywhere in a referenced file so ambiguous source cannot silently build. CI remains authoritative for the supported visual baseline environment.