### PR TITLE
Document standard-tooling-first infrastructure policy

### DIFF
--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -16,6 +16,8 @@ If there is no eligible issue, report a no-op and change nothing.
 
 Before claiming, read AGENTS.md, docs/codex-workflow.md, the complete issue and all comments, all project fields, linked pull requests, review submissions and unresolved review threads, current CI, and the current remote develop branch. Confirm that the issue satisfies Definition of Ready and classify it as either fresh work or a continuation.
 
+Apply the standard-tooling and infrastructure-approval gate in AGENTS.md before implementation. For common build, CI, release, dependency, or security problems, prefer maintained tools, official actions, platform features, and declarative configuration. Bespoke infrastructure or a materially new workflow/job is not ready unless the authoritative issue contains the required maintainer-approved alternatives, gap, ownership, security, test, upgrade, operational, and removal rationale. If that approval is absent, set Status to "Blocked" and report the missing decision instead of inventing infrastructure.
+
 Fresh work has no active local claim and no implementation pull request.
 
 A continuation is eligible when all of the following are true:

--- a/.github/ISSUE_TEMPLATE/codex-task.yml
+++ b/.github/ISSUE_TEMPLATE/codex-task.yml
@@ -49,6 +49,23 @@ body:
     validations:
       required: true
   - type: textarea
+    id: standard_tooling
+    attributes:
+      label: Standard tooling and infrastructure rationale
+      description: Evaluate maintained tools and declarative composition first. Write "Not applicable - no shared infrastructure change" when appropriate.
+      placeholder: |
+        For bespoke infrastructure, record the maintainer-approved:
+        1. Exact requirement and observable gap
+        2. Maintained alternatives evaluated and why composition is insufficient
+        3. Smallest custom surface and maintenance owner
+        4. Security/permissions model and deterministic tests
+        5. Upgrade/compatibility strategy and failure/noise semantics
+        6. Removal condition and migration plan
+
+        For a new workflow or materially new job, also record why an existing job cannot host it, triggers, least privilege, required-check behavior, maintainer response, lifecycle, and overlap with platform signals.
+    validations:
+      required: true
+  - type: textarea
     id: delivery
     attributes:
       label: Delivery topology and checkpoints
@@ -94,6 +111,8 @@ body:
         - label: Module/API scope boundaries and any global-state or lifecycle decisions are explicit.
           required: true
         - label: Every acceptance criterion is mapped to an executable or inspectable proof.
+          required: true
+        - label: Maintained alternatives were assessed; bespoke infrastructure or new CI topology has explicit maintainer approval.
           required: true
         - label: Acceptance criteria are testable.
           required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,11 @@ Sniffy is a Java profiler which shows results directly in your browser. It also 
 
 **ALWAYS reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.**
 
+`AGENTS.md` is the authoritative repository policy. In particular, follow its standard-tooling and infrastructure-
+approval gate: prefer maintained tools and declarative configuration for common build, CI, release, dependency, and
+security problems, and do not implement bespoke infrastructure or a materially new workflow/job without the required
+maintainer-approved issue rationale.
+
 ## Working Effectively
 
 **CRITICAL BUILD REQUIREMENTS:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,32 @@ constraints for their subtrees.
   visual patterns and Cloud for isolated, fully specified tasks with deterministic Cloud-available proof. Do not estimate
   task suitability from changed-line or lockfile size alone.
 
+## Standard tooling and infrastructure approval
+
+- For established engineering domains such as dependency scanning, vulnerability management, formatting, linting,
+  build orchestration, release automation, test reporting, coverage, packaging, and scaffolding, prefer maintained,
+  widely adopted tools, official actions, platform features, and ecosystem-standard declarative configuration. Compose
+  and configure those capabilities before writing custom code. Do not recreate capabilities already provided by npm,
+  Maven, GitHub, Dependabot, GitHub Dependency Review, OSV-Scanner, CodeQL, Renovate, established linters/build systems,
+  or equivalent maintained tooling.
+- Evaluate maintenance status, ecosystem adoption, update path, security and permissions model, portability, expected
+  failure/noise semantics, and operational burden—not only whether custom code can be made to pass tests.
+- Bespoke build, CI, release, dependency, or security infrastructure requires a maintainer-approved rationale in the
+  authoritative issue before implementation. It must state: the exact requirement and observable gap; maintained
+  alternatives evaluated; why configuration or composition is insufficient; the smallest custom surface; owner and
+  maintenance burden; security and permissions model; deterministic test strategy; upgrade and compatibility strategy;
+  operational failure/noise semantics; and the removal condition and exit or migration plan. Missing approval is a
+  blocker, not permission to invent a framework.
+- Every new CI workflow or materially new job additionally requires the issue to document why an existing workflow or
+  job cannot host the check; its trigger model; least-privilege permissions; required-check or blocking semantics;
+  expected signal and acceptable noise; the maintainer response to failure; owner and lifecycle/removal condition; and
+  overlap with existing GitHub or platform signals.
+- Review architecture and operational simplicity before accepting green CI. Ask whether common-problem custom code is
+  being introduced, which standard tools were considered, whether declarative composition can achieve the outcome,
+  whether the custom surface is proportionate, and who maintains it as upstream formats, APIs, or advisories change.
+- Resolve policy and architecture before implementation. If a task discovers a need for shared infrastructure, stop,
+  create a separate issue, and obtain the required design approval instead of expanding an unrelated pull request.
+
 ## Compatibility and scope
 
 - Preserve Java 8 source, bytecode, and runtime compatibility unless a task explicitly changes the supported baseline.

--- a/docs/codex-supervision-policy.md
+++ b/docs/codex-supervision-policy.md
@@ -25,6 +25,21 @@ The first check must never be delayed until the hourly monitor. Returning an exi
 
 Each check should verify that the intended executor claimed the task, continues on the expected branch and pull request, and has not silently stalled or opened a duplicate pull request. Executor verification must use the GitHub Project `Executor` field rather than inferring the executor from assignee or labels.
 
+## Architecture and tooling review
+
+`AGENTS.md` is the canonical standard-tooling and infrastructure-approval policy. Before dispatch and again during
+completion review, ask:
+
+- Is the change solving a common engineering problem with custom code?
+- Which maintained standard tools, official actions, or platform features were considered?
+- Can declarative configuration or composition achieve the same outcome?
+- Is any custom surface proportionate to the repository-specific gap?
+- Who maintains it when upstream formats, APIs, or advisories change?
+
+Green tests do not justify a bespoke framework that duplicates maintained tooling without the issue-level approval,
+alternatives analysis, ownership, security, operational, upgrade, and removal rationale required by `AGENTS.md`. Apply
+the additional workflow/job gate there before accepting new CI topology.
+
 ## Completion review
 
 After the agent reports completion, the supervisor must independently inspect:

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -160,6 +160,18 @@ A short read-only design/refinement task before implementation is often cheaper 
 feature that combines global state, failure composition, and multiple runtime versions, use that refinement step even
 when the final implementation remains one PR.
 
+### 4.3. Standard tooling and infrastructure gate
+
+`AGENTS.md` is the canonical policy for standard tooling and bespoke infrastructure. During refinement, first determine
+whether a maintained tool, official action, platform feature, or declarative configuration already covers the
+requirement. Prefer configuring or composing that standard capability over custom build, CI, release, dependency, or
+security code.
+
+Do not dispatch bespoke infrastructure unless the authoritative issue contains the maintainer-approved alternatives and
+rationale required by `AGENTS.md`. Apply the additional trigger, permissions, required-check, noise, response, ownership,
+lifecycle, and overlap analysis before adding a workflow or materially new job. Missing rationale is a Definition-of-Ready
+failure. If the need emerges during another task, stop and refine a separate infrastructure issue before implementation.
+
 ## 5. Routing tasks
 
 ### Use Codex Cloud by default when
@@ -318,6 +330,8 @@ Useful labels include `agent:cloud`, `agent:local`, `agent:blocked`, `needs:prod
 The delivery lead reviews:
 
 - whether the implementation matches every acceptance criterion;
+- whether a standard maintained tool or declarative composition covers the requirement, and any bespoke infrastructure
+  or new workflow/job has the issue-level approval and operational rationale required by `AGENTS.md`;
 - compatibility and public API impact;
 - module boundaries and unnecessary complexity;
 - test quality, discovery, execution, and whether tests were weakened or made flaky;


### PR DESCRIPTION
Closes #715.

## What changed

- Make `AGENTS.md` the canonical standard-tooling-first policy for common build, CI, release, dependency, and security work.
- Require maintainer-approved alternatives, gap, ownership, permissions, test, upgrade, operational, and exit rationale before bespoke infrastructure is implemented.
- Add the additional gate for new workflows or materially new jobs.
- Carry the gate into the Codex workflow, local scheduled-worker prompt, autonomous issue template, supervisor review checklist, and Copilot entry point.

## Why

PR #713 demonstrated that functional correctness and green CI are insufficient when a bespoke dependency-security framework duplicates maintained platform and ecosystem tooling. Architecture and operational burden must be reviewed before implementation, not after a large custom system is built.

## How this would have prevented PR #713

Issue #711 would have failed Definition of Ready before dispatch because it did not contain a maintainer-approved comparison of GitHub Dependency Review, OSV-Scanner, npm audit, Dependabot, or equivalent standard tools against an observable unmet requirement. Its custom comparator and separate scheduled workflow would also have required explicit ownership, permissions, noise/failure semantics, upgrade strategy, overlap analysis, and removal plan. The new supervisor prompts would reject the bespoke engine on that architectural basis even if its tests and CI were green.

## Scope

Documentation and instruction policy only. This PR adds no scanner, workflow, CI job, dependency, lockfile, runtime, or product change, and does not modify PR #713, #710, or #712.

Dependency impact: none.

## Validation

- `git diff --check`
- Pinned Node 24.18.0 / npm 11.16.0 Issue Form YAML parse and focused field/readiness constraints
- Policy entry-point coverage and forbidden-scope contract
- Prettier 3.9.5 check for `AGENTS.md`, `docs/codex-workflow.md`, `.codex/local/scheduled-task-prompt.md`, `.github/ISSUE_TEMPLATE/codex-task.yml`, and `docs/codex-supervision-policy.md`

The base version of `.github/copilot-instructions.md` already fails a whole-file Prettier check; this focused PR does not reformat unrelated legacy content. Ruby and host Node were unavailable, so validation used the repository's pinned Node toolchain.

Published head: `909d5918e4f50ded58da0c6a72ebf624301b8ec0`
