### PR TITLE
Document mandatory Codex supervision cycle

### DIFF
--- a/docs/codex-supervision-policy.md
+++ b/docs/codex-supervision-policy.md
@@ -1,0 +1,30 @@
+# Codex supervision policy
+
+This document defines the mandatory maintainer workflow for work delegated to Codex Cloud, the local Codex worker, or another implementation agent.
+
+## Dispatch and monitoring
+
+Every time an agent receives a new task, retry, continuation request, or Request Changes follow-up, the supervising ChatGPT workflow must immediately schedule:
+
+1. a first check after 15 minutes;
+2. a second check 15 minutes later;
+3. hourly monitoring after that while the task remains incomplete.
+
+The first check must never be delayed until the hourly monitor. Returning an existing pull request to the agent counts as a new supervision cycle and requires fresh 15-minute checks even if an earlier monitor was stopped after approval.
+
+Each check should verify that the intended agent claimed the task, continues on the expected branch and pull request, and has not silently stalled or opened a duplicate pull request.
+
+## Completion review
+
+After the agent reports completion, the supervisor must independently inspect:
+
+- the complete diff at the exact head commit;
+- unresolved review comments and conversations;
+- the relevant functional behavior, including local or artifact verification when applicable;
+- all required CI checks for that exact commit.
+
+Approve only when the implementation, review comments, and CI are all satisfactory. Otherwise, leave precise Request Changes and explicitly return the task to the agent in the same branch and pull request when possible. Starting that follow-up work requires a new 15-minute, 15-minute, then hourly supervision cycle.
+
+## Merge boundary
+
+Agents and the supervising ChatGPT workflow must never merge or enable auto-merge without an explicit maintainer instruction.


### PR DESCRIPTION
Documents the required supervision workflow for Codex Cloud, local Codex, and other implementation agents.

## Agreed so far

- Every new task, retry, continuation, or Request Changes follow-up starts a fresh supervision cycle: first check after 15 minutes, second check 15 minutes later, then hourly monitoring while incomplete.
- Completion review must independently inspect the exact-head diff, unresolved review comments, relevant functional behavior, and all required CI.
- No merge or auto-merge without explicit maintainer instruction.
- GitHub assignee is a technical identity, not the source of truth for the actual executor. The same account may be reused by local Codex, local Claude, or another worker.
- The GitHub Project `Executor` field is the source of truth for the actual executor.
- Workflow status describes delivery stage; a separate execution-request field may later represent start/continue/retry without overloading status.
- Existing `agent:local` / `agent:cloud` labels remain for now as transitional operational metadata. Do not remove them yet, but do not infer or override `Executor` from them.
- Any eventual removal or redesign of these labels should be handled explicitly after the Project field model and dispatchers are finalized.

This PR intentionally records the current process discussion so we can return to it and finish the workflow design later.