### PR TITLE
Document Codex model selection policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,53 @@ constraints for their subtrees.
   visual patterns and Cloud for isolated, fully specified tasks with deterministic Cloud-available proof. Do not estimate
   task suitability from changed-line or lockfile size alone.
 
+## Standard tooling and infrastructure approval
+
+- For established engineering domains such as dependency scanning, vulnerability management, formatting, linting,
+  build orchestration, release automation, test reporting, coverage, packaging, and scaffolding, prefer maintained,
+  widely adopted tools, official actions, platform features, and ecosystem-standard declarative configuration. Compose
+  and configure those capabilities before writing custom code. Do not recreate capabilities already provided by npm,
+  Maven, GitHub, Dependabot, GitHub Dependency Review, OSV-Scanner, CodeQL, Renovate, established linters/build systems,
+  or equivalent maintained tooling.
+- Evaluate maintenance status, ecosystem adoption, update path, security and permissions model, portability, expected
+  failure/noise semantics, and operational burden—not only whether custom code can be made to pass tests.
+- Bespoke build, CI, release, dependency, or security infrastructure requires a maintainer-approved rationale in the
+  authoritative issue before implementation. It must state: the exact requirement and observable gap; maintained
+  alternatives evaluated; why configuration or composition is insufficient; the smallest custom surface; owner and
+  maintenance burden; security and permissions model; deterministic test strategy; upgrade and compatibility strategy;
+  operational failure/noise semantics; and the removal condition and exit or migration plan. Missing approval is a
+  blocker, not permission to invent a framework.
+- Every new CI workflow or materially new job additionally requires the issue to document why an existing workflow or
+  job cannot host the check; its trigger model; least-privilege permissions; required-check or blocking semantics;
+  expected signal and acceptable noise; the maintainer response to failure; owner and lifecycle/removal condition; and
+  overlap with existing GitHub or platform signals.
+- Review architecture and operational simplicity before accepting green CI. Ask whether common-problem custom code is
+  being introduced, which standard tools were considered, whether declarative composition can achieve the outcome,
+  whether the custom surface is proportionate, and who maintains it as upstream formats, APIs, or advisories change.
+- Resolve policy and architecture before implementation. If a task discovers a need for shared infrastructure, stop,
+  create a separate issue, and obtain the required design approval instead of expanding an unrelated pull request.
+
+## Compatibility and scope
+
+- Preserve Java 8 source, bytecode, and runtime compatibility unless a task explicitly changes the supported baseline.
+  Do not use post-Java-8 language features or APIs in shared production or test sources. JDK-specific integrations must
+  stay behind capability probes, isolated modules, or Maven profiles.
+- Keep changes inside the requested behavior. Preserve public contracts and existing user changes; do not turn a
+  focused fix into an unrelated redesign.
+- Prefer the smallest compatible dependency update. Do not perform broad dependency modernization as part of an
+  unrelated task. Document security-motivated upgrades and compatibility trade-offs in the pull request.
+
 ## Codex model selection and budget
 
 - Treat model cost as an engineering constraint. Do not default every task to the strongest model or highest reasoning
   level when the task has already been decomposed and specified by a maintainer or project-management agent.
-- Use Terra with medium reasoning as the default for well-scoped implementation work: focused bug fixes, CI fixes,
-  review follow-ups, tests, documentation, dependency updates, localized refactors, and module moves with clear acceptance
-  criteria. Use low reasoning for mechanical edits where the exact files and required transformation are already known.
+- Explicit issue or project routing overrides the defaults. For the local dispatcher, `agent:model:luna` means GPT-5.6
+  Luna with low reasoning, `agent:model:sol` means GPT-5.6 Sol with high reasoning, and an issue without a stronger route
+  defaults to GPT-5.6 Terra with medium reasoning.
+- Use Terra with medium reasoning for well-scoped implementation work: focused bug fixes, CI fixes, review follow-ups,
+  tests, documentation, dependency updates, localized refactors, and module moves with clear acceptance criteria.
+- Use Luna with low reasoning only for mechanical edits where the exact files and required transformation are already
+  known and no material design, compatibility, failure-analysis, or proof decision remains.
 - Escalate to Sol with high reasoning only when the task materially benefits from repository-wide or architectural
   reasoning, such as a new public API, a first-of-kind design, concurrency or lifecycle defects, cross-version Java
   compatibility, subtle performance work, or an unresolved failure that persisted after a focused Terra attempt.
@@ -48,16 +88,6 @@ constraints for their subtrees.
   obligations, but do not redo settled analysis without evidence that it is wrong.
 - Record model escalations in the task or pull-request notes when they are non-obvious, including the specific complexity
   or failed attempt that justified Sol. This is for cost and workflow calibration, not for judging implementation quality.
-
-## Compatibility and scope
-
-- Preserve Java 8 source, bytecode, and runtime compatibility unless a task explicitly changes the supported baseline.
-  Do not use post-Java-8 language features or APIs in shared production or test sources. JDK-specific integrations must
-  stay behind capability probes, isolated modules, or Maven profiles.
-- Keep changes inside the requested behavior. Preserve public contracts and existing user changes; do not turn a
-  focused fix into an unrelated redesign.
-- Prefer the smallest compatible dependency update. Do not perform broad dependency modernization as part of an
-  unrelated task. Document security-motivated upgrades and compatibility trade-offs in the pull request.
 
 ## Concurrency and lifecycle
 
@@ -99,8 +129,11 @@ constraints for their subtrees.
   and the root workspace scripts; do not hand-edit generated Java resources.
 - Keep profiler CSS and Base UI portals inside its open ShadowRoot. Do not add dynamic imports, runtime assets, host-page
   mutations, global CSS, or absolute backend assumptions.
-- Run lint, typecheck, Vitest, Storybook build, production build, generated-resource comparison, bundle validation, npm
-  audit, and Playwright for UI changes. Review `npm run dev` playground pages and visual diffs before updating baselines.
+- Run lint, typecheck, Vitest, Storybook build, production build, generated-resource comparison, bundle validation, and
+  Playwright for UI changes. GitHub Dependency Review is the causal pull-request gate for newly introduced
+  vulnerabilities. Use `npm audit` as diagnostic or remediation evidence for dependency-security work, not as a reason
+  to broaden an unrelated feature pull request; Dependabot and issue #712 own the current frontend vulnerability
+  baseline. Review `npm run dev` playground pages and visual diffs before updating baselines.
 - Storybook's MCP addon is optional for local exploration. CI and tests must never require an external AI or MCP service.
 
 ### Visual evidence contract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,25 @@ constraints for their subtrees.
   visual patterns and Cloud for isolated, fully specified tasks with deterministic Cloud-available proof. Do not estimate
   task suitability from changed-line or lockfile size alone.
 
+## Codex model selection and budget
+
+- Treat model cost as an engineering constraint. Do not default every task to the strongest model or highest reasoning
+  level when the task has already been decomposed and specified by a maintainer or project-management agent.
+- Use Terra with medium reasoning as the default for well-scoped implementation work: focused bug fixes, CI fixes,
+  review follow-ups, tests, documentation, dependency updates, localized refactors, and module moves with clear acceptance
+  criteria. Use low reasoning for mechanical edits where the exact files and required transformation are already known.
+- Escalate to Sol with high reasoning only when the task materially benefits from repository-wide or architectural
+  reasoning, such as a new public API, a first-of-kind design, concurrency or lifecycle defects, cross-version Java
+  compatibility, subtle performance work, or an unresolved failure that persisted after a focused Terra attempt.
+- Prefer staged escalation over expensive retries: first give Terra a precise task, acceptance criteria, relevant files,
+  and required checks; inspect its diff and failure evidence; then route only the unresolved part to Sol. Do not restart
+  the entire task on Sol merely because one check failed or one review item remains.
+- Avoid duplicate planning. When an upstream agent or maintainer provides a concrete breakdown and design decisions,
+  execute that plan rather than spending a high-reasoning pass rediscovering it. Surface contradictions or missing proof
+  obligations, but do not redo settled analysis without evidence that it is wrong.
+- Record model escalations in the task or pull-request notes when they are non-obvious, including the specific complexity
+  or failed attempt that justified Sol. This is for cost and workflow calibration, not for judging implementation quality.
+
 ## Compatibility and scope
 
 - Preserve Java 8 source, bytecode, and runtime compatibility unless a task explicitly changes the supported baseline.


### PR DESCRIPTION
## What changed

Added a repository-level Codex model-selection and budget policy to `AGENTS.md`, then reconciled it with the current `develop` agent policy after the file diverged.

The resolved policy now:
- preserves the current `develop` standard-tooling/infrastructure approval rules and frontend dependency-security guidance;
- aligns model names and routing with the current app-native local dispatcher: Luna with low reasoning for explicitly routed mechanical work, Terra with medium reasoning by default, and Sol with high reasoning for explicitly routed or genuinely complex work;
- reserves Luna for transformations whose exact files and edits are already known and where no design, compatibility, failure-analysis, or proof decision remains;
- uses Terra for ordinary well-scoped implementation work;
- escalates to Sol only for architectural, concurrency, lifecycle, cross-version Java, subtle performance, first-of-kind, or unresolved work;
- requires staged escalation instead of restarting whole tasks on the strongest model;
- avoids duplicate planning when a maintainer or upstream agent already supplied a concrete breakdown;
- records non-obvious escalations for later cost/workflow calibration.

## Conflict resolution

`develop` had added a substantial `Standard tooling and infrastructure approval` section at the same location where this branch originally inserted the model policy, and had also replaced the old blanket frontend `npm audit` requirement with the current Dependency Review / issue #712 ownership contract.

The resolution uses the complete current `develop` content as the baseline, retains both of those newer policies unchanged, and places the updated model-selection section after `Compatibility and scope`. This avoids duplicating or reverting either side and keeps the resulting document internally consistent.

## Why

Sniffy tasks are often decomposed and specified before Codex starts implementation. Repeating the same planning with the most expensive model wastes the weekly budget without necessarily improving the resulting pull request.

## Compatibility and impact

Documentation and agent-workflow guidance only. No production code, build configuration, dependencies, workflows, or public APIs changed.

## Validation

- Read the conflicting `AGENTS.md` content from the original feature head and current `develop`.
- Cross-checked the current dispatcher routing in `.codex/local/scheduled-task-prompt.md`.
- Updated only `AGENTS.md` on the existing branch `agent/codex-model-selection-policy`.
- GitHub now reports the pull request as mergeable with no content conflict.
- No runtime tests are applicable to this documentation-only change.

Published head SHA: `868a5145580ac03a8ba1d3bb7ed62f46e69295fb`