### PR TITLE
Use standard dependency security tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,17 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+
+  # Frontend npm workspace
+  - package-ecosystem: "npm"
+    directory: "/sniffy-ui"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "05:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
   frontend:
     name: Frontend
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     env:
       HOME: /root
       PLAYWRIGHT_BROWSERS_PATH: /root/.cache/ms-playwright
@@ -30,6 +32,11 @@ jobs:
         working-directory: sniffy-ui
     steps:
       - uses: actions/checkout@v7
+      - name: Review dependency changes
+        if: github.event_name == 'pull_request'
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high
       - uses: actions/setup-node@v6
         with:
           node-version: 24.18.0
@@ -68,8 +75,6 @@ jobs:
         run: npm run check:generated
       - name: Validate bundle
         run: npm run check:bundle
-      - name: Audit frontend dependencies
-        run: npm audit --audit-level=high
       - name: Playwright end-to-end tests
         run: npm run test:e2e
       - uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,11 @@ constraints for their subtrees.
   and the root workspace scripts; do not hand-edit generated Java resources.
 - Keep profiler CSS and Base UI portals inside its open ShadowRoot. Do not add dynamic imports, runtime assets, host-page
   mutations, global CSS, or absolute backend assumptions.
-- Run lint, typecheck, Vitest, Storybook build, production build, generated-resource comparison, bundle validation, npm
-  audit, and Playwright for UI changes. Review `npm run dev` playground pages and visual diffs before updating baselines.
+- Run lint, typecheck, Vitest, Storybook build, production build, generated-resource comparison, bundle validation, and
+  Playwright for UI changes. GitHub Dependency Review is the causal pull-request gate for newly introduced
+  vulnerabilities. Use `npm audit` as diagnostic or remediation evidence for dependency-security work, not as a reason
+  to broaden an unrelated feature pull request; Dependabot and issue #712 own the current frontend vulnerability
+  baseline. Review `npm run dev` playground pages and visual diffs before updating baselines.
 - Storybook's MCP addon is optional for local exploration. CI and tests must never require an external AI or MCP service.
 
 ### Visual evidence contract

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -32,6 +32,17 @@ The profiler derives its backend from the resolved `#sniffy-header` script URL, 
 
 `npm run test` runs unit tests plus Storybook interaction/accessibility tests in Chromium. Install all browser engines with `npx playwright install chromium firefox webkit`, then use `npm run test:e2e` for behavior coverage in Chromium, Firefox, and WebKit. Visual baselines live in `tests/e2e/visual-baselines/` and are updated only with `npm run test:e2e:update` in the pinned Playwright Linux/Chromium environment used by CI; inspect both profiler and agent images before committing them.
 
+## Dependency security
+
+The pull-request workflow uses GitHub Dependency Review to fail when a pull request introduces a vulnerability with
+`high` or `critical` severity. Because that maintained action compares the base and head dependency graphs, newly
+published advisories for an unchanged graph do not make unrelated feature pull requests responsible for baseline
+remediation. Weekly Dependabot updates for `/sniffy-ui` and repository Dependabot alerts own current-state visibility
+and update proposals.
+
+Use `npm audit` locally for diagnosis and as remediation evidence for dependency-security work such as issue #712. Do
+not expand an unrelated feature pull request to repair the existing advisory baseline.
+
 The existing `Check Pull Request` workflow includes an always-on `Website` job for every pull request. It reports locked dependency installation, lint, formatting, typecheck, site contract tests, the Docusaurus production build, deterministic documentation-index verification, and desktop/mobile Playwright coverage as separate steps, then uploads the complete `apps/site/build/` directory as a downloadable artifact. The local search index contains only current `/docs/` pages and useful section headings; the Sniffy-owned search dialog loads it lazily and requires no hosted service or backend. During `npm run dev:site`, the Docusaurus plugin builds an in-memory index from its current loaded MDX sources and refreshes it through the normal documentation watch/reload cycle, so a clean development checkout supports search without a preceding build or a stale checked-in index. The port-3200 Playwright project verifies that real development path. The artifact includes a README, the CI Node version pin, and a dependency-free `preview.mjs` launcher. After extraction, `node preview.mjs` serves the unchanged production build on macOS, Linux, or Windows; opening `index.html` through `file://` is intentionally unsupported because the production site uses `baseUrl: /`. CI starts that packaged launcher and verifies `/`, `/docs/`, a representative keyboard search, and the branded 404 response over HTTP before upload. The job also runs with the workflow's existing manual and `develop`-push triggers; it stays independent from Maven publication and never deploys the site.
 
 The branded site shell aliases shared semantic tokens in `apps/site/src/css/custom.css`. Variables prefixed

--- a/sniffy-ui/apps/site/AGENTS.md
+++ b/sniffy-ui/apps/site/AGENTS.md
@@ -41,7 +41,9 @@ These rules apply to every change under `sniffy-ui/apps/site` in addition to the
 
 - Run `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test`, `npm run build:site`, and `npm run test:site`.
 - For any frontend change, also run the repository-required Storybook build, existing production build,
-  `check:generated`, `check:bundle`, audit, and applicable Playwright checks.
+  `check:generated`, `check:bundle`, and applicable Playwright checks. Use `npm audit` for dependency diagnostics or
+  remediation evidence; ordinary site changes rely on the pull-request Dependency Review gate and must not absorb the
+  existing advisory baseline.
 - Verify `/`, `/docs/`, and the deliberate 404 behavior for reserved routes against the production site build.
 - Review desktop and meaningful mobile states and attach review-only screenshots to the pull request, never to this
   directory or repository history.


### PR DESCRIPTION
Closes #711

## Summary

- add the official `actions/dependency-review-action@v5` to the existing Frontend job for pull-request events, with `contents: read` and `fail-on-severity: high`
- remove the unconditional repository-wide `npm audit --audit-level=high` step from ordinary pull-request acceptance
- add weekly Dependabot npm coverage for `/sniffy-ui`
- align the minimal frontend and agent guidance with the new causal security signal

Published head: `700071da9b4dcff3606100285402d612f53bd4dd`

## Standard-tooling decision

GitHub Dependency Review is the selected pull-request signal because it compares the base and head dependency graphs and fails only for vulnerabilities introduced by the proposed change. Dependabot alerts and weekly npm update proposals own current default-branch drift. `npm audit` remains useful for local diagnosis and issue #712 remediation evidence, but it is not a causal gate for unrelated pull requests.

OSV-Scanner is not added because it would overlap with the GitHub-native signal and add another workflow and permissions surface without an approved gap. PR #713's bespoke comparator, advisory/path model, fixtures, exception and override registries, and scheduled workflow were not reused. This branch was created from post-#716 `develop`; `8081be612d4517ac294c430d94dfe0ea6403a1a1` is not an ancestor of this branch.

## Placement, permissions, and failure semantics

The action is a step in the existing Frontend job, so no workflow or materially new job is introduced. It runs only for `pull_request`; push and manual executions skip it. The job grants only `contents: read`, matching the official action's documented minimum. No pull-request write permission is granted and no PR comment mode is enabled.

At `high`, the action fails when a pull request introduces a high- or critical-severity known vulnerability. Existing baseline advisories and non-dependency changes do not fail this step. No allowlist or exception is added.

## Proof

- `git diff --check` — passed
- pinned Node 24 container Prettier/YAML syntax check for all five changed files — passed
- PyYAML structural assertions for the action, event guard, permission, severity, removed audit step, and `/sniffy-ui` weekly Dependabot entry — passed
- GitHub dependency-graph comparison for PR #710, base `7d232ad06d6dfefecc18e979b2fd32b320afd78e` to head `7875ef31f55f7783bb04a9ad754941549e4dcfe7` — `0` dependency changes despite its script-only `package.json` edit
- official action `v5` currently resolves to `a1d282b36b6f3519aa1f3fc636f609c47dddb294`; its published action contract defines `fail-on-severity` as the blocking threshold and supports `high`
- exact-head GitHub CI — [run 30175531660](https://github.com/sniffy/sniffy/actions/runs/30175531660) passed all 26 jobs on attempt 2 at the published head; attempt 1 completed the full JDK 25/macOS Intel reactor but its test-report artifact upload hit transient DNS `ENOTFOUND`

## Compatibility and scope

No dependency version, lockfile, backend/runtime, product, website content, PR #710, or issue #712 implementation change is included. No custom scanner, comparator, parser, wrapper, fixture framework, registry, or new workflow/job is added. Never merge or enable auto-merge from this agent run.