### PR TITLE
Clarify executor identity and transitional agent labels

### DIFF
--- a/docs/codex-supervision-policy.md
+++ b/docs/codex-supervision-policy.md
@@ -2,6 +2,17 @@
 
 This document defines the mandatory maintainer workflow for work delegated to Codex Cloud, the local Codex worker, or another implementation agent.
 
+## Execution identity and source of truth
+
+GitHub assignment, labels, and project fields serve different purposes and must not be treated as interchangeable.
+
+- The GitHub assignee is a technical identity used by an agent to interact with issues and pull requests. It is not the source of truth for the implementation runtime or agent product. The same GitHub account may be reused by local Codex, local Claude, or another local worker.
+- The GitHub Project `Executor` field is the source of truth for which executor is expected to perform the work, such as Local Codex, Codex Cloud, local Claude, or another explicitly named agent.
+- Workflow status describes the delivery stage of the issue. A separate execution-request field may later distinguish start, continue, and retry requests without overloading status.
+- Agent labels such as `agent:local` and `agent:cloud` are currently retained as transitional operational metadata. They may help filtering or compatibility with existing dispatch scripts, but they must not override or be used to infer the Project `Executor` value.
+
+Do not remove or redesign the current agent labels as part of unrelated work. Their eventual retirement or replacement should be handled as an explicit workflow change after the Project field model and dispatchers are finalized.
+
 ## Dispatch and monitoring
 
 Every time an agent receives a new task, retry, continuation request, or Request Changes follow-up, the supervising ChatGPT workflow must immediately schedule:
@@ -12,7 +23,7 @@ Every time an agent receives a new task, retry, continuation request, or Request
 
 The first check must never be delayed until the hourly monitor. Returning an existing pull request to the agent counts as a new supervision cycle and requires fresh 15-minute checks even if an earlier monitor was stopped after approval.
 
-Each check should verify that the intended agent claimed the task, continues on the expected branch and pull request, and has not silently stalled or opened a duplicate pull request.
+Each check should verify that the intended executor claimed the task, continues on the expected branch and pull request, and has not silently stalled or opened a duplicate pull request. Executor verification must use the GitHub Project `Executor` field rather than inferring the executor from assignee or labels.
 
 ## Completion review
 


### PR DESCRIPTION
Follow-up to #698.

## Agreed so far

- GitHub assignee is a technical identity, not the source of truth for the actual executor. The same account may be reused by local Codex, local Claude, or another worker.
- The GitHub Project `Executor` field is the source of truth for the actual executor.
- Workflow status describes delivery stage; a separate execution-request field may later represent start/continue/retry without overloading status.
- Existing `agent:local` / `agent:cloud` labels remain for now as transitional operational metadata. Do not remove them yet, but do not infer or override `Executor` from them.
- Any eventual removal or redesign of these labels should be handled explicitly after the Project field model and dispatchers are finalized.

The markdown also updates supervision checks to verify the executor from the Project field rather than inferring it from assignee or labels.

This PR intentionally records the current process discussion so we can return to it and finish the workflow design later.