### PR TITLE
Document app-native Codex dispatcher and worker chats

### DIFF
--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -1,65 +1,62 @@
-# Sniffy local Codex scheduled-task prompt
+# Sniffy local Codex dispatcher prompt
 
-Copy the text block below verbatim into the ChatGPT desktop app Scheduled task that dispatches the local Sniffy worker. The prompt supports both a fresh implementation and a continuation of an existing local-worker pull request.
+Copy the text block below into a Scheduled task **attached to one persistent dispatcher chat** in the ChatGPT/Codex desktop app. Configure the task to run every 15 minutes against the local Sniffy project checkout, not a new worktree. The desktop app must use WSL for the Codex agent so all repository and GitHub commands run in Linux.
+
+The dispatcher is intentionally read-only with respect to source code. A no-op cycle stays in the same dispatcher chat. An eligible issue is handed to a one-time standalone Scheduled task, which creates exactly one dedicated worker chat and one isolated worktree for that issue.
 
 ```text
-Run one Sniffy local-worker cycle in the selected WSL project and its dedicated worktree.
+Run one Sniffy dispatcher cycle in this existing dispatcher chat.
 
-Use organization project 2 (https://github.com/orgs/sniffy/projects/2) owned by sniffy as the book of work. Select at most one Issue from sniffy/sniffy whose Status is "Ready for agent" and Executor is "Local Codex".
+Repository: sniffy/sniffy
+Book of work: organization project 2, https://github.com/orgs/sniffy/projects/2
+Base branch: develop
+Ready status: Ready for agent
+Executor: Local Codex
+Canonical worker template: .codex/local/worker-task-prompt.md
 
-Prioritize eligible work in this order:
+This chat is a coordinator only. Never edit source files, create an implementation branch, run tests, launch codex exec, or implement an issue in this dispatcher chat.
 
-1. An explicitly re-queued continuation that already has an open local-worker pull request and actionable maintainer review feedback or required failing checks.
-2. Otherwise, fresh work by highest project Priority and oldest issue number.
+1. Read AGENTS.md, docs/codex-workflow.md, this prompt, and the worker template before making queue decisions.
+2. Inspect project 2 and select at most one Issue from sniffy/sniffy whose Status is "Ready for agent" and Executor is "Local Codex".
+3. Do not dispatch a second issue while another local-worker item is still genuinely active. Inspect the issue, project state, claim comments, linked pull request, and current remote state instead of relying on a stale label alone.
+4. Prefer an explicitly re-queued continuation with an existing local-worker pull request and actionable maintainer feedback or failing required checks. Otherwise choose fresh work by project Priority and oldest issue number.
+5. Confirm that the selected issue satisfies the Definition of Ready in docs/codex-workflow.md. Read the complete issue and comments, relevant project fields, linked pull requests, review submissions and unresolved threads, and current CI. Apply the standard-tooling and infrastructure-approval gate in AGENTS.md.
+6. If no eligible issue exists, create no task, no chat, no worktree, no branch, and no GitHub mutation. Reply only NO_CHANGE.
+7. Classify the selected item as fresh work or an explicitly re-queued continuation. A continuation must have an open writable local-worker pull request and branch plus actionable feedback or required failing checks. Do not continue work owned by another executor.
+8. Select the worker model and reasoning effort from explicit issue or project routing. Use these defaults when no stronger instruction exists:
+   - agent:model:luna -> GPT-5.6 Luna with low reasoning;
+   - agent:model:sol -> GPT-5.6 Sol with high reasoning;
+   - otherwise -> GPT-5.6 Terra with medium reasoning.
+9. Claim the issue before spawning the worker:
+   - set project Status to "In progress";
+   - add the dedicated local-worker account as assignee when missing;
+   - add agent:local when missing;
+   - post a claim comment with worker name, fresh/continuation mode, intended or existing branch, existing pull request when applicable, selected model and reasoning, and an ISO-8601 timestamp.
+10. If any claim mutation fails, roll back mutations already made and stop before creating a task.
+11. Read .codex/local/worker-task-prompt.md and replace every placeholder with the selected issue, branch, pull request, model, and reasoning values. Do not leave unresolved placeholders in the child prompt.
+12. Using the desktop app's native Scheduled task capability, create one NEW ONE-TIME STANDALONE task:
+    - title: "Sniffy #<issue-number>: <issue-title>";
+    - run once as soon as possible;
+    - destination: a new standalone chat, never this dispatcher chat;
+    - project: the current local Sniffy project;
+    - environment: a new isolated Git worktree;
+    - model and reasoning: the values selected above;
+    - prompt: the fully rendered worker template.
+13. Do not use shell UI automation, Python observers, codex app-server, codex exec, or .codex/local/run-issue.sh to create the worker. The child must be an app-owned task so its chat remains visible in the desktop app and Remote.
+14. After the child task is confirmed created, post a second issue comment containing the exact child task title and timestamp. Keep Status "In progress". Report the issue number, worker task title, model, reasoning, and fresh/continuation mode in this dispatcher chat.
+15. If child-task creation fails, remove the local claim changes, restore Status "Ready for agent", post the exact failure on the issue, and report the error here. Never leave an issue silently claimed without a confirmed worker task.
 
-If there is no eligible issue, report a no-op and change nothing.
-
-Before claiming, read AGENTS.md, docs/codex-workflow.md, the complete issue and all comments, all project fields, linked pull requests, review submissions and unresolved review threads, current CI, and the current remote develop branch. Confirm that the issue satisfies Definition of Ready and classify it as either fresh work or a continuation.
-
-Apply the standard-tooling and infrastructure-approval gate in AGENTS.md before implementation. For common build, CI, release, dependency, or security problems, prefer maintained tools, official actions, platform features, and declarative configuration. Bespoke infrastructure or a materially new workflow/job is not ready unless the authoritative issue contains the required maintainer-approved alternatives, gap, ownership, security, test, upgrade, operational, and removal rationale. If that approval is absent, set Status to "Blocked" and report the missing decision instead of inventing infrastructure.
-
-Fresh work has no active local claim and no implementation pull request.
-
-A continuation is eligible when all of the following are true:
-
-- the issue was deliberately returned to "Ready for agent";
-- Executor is "Local Codex";
-- the issue remains assigned to the dedicated local worker or can safely be assigned to it;
-- an existing local-worker claim, agent:local label, writable agent/issue-N branch, and open implementation pull request are present;
-- maintainer review feedback or required failed checks call for additional implementation.
-
-For a continuation, the historical local claim, assignee, agent:local label, existing branch, and open pull request are required context. They are not reasons for a guarded no-op. The existence of an implementation pull request disqualifies only fresh work; it does not disqualify an explicitly re-queued continuation.
-
-Do not continue a pull request owned by another executor or a branch the worker cannot update. Report that exact blocker instead.
-
-Claim the selected item by changing project Status to "In progress". Add the dedicated worker account as assignee and add agent:local only when missing. Post a claim comment.
-
-For fresh work, record the intended agent/issue-N branch.
-
-For a continuation, post "Claimed continuation" and record the existing branch, pull-request number, current head SHA, timestamp, and feedback scope. Preserve the existing claim and pull request rather than creating replacements.
-
-If any claim mutation fails, roll back mutations already made and stop before editing code.
-
-After a successful fresh claim, create agent/issue-N from the latest origin/develop without force-pushing.
-
-After a successful continuation claim, fetch and check out the exact existing pull-request head branch. Do not reset it to develop, rebase or rewrite its published history, create a replacement branch, or open a separate pull request. Verify that local HEAD, the remote branch, and the existing pull-request head agree before editing. Address all actionable review feedback and relevant failing checks on that pull request while preserving unrelated work already on the branch.
-
-Follow AGENTS.md and the issue as the source of truth. Implement the fresh task or continuation fixes end to end, add or update tests and documentation, run all applicable focused checks as separately reported commands, inspect the final diff, commit, push, and create or update the pull request. Do not merge or enable auto-merge.
-
-Verify the remote branch, full head SHA, pull-request URL, base/head branches, and pull-request head SHA. Move project Status to "Review" only after publication is verified and the requested continuation proof is satisfied. When the maintainer explicitly requires green remote CI, verify that CI before moving to Review.
-
-If a genuine blocker remains, set Status to "Blocked" and post the exact blocker and smallest required decision. Never claim or implement more than one issue in this run.
+Never dispatch the same issue twice. Never merge or enable auto-merge.
 ```
 
-## Continuation smoke test
+## Required smoke test
 
-Before enabling the recurring schedule, test the prompt against a disposable or intentionally re-queued issue with:
+Before enabling the recurring dispatcher, use a disposable issue or a read-only child prompt to verify that a run of an in-chat Scheduled task can create one one-time standalone child task in the current desktop-app version. The smoke test must prove:
 
-- `Status = Ready for agent`;
-- `Executor = Local Codex`;
-- an existing local claim and `agent:local` label;
-- the local-worker assignee;
-- an existing `agent/issue-N` branch and open pull request;
-- actionable `CHANGES_REQUESTED` feedback.
+- an empty queue adds no chat and no worktree;
+- one eligible issue creates exactly one worker chat;
+- the worker chat uses the expected WSL project and a separate worktree;
+- the task title contains the issue number;
+- a failed child creation rolls the claim back.
 
-The worker must claim the continuation, reuse the existing branch and pull request, and must not report a no-op merely because the claim or pull request already exists.
+Repeat this smoke test after material desktop-app Scheduled-task changes. If nested task creation is unavailable, pause the dispatcher and use the documented manual app workflow; do not silently replace it with external UI automation.

--- a/.codex/local/worker-task-prompt.md
+++ b/.codex/local/worker-task-prompt.md
@@ -1,0 +1,85 @@
+# Sniffy local Codex worker-task prompt
+
+This is the canonical template rendered by the persistent dispatcher when it creates a one-time standalone Scheduled task. The dispatcher must replace all angle-bracket placeholders before creating the child task.
+
+```text
+Work autonomously on Sniffy GitHub issue #<ISSUE_NUMBER> in this dedicated worker chat and isolated app-managed worktree.
+
+Issue title: <ISSUE_TITLE>
+Issue URL: <ISSUE_URL>
+Mode: <WORK_MODE>
+Base branch: develop
+Branch: <BRANCH_NAME>
+Existing pull request: <PR_URL_OR_NONE>
+Selected model: <MODEL>
+Reasoning effort: <REASONING_EFFORT>
+
+The issue and its complete comment thread are authoritative. Read AGENTS.md, docs/codex-workflow.md, the issue, project fields, linked pull requests, all review submissions and unresolved review threads, current CI, and the current remote develop branch before editing.
+
+Confirm the Definition of Ready and apply the standard-tooling and infrastructure-approval gate in AGENTS.md. If a material product, public-API, architecture, security, permissions, or bespoke-infrastructure decision is missing, do not invent it. Set project Status to "Blocked", post the exact blocker and smallest required decision, pause any follow-up task, and stop.
+
+For fresh work:
+- verify that no implementation pull request or active worker branch already owns the issue;
+- create <BRANCH_NAME> from the latest origin/develop without force-pushing or rewriting shared history.
+
+For continuation work:
+- verify that <PR_URL_OR_NONE> is open and that its head is <BRANCH_NAME>;
+- fetch and check out that exact published head branch;
+- verify local HEAD, the remote branch, and pull-request head agree before editing;
+- preserve the existing pull request and branch;
+- do not reset to develop, rebase, force-push, create a replacement branch, or open a duplicate pull request.
+
+Then:
+
+1. Convert every acceptance criterion into an explicit proof obligation before implementation.
+2. Implement the smallest coherent solution and avoid unrelated refactoring.
+3. Add or update focused tests and documentation where required.
+4. Run focused checks first. Run broader relevant checks when practical, using separate commands and explicit JDKs as required by AGENTS.md.
+5. Inspect the complete final diff, generated files, dependency changes, and test discovery/execution evidence.
+6. Run git diff --check.
+7. Commit and push the intended branch using the dedicated worker identity.
+8. Create or update the intended pull request. Keep it draft while implementation or locally applicable validation is incomplete, then mark it ready for review unless the issue explicitly requires a draft handoff.
+9. Verify the remote branch, full head SHA, pull-request URL, base/head branches, draft state, and matching pull-request head SHA. A local commit or task summary is not publication.
+10. Update the issue with exact commands and results, the full SHA, and resolvable branch and pull-request links. Move project Status to "Review" only after publication is verified and the requested local proof is complete. Never close the issue automatically.
+
+After publication, create or update one Scheduled task ATTACHED TO THIS CURRENT WORKER CHAT. Name it "Sniffy #<ISSUE_NUMBER> follow-up". Do not create a new standalone continuation chat.
+
+Continuation cadence and state:
+
+- Schedule the first check 15 minutes after publication or after an explicit correction dispatch.
+- If work is still incomplete, keep the same task for a second check 15 minutes after the first.
+- After the second incomplete check, update this same task to run hourly.
+- Record the completed check count and latest inspected pull-request head in this chat so the cadence is not reset by every run.
+- Pause the continuation task as soon as the review cycle is complete or a human/product decision is required.
+
+On every continuation check:
+
+1. Re-read the authoritative issue, new issue and pull-request comments, review submissions, unresolved review threads, latest complete diff, current head SHA, and every relevant CI job.
+2. Do not infer that work started from a review alone. Verify an explicit dispatch/acknowledgement or a new commit when another agent was asked to fix something.
+3. Address all actionable feedback together, preserve unrelated work, run the affected proof matrix, inspect the new complete diff, commit, push, and verify the new remote head.
+4. If required CI is pending, record that state and continue at the configured cadence. Do not approve from a local summary or an older green head.
+5. When the complete diff satisfies the issue and AGENTS.md, all actionable review threads are resolved, named tests actually ran, and required CI is green:
+   - use a configured reviewer identity that is permitted to review and is not the pull-request author to submit APPROVE;
+   - if no such identity is available, report that formal approval is impossible, leave an exact ready-for-human-approval comment, and pause the task rather than pretending approval was submitted.
+6. If blocking defects remain, use a configured independent reviewer identity to submit one precise REQUEST_CHANGES review covering all current findings. If the active identity cannot formally review its own pull request, leave the same precise blocking feedback as a pull-request comment and report the identity limitation.
+7. Never merge, enable auto-merge, close the issue, bypass branch protection, or rewrite the published branch without an explicit instruction from Dmitry.
+
+At completion, summarize the final head SHA, diff reviewed, review-thread state, CI checked, formal review action actually submitted, and any residual risk. Then pause the in-chat follow-up task.
+```
+
+## Placeholder contract
+
+The dispatcher must provide:
+
+| Placeholder | Meaning |
+| --- | --- |
+| `<ISSUE_NUMBER>` | Numeric Sniffy issue number |
+| `<ISSUE_TITLE>` | Current issue title |
+| `<ISSUE_URL>` | Resolvable GitHub issue URL |
+| `<WORK_MODE>` | `fresh` or `continuation` |
+| `<BRANCH_NAME>` | New `agent/issue-N` branch or the exact existing PR head |
+| `<PR_URL_OR_NONE>` | Existing continuation PR URL or `none` |
+| `<MODEL>` | Exact model selected in the app |
+| `<REASONING_EFFORT>` | Exact reasoning effort selected in the app |
+
+Do not launch a worker when any placeholder cannot be resolved safely.

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -1,314 +1,305 @@
 # Codex Cloud and autonomous delivery workflow
 
-This document describes the one-time Codex Cloud setup for Sniffy and the operating model for turning product ideas into reviewed pull requests with minimal interactive intervention.
+This document describes the operating model for turning Sniffy product ideas into reviewed pull requests with minimal
+interactive intervention. It covers Codex Cloud, the native Windows desktop app with a WSL local worker, GitHub delivery,
+review convergence, and the project states that make those systems cooperate safely.
 
 ## 1. What is stored in the repository
 
-- `AGENTS.md` contains repository-wide engineering, autonomy, verification, and review rules.
-- `.codex/cloud/setup.sh` installs GitHub CLI and Temurin JDK 8, writes Maven toolchains for JDK 8, 11, 17, 21, and 25, persists the environment, configures GitHub authentication when the `GH_TOKEN` secret is present, and primes the Maven dependency cache.
-- `.codex/cloud/maintenance.sh` refreshes dependencies when a cached cloud environment is resumed on another branch.
+- `AGENTS.md` contains repository-wide engineering, autonomy, verification, publication, and review rules.
+- `.codex/cloud/setup.sh` installs GitHub CLI and Temurin JDK 8, writes Maven toolchains for JDK 8, 11, 17, 21, and 25,
+  persists the environment, configures GitHub authentication when `GH_TOKEN` is present, and primes Maven dependencies.
+- `.codex/cloud/maintenance.sh` refreshes dependencies when a cached cloud environment resumes on another branch.
 - `.codex/cloud/use-jdk.sh` switches the current shell between installed JDKs.
-- `.codex/local/run-issue.sh` prepares an issue branch and launches unattended local Codex in an isolated machine.
-- `docs/local-codex-worker.md` is the Hyper-V, Windows app, WSL2, Docker, GitHub Project, Scheduled task, and Remote runbook for the always-on local worker.
-- `.github/ISSUE_TEMPLATE/codex-task.yml` provides a Definition-of-Ready template for autonomous tasks.
+- `.codex/local/run-issue.sh` is the unattended CLI fallback for an isolated local machine.
+- `.codex/local/scheduled-task-prompt.md` is the canonical prompt for the persistent app-native dispatcher chat.
+- `.codex/local/worker-task-prompt.md` is the canonical template for the one-time standalone worker created per issue.
+- `docs/local-codex-worker.md` is the Hyper-V, Windows app, WSL2, Docker, GitHub Project, Scheduled task, and Remote runbook.
+- `.github/ISSUE_TEMPLATE/codex-task.yml` provides the Definition-of-Ready template for autonomous work.
 
-Codex loads `AGENTS.md` automatically. More specific instructions can be added later in subdirectories when a module needs different build or review rules.
+Codex loads `AGENTS.md` automatically. More specific instructions may be added in subdirectories when a module needs a
+different build or review contract.
 
 ## 2. One-time Codex Cloud setup
 
-The repository files cannot create an environment in another user's OpenAI account, so the following UI setup is required once.
+Repository files cannot create an environment in another user's OpenAI account. Complete this UI setup once:
 
-1. Open Codex Cloud and connect the GitHub account that has access to `sniffy/sniffy`.
-2. Allow Codex access to the repository.
-3. Create an environment named `sniffy` for repository `sniffy/sniffy`.
-4. Use `develop` as the default branch.
-5. Set the setup script to:
+1. Connect the GitHub account that can access `sniffy/sniffy`.
+2. Create a Codex environment named `sniffy` for `sniffy/sniffy` with `develop` as the default branch.
+3. Configure setup:
 
    ```bash
    bash .codex/cloud/setup.sh
    ```
 
-6. Set the maintenance script to:
+4. Configure maintenance:
 
    ```bash
    bash .codex/cloud/maintenance.sh
    ```
 
-7. Codex Cloud setup always has internet access, but the agent phase is offline by default and follows a separate environment policy. For tasks that must publish branches or pull requests, set **Agent internet access** to **On**, allow only `github.com` and `api.github.com`, and enable `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`, and `DELETE`. A read-only method policy can let `git push --dry-run` succeed while the real `POST /git-receive-pack` and GitHub API writes fail with HTTP 403. Keep broader internet access disabled unless the task explicitly needs it.
-8. Add a Codex environment secret named `GH_TOKEN` when Cloud tasks should push branches and create or update pull requests autonomously. Prefer a dedicated, revocable, fine-grained PAT whose owner is a member of the `sniffy` organization. Set the resource owner to `sniffy`, select only `sniffy/sniffy`, and grant Metadata read, Contents read/write, Pull requests read/write, and Issues read/write. Grant **Workflows read/write** whenever an authorized task may add, modify, rename, or delete files under `.github/workflows/`; Contents read/write alone cannot publish those changes. GitHub may describe the rejected push as requiring the classic-PAT `workflow` scope, while the equivalent fine-grained permission is **Workflows read/write**. The separate **Actions** permission controls workflow runs and Actions resources (for example dispatch, rerun, cancel, artifacts, and caches); it does not authorize workflow-file changes, so grant it only when a task must perform those operations. If organization policy requires approval, approve the newly created or modified token before resetting the Codex environment cache. GitHub does not support fine-grained PAT contributions from outside or repository collaborators; for such an account, either make it an organization member before issuing the token or, if organization policy permits, use a short-lived classic PAT with the `public_repo` and `workflow` scopes when workflow files are in scope.
-9. The setup script installs the pinned GitHub CLI release into `~/.local`, verifies its published SHA-256 checksum, then consumes `GH_TOKEN` while secrets are available, stores it in GitHub CLI's host configuration, and configures Git to use GitHub CLI as its credential helper. Its non-mutating `git push --dry-run` verifies setup-phase endpoint and credential-helper connectivity only; it does not prove token write permission or agent-phase `POST` access. The repository API's `.permissions.push` field is also insufficient because it reports the account role without proving that the token can write. This intentionally makes the credential available to the agent phase even though the `GH_TOKEN` environment variable itself is removed.
-10. Codex invalidates the environment cache when the setup script or secrets change. Use **Reset cache** if the next task still uses stale credentials or an inconsistent cached toolchain.
-11. In Codex settings, enable code review for this repository. Automatic review may be enabled after the review rules in `AGENTS.md` have produced useful results on several test pull requests.
+5. Enable agent internet access only when a task must publish or access GitHub. Allow `github.com` and `api.github.com`
+   and the HTTP methods required by the task. A policy that allows only read methods may let a dry-run appear healthy while
+   the real `git-receive-pack` or GitHub API write fails.
+6. Add `GH_TOKEN` when Cloud tasks should publish autonomously. Prefer a dedicated, revocable, fine-grained PAT owned by a
+   `sniffy` organization member and limited to `sniffy/sniffy`.
+7. Grant Metadata read, Contents read/write, Pull requests read/write, and Issues read/write. Grant Workflows read/write
+   only when authorized tasks may change files under `.github/workflows/`. The GitHub Actions permission controls workflow
+   runs and artifacts; it does not authorize edits to workflow files.
+8. Approve a new or changed token when organization policy requires approval, then reset the Codex environment cache.
+9. The setup script installs a pinned GitHub CLI release, verifies its checksum, persists the credential through `gh`, and
+   configures Git's credential helper. Its dry-run push proves endpoint and credential-helper connectivity, not effective
+   write permission or agent-phase network policy.
+10. Use **Reset cache** after setup scripts, secrets, token approval, or environment policy changes.
+11. Enable Codex code review for this repository after the rules in `AGENTS.md` have been smoke-tested.
 
-The setup phase has internet access and the agent phase follows the environment's configured internet policy. Cached environments may be reused, so the maintenance script must remain safe and idempotent.
+### Credential safety and rollback
 
-### Credential safety, identity, and rollback
+Persisting GitHub authentication exposes the credential to repository code, build plugins, dependencies, and processes
+running as the environment user. Treat this as an explicit security trade-off.
 
-Persisting GitHub authentication for the agent phase intentionally makes the credential available to repository code,
-build plugins, dependencies, and other processes running as the container user. Treat that as an explicit security
-trade-off, not as a hidden setup detail.
+- Prefer a dedicated agent account, short expiration, and least privilege.
+- Never place tokens in remote URLs, command lines, commits, logs, summaries, or fixtures.
+- Protect `develop` with required pull requests and block force pushes and deletion. Automation identities must not bypass
+  the ruleset.
+- A fine-grained PAT cannot be restricted to one branch, so branch safety belongs in GitHub rules.
+- Keep commit author, GitHub actor, Codex task, and human reviewer identities distinct when formal review matters.
+- Revoke immediately after credential exposure or an unexpected write. Reset cached environments and verify the revoked
+  credential no longer authenticates.
 
-- Use a dedicated agent or machine account when possible, a short expiration, and repository-only least privilege.
-  Treat Workflows read/write as an additional high-impact capability and omit it from environments whose tasks never
-  edit `.github/workflows/`.
-- Never place a token in a remote URL, command line, commit, log, task summary, or test fixture.
-- Protect `develop` with server-side rules that require pull requests and block force pushes and deletion. The token
-  owner and administrators used by automation must not bypass those rules. Local hooks are defense in depth only.
-- A fine-grained PAT cannot be limited to one branch or to fast-forward updates, so branch/ruleset enforcement belongs
-  on GitHub rather than in agent instructions alone.
-- Git commit author, GitHub push/API actor, and Codex task identity are different. Use a dedicated authenticated agent
-  account to make publication provenance clear and to preserve the human maintainer's ability to submit formal reviews.
-- Revoke the token immediately if it appears in output, an unexpected branch is updated, or required rules fail. Remove
-  the secret, reset the Cloud environment cache, and verify that the old credential no longer authenticates.
+The historical `SNIFFY_GITHUB_PAT` bootstrap is superseded by `GH_TOKEN` plus GitHub CLI. Do not add a parallel credential
+store.
 
-The earlier `SNIFFY_GITHUB_PAT` bootstrap proposed in PR #635 is superseded by the repository's current `GH_TOKEN` and
-GitHub CLI setup. Do not add a second credential store or parallel authentication path.
+## 3. Validate the environment
 
-## 3. Validating the environment
+Run a small Cloud task that reads `AGENTS.md`, reports Java/Maven/`gh` versions, checks `gh auth status`, performs a
+reversible remote-ref round trip, switches between JDK 8 and JDK 25, runs `git diff --check`, and executes one focused test
+without leaving a branch or PR.
 
-Start a small cloud task on `develop` with this prompt:
-
-```text
-Validate the Sniffy development environment only. Read AGENTS.md, report the active Java and Maven versions, report `gh --version`, and verify GitHub authentication with `gh auth status --hostname github.com`. Prove effective token and agent-network write access with a reversible remote-ref round trip: set `probe_branch="agent/codex-auth-check-$(git rev-parse --short=12 HEAD)"`, run `git push --porcelain https://github.com/sniffy/sniffy.git "HEAD:refs/heads/${probe_branch}"`, delete it with `gh api --method DELETE "repos/sniffy/sniffy/git/refs/heads/${probe_branch}"`, and confirm `git ls-remote --heads https://github.com/sniffy/sniffy.git "${probe_branch}"` returns no ref. Stop and report the exact output if creation or cleanup fails. Switch to JDK 8 and JDK 25 using .codex/cloud/use-jdk.sh, run git diff --check, and run one small focused Maven test without changing tracked files. Report every command and result. Do not leave a remote branch or open a pull request.
-```
-
-For manual validation inside a shell:
+For manual toolchain validation:
 
 ```bash
 source .codex/cloud/use-jdk.sh 8
 mvn -version
-
 source .codex/cloud/use-jdk.sh 25
 mvn -version
 ```
 
 ### Cross-JDK and time-bounded validation
 
-Switching `JAVA_HOME` does not invalidate Maven outputs. When two JDKs are used in one worktree, the first Maven command
-under each newly selected JDK must include `clean`, or the runs must use isolated checkouts/output directories. Otherwise
-a Java 8 run can reuse `target/` classes compiled by a newer JDK and fail with misleading linkage errors such as a
-covariant `ByteBuffer.position(int)` or `limit(int)` descriptor that Java 8 does not provide.
+Switching `JAVA_HOME` does not invalidate Maven output. The first Maven command under each newly selected JDK must use
+`clean`, or the runs must use isolated output/checkouts. Otherwise Java 8 may execute classes compiled against a newer JDK
+and fail with misleading linkage errors such as covariant `ByteBuffer.position(int)` or `limit(int)` descriptors.
 
-For Java 8 artifacts, distinguish three separate proofs:
+For Java 8 artifacts distinguish:
 
-1. a clean compile and focused test on real JDK 8;
-2. a modern-JDK `verify` run that executes the configured Java 8 API-signature check;
-3. for compatibility-sensitive code, execution on real JDK 8 of the same artifact built on the modern JDK, without
-   recompiling that artifact under JDK 8.
+1. clean compile and focused tests on real JDK 8;
+2. a modern-JDK `verify` that executes the configured Java 8 API-signature check;
+3. for compatibility-sensitive code, execution on real JDK 8 of the same artifact built on the modern JDK without
+   recompiling that artifact under Java 8.
 
-Run independent focused, cross-version, regression, and diff checks as separate commands. Give an intentionally bounded
-command its own explicit timeout and report the timeout exit status. Do not manually interrupt a combined command and
-present the earlier parts as one completed validation result. If the full reactor cannot finish within the Cloud task
-window, report the focused results separately and make the corresponding GitHub Actions run the authoritative
-full-reactor proof.
+Run independent obligations as separate commands with visible exit statuses. Use explicit timeouts for intentionally
+bounded commands and report timeout status. Do not manually interrupt one combined command and describe its earlier steps
+as a completed validation result.
 
-## 4. Definition of Ready for autonomous work
+## 4. Definition of Ready
 
-An issue is ready when it states:
+An autonomous issue is ready only when it states:
 
-- the desired observable outcome;
-- relevant current behavior, modules, and links;
-- product, compatibility, and migration decisions;
+- desired observable outcome;
+- relevant current behavior, modules, links, and existing PR/branch constraints;
+- product, compatibility, migration, and public-API decisions;
 - explicit non-goals;
 - testable acceptance criteria;
-- required JDKs, platforms, tests, and documentation;
-- branch/history constraints and external-service requirements;
+- required JDKs, platforms, tests, documentation, and external services;
 - whether the agent may commit/push and whether it should create or update a pull request.
 
-The issue must not delegate unresolved product decisions to Codex. Implementation choices may remain open when a conservative, maintainable answer can be derived from the repository.
+The issue must not delegate unresolved product decisions to Codex. Conservative implementation details may remain open
+when they can be derived from repository conventions.
 
 ### 4.1. Complex-task design and proof preflight
 
-A task needs a preflight before implementation when it combines two or more of these risk axes:
+A preflight is required when a task combines two or more high-risk axes:
 
 - a new published artifact or public API;
 - global mutable state, concurrency, resource ownership, or cleanup;
-- failure composition where primary and suppressed exceptions matter;
-- multiple JDK, framework, engine, or platform versions;
+- failure composition involving primary and suppressed exceptions;
+- several JDK, framework, engine, or platform versions;
 - cross-reactor module placement or a test-only compatibility consumer;
-- migration or compatibility requirements that can conflict with existing behavior.
+- migration or compatibility requirements that may conflict with existing behavior.
 
-The preflight is a short addition to the authoritative issue, not a speculative design document. It must resolve:
+The authoritative issue must resolve:
 
-1. **Scope boundary:** which modules and APIs may change, and which tempting adjacent redesigns are excluded.
-2. **Architecture ownership:** where production code, test-only consumers, compatibility checks, and documentation belong.
-3. **Lifecycle/failure matrix:** success, user failure, framework failure, partial setup, cleanup failure, and combined failure.
-4. **Compatibility matrix:** the exact built artifact, runtime/JDK/framework combinations, and whether sources are rebuilt or the same artifact is consumed.
-5. **Acceptance-to-proof matrix:** every criterion mapped to a focused test, CI job, static inspection, or explicitly documented manual check.
-6. **Delivery topology:** base/head branch, existing or new PR, PR author identity, draft/ready transition, and publication verification.
+1. scope boundaries and excluded adjacent redesigns;
+2. ownership of production code, test-only consumers, compatibility checks, and documentation;
+3. lifecycle/failure matrix including setup, user failure, framework failure, cleanup, and combined failure;
+4. exact artifact/runtime/framework compatibility matrix and whether the same artifact or rebuilt sources are exercised;
+5. acceptance-to-proof matrix mapping every criterion to named tests, CI jobs, static checks, or documented manual proof;
+6. delivery topology: base/head branch, new or existing PR, author identity, draft/ready behavior, and publication proof.
 
-If the preflight exposes a product decision—especially whether to add a public/core API or preserve unrelated global
-state—the delivery lead resolves it before dispatch. Codex should not infer such a decision from a cleanup requirement.
+A green build proves only the tests that were actually discovered and executed. Confirm named tests in Surefire/CI output.
 
-A green build is evidence only for tests that were actually discovered and executed. The proof matrix must name the
-test class or CI job and later be checked against Surefire/CI output.
+### 4.2. Slice by independently useful delivery, not by file count
 
-### 4.2. Slicing complex work without creating micro-PR overhead
+Create separate issues or PRs only when slices are independently useful, reviewable, and mergeable. For a cohesive
+cross-cutting feature, prefer one draft PR with explicit checkpoints for skeleton/boundary, lifecycle behavior, failure
+matrix, cross-version consumer, and documentation/proof audit.
 
-Split work into separate issues or pull requests only when the slices are independently useful, reviewable, and
-mergeable. Do not create a PR per test or per callback merely to make the task look smaller.
-
-For a cohesive cross-cutting feature, prefer one draft PR with explicit implementation checkpoints:
-
-1. module/artifact skeleton and compatibility boundary;
-2. production lifecycle and happy-path tests;
-3. failure/cleanup matrix and regression tests;
-4. cross-version consumer and reactor/CI wiring;
-5. documentation, final proof-matrix audit, and ready-for-review handoff.
-
-A short read-only design/refinement task before implementation is often cheaper than multiple review/fix loops. For a
-feature that combines global state, failure composition, and multiple runtime versions, use that refinement step even
-when the final implementation remains one PR.
+A short read-only design/proof task is often cheaper than several review/fix rounds.
 
 ### 4.3. Standard tooling and infrastructure gate
 
-`AGENTS.md` is the canonical policy for standard tooling and bespoke infrastructure. During refinement, first determine
-whether a maintained tool, official action, platform feature, or declarative configuration already covers the
-requirement. Prefer configuring or composing that standard capability over custom build, CI, release, dependency, or
-security code.
+Before custom build, CI, release, dependency, security, formatting, linting, reporting, packaging, or scaffolding code,
+check maintained tools, official actions, platform features, and declarative configuration. Missing maintainer-approved
+rationale required by `AGENTS.md` is a Definition-of-Ready failure, not permission to invent a framework.
 
-Do not dispatch bespoke infrastructure unless the authoritative issue contains the maintainer-approved alternatives and
-rationale required by `AGENTS.md`. Apply the additional trigger, permissions, required-check, noise, response, ownership,
-lifecycle, and overlap analysis before adding a workflow or materially new job. Missing rationale is a Definition-of-Ready
-failure. If the need emerges during another task, stop and refine a separate infrastructure issue before implementation.
+If an unrelated task discovers a need for shared infrastructure, stop and refine a separate issue with alternatives,
+ownership, permissions, failure/noise behavior, deterministic testing, upgrade path, and removal condition.
 
-## 5. Routing tasks
+## 5. Route work to the right executor
 
 ### Use Codex Cloud by default when
 
 - work starts from a clean branch based on `develop`;
-- the task is well specified and can be validated in the cloud container;
-- dependencies are public or can be installed in the setup phase;
-- no unusual Git history surgery is required;
-- no private local service, hardware, proprietary IDE, or operating-system-specific environment is required;
-- the task can finish as a reviewable diff or draft pull request.
+- the task is isolated, well specified, and provable in the cloud environment;
+- dependencies are public or installed during setup;
+- no unusual Git history surgery, local hardware, private service, or special networking is required;
+- the task can finish as a reviewable diff or published pull request within the task window.
 
-Examples: focused fixes, tests, documentation, ordinary refactoring, dependency updates, adding a new isolated module, and most issue-driven implementation.
+Examples include focused fixes, tests, docs, ordinary refactoring, dependency updates, and isolated modules.
 
-### Use unattended local Codex in an isolated VM or dev container when
+### Use the app-native local worker when
 
-- the existing branch and commit ancestry must be manipulated precisely;
-- the task needs unrestricted Git/GitHub CLI operations against an existing pull request;
-- several local services, Docker, special networking, hardware, or corporate resources are needed;
-- debugging requires an environment not available in Codex Cloud;
-- the task is broad enough that persistent local artifacts and manual inspection are valuable.
+- an existing branch/PR must be updated precisely;
+- persistent artifacts or long builds improve iteration;
+- Docker, browsers, local services, special networking, hardware, or privileged tools are needed;
+- Remote visibility from mobile and a dedicated issue chat are valuable;
+- repeated Cloud cold starts or time windows are material.
 
-The local run should still be non-interactive: use `--ask-for-approval never`, run inside a disposable VM/container, put the complete specification in the issue, and instruct the agent to implement, test, commit, push, and update the draft pull request without asking routine questions.
+Follow [`docs/local-codex-worker.md`](local-codex-worker.md). The app-native topology is:
 
-Recommended launcher:
+```text
+one persistent in-chat dispatcher
+  -> no eligible issue: NO_CHANGE, no new chat/worktree
+  -> eligible issue: one-time standalone task
+       -> one dedicated worker chat
+       -> one isolated worktree
+       -> in-chat PR continuation at 15 min, 15 min, then hourly
+```
+
+The dispatcher uses [`.codex/local/scheduled-task-prompt.md`](../.codex/local/scheduled-task-prompt.md), never implements
+source changes, and claims at most one issue. It renders
+[`.codex/local/worker-task-prompt.md`](../.codex/local/worker-task-prompt.md) into the one-time child task.
+
+The worker implements, tests, publishes, and then supervises its PR in the same worker chat. Every follow-up inspects the
+latest complete diff, review comments/threads, and CI. It approves only through an independent permitted reviewer identity;
+otherwise it reports the identity limitation. Blocking defects receive one precise Request Changes review or equivalent
+blocking comment. No task merges or enables auto-merge without explicit instruction.
+
+Before enabling the recurring dispatcher, smoke-test that the installed desktop app allows an in-chat scheduled run to
+create one one-time standalone child task. If that app-native composition is unavailable, pause the dispatcher and create
+the child manually in the app. Do not add an external observer, App Server integration, or UI automation without a
+separately approved design.
+
+### Use the unattended local CLI only as a fallback
 
 ```bash
 bash .codex/local/run-issue.sh NUMBER [BRANCH_NAME]
 ```
 
-The script requires authenticated `gh`, a clean working tree, and an installed Codex CLI. It fetches the issue text, switches to an existing issue branch or creates `agent/issue-NUMBER` from the default branch, and starts Codex with `gpt-5.6-sol`, Extra High reasoning, no approvals, search enabled, and `danger-full-access`. Override the defaults with `CODEX_MODEL` and `CODEX_REASONING_EFFORT`.
+The script requires authenticated `gh`, a clean tree, and Codex CLI. It prepares or reuses an issue branch and starts an
+unattended local agent. A CLI run is not an app-owned task and does not provide the same desktop/Remote chat lifecycle. Do
+not launch it from an app Scheduled task because that creates a nested agent with split context.
 
-`danger-full-access` is appropriate only inside the isolated environment because it grants the agent the same filesystem and network authority as the executing user.
+`danger-full-access` is appropriate only inside the disposable environment because it grants the agent the same authority
+as its operating-system user.
 
-For the app-native Windows VM route, follow [Local Codex worker on a Windows virtual machine](local-codex-worker.md). Its ChatGPT desktop app Scheduled task claims and executes one ready project item directly so the run remains visible through the app and Remote. `.codex/local/run-issue.sh` remains the unattended CLI fallback; do not invoke it from inside an app Scheduled task.
+## 6. Start and follow up Cloud work
 
-## 6. Starting and following up cloud work
+1. Refine the issue with the autonomous task template and complete any required preflight.
+2. Start implementation with a top-level issue comment containing `@codex`. Record the comment URL and do not call work
+   started until the connector reacts or posts a task link. A review mention alone is not a reliable implementation trigger.
+3. Select the `sniffy` environment and current `develop`; use stronger reasoning for complex architectural work.
+4. Ask for implementation, validation, real GitHub publication, and a ready-for-review handoff, not merely a plan or local
+   commit.
+5. Require the agent to push, create/update the intended PR, and verify remote branch, full SHA, PR URL, base/head, draft
+   state, and PR head through GitHub. A dry-run push is not publication.
+6. Treat Codex UI metadata as informative. GitHub branch, commit, PR, reviews, and checks are authoritative.
+7. Review the complete remote diff, issue acceptance/proof matrix, `AGENTS.md`, comments, threads, and CI. Confirm named
+   tests executed; do not approve from the agent summary.
+8. For corrections, leave precise feedback and a separate explicit `@codex` dispatch comment that links the existing PR,
+   branch, review, and required checks. Update the issue first when scope or architecture changes.
+9. Check after 15 minutes, again 15 minutes later, then hourly while incomplete. Verify acknowledgement or a new commit;
+   do not infer active work from a review alone.
+10. Request `@codex review` or rely on automatic review only after it has produced useful results on test PRs.
 
-1. Refine the issue with the autonomous task template. For a complex task, complete the design/proof preflight and make
-   the issue thread the authoritative dispatch record.
-2. Start implementation from a top-level issue comment containing `@codex`. Record the comment URL and do not describe
-   the task as started until the Codex connector reacts or posts a task link. A mention inside a submitted GitHub review
-   is not a reliable task trigger. Pull-request comment triggers additionally depend on Codex code review being enabled;
-   use the authoritative issue thread as the fallback for implementation and correction tasks.
-3. Select the `sniffy` environment and current `develop`. For complex architectural work, select the strongest available
-   coding model and High or Extra High reasoning.
-4. Ask for implementation, validation, actual GitHub publication, and a ready-for-review handoff—not merely a plan,
-   local commit, `make_pr` call, or draft that remains draft after the work is complete.
-5. Require the agent to push the branch, create or update the intended pull request, and verify the remote branch, full
-   commit SHA, pull-request URL, base/head branches, draft state, and head SHA through `git ls-remote`, `gh api`, and
-   `gh pr view` before reporting success. A dry-run push is not publication.
-6. Treat Codex Cloud UI metadata as informative rather than authoritative. A pull request created directly with `gh`
-   may not appear as attached in the Cloud UI; the resolvable GitHub branch, commit, and pull-request URLs are the source
-   of truth. A `GitHub Mention` card is task history, not evidence of an unpublished branch or PR. Avoid duplicate
-   mentions merely to republish the same work.
-7. Review the complete remote diff, issue acceptance criteria and proof matrix, `AGENTS.md`, comments, review threads,
-   and every relevant CI job. Confirm named tests were discovered and executed; do not approve from an agent summary.
-8. For bounded corrections, leave precise review feedback and dispatch a new top-level `@codex` comment on the
-   authoritative issue that links the existing pull request, branch, review, and required checks. If review changes
-   architecture or product scope, first update the issue and mark conflicting older guidance as superseded.
-9. Request a high-signal review with `@codex review`, or rely on automatic reviews after they have been enabled.
-
-A standard dispatch prompt is:
-
-```text
-@codex Implement the complete linked issue autonomously from current develop. Read AGENTS.md, docs/codex-workflow.md,
-and the entire issue thread first; the issue is authoritative. Make ordinary conservative engineering decisions without
-asking for routine clarification. Before editing, turn every acceptance criterion into a proof matrix and identify any
-unresolved scope, public-API, global-state, lifecycle, module-placement, or compatibility decision. Do not implement
-through a material ambiguity. Implement the change, add or update tests and documentation, run every applicable focused
-and repository check as separately reported commands, and review the final diff.
-
-Use a new agent/<short-description> branch unless the issue names an existing pull-request branch. Publish real GitHub
-state: push the branch, create or update the intended pull request using the authenticated agent account when authorized,
-and verify the remote branch, full commit SHA, pull-request URL, base/head branches, draft state, and head SHA with
-git ls-remote, gh api, and gh pr view. Do not treat a local commit, make_pr metadata, or a Cloud summary as publication.
-Use a draft while work is incomplete, then mark the pull request ready for review after implementation and locally
-applicable verification are complete unless this issue explicitly requires it to remain draft. Do not merge or enable
-auto-merge.
-
-During handoff, map each criterion to the focused test or CI job that proves it, confirm those tests actually executed,
-and reply on the issue and pull request with exact resolvable URLs, the full SHA, and exact check results. If a genuine
-blocker remains, stop without repeatedly rebuilding the same change and report the exact command/output plus the
-smallest permission or decision needed.
-```
+A standard dispatch prompt must require reading the authoritative issue and `AGENTS.md`, a proof matrix, conservative
+implementation, focused and repository checks, final-diff review, real publication and remote verification, draft-to-ready
+handoff when appropriate, and no merge or auto-merge.
 
 ### Review convergence and escalation
 
-The first review should be comprehensive: inspect the full diff, all acceptance criteria, test discovery/execution,
-module boundaries, compatibility evidence, documentation, and CI. Report independent findings together.
+The first review should be comprehensive: full diff, all criteria, test discovery, module boundaries, compatibility,
+documentation, and CI. Report independent findings together.
 
-After each follow-up, review the new delta and re-run the full proof matrix. Do not assume an older green run covers a
+After every correction, review the new delta and rerun the affected full proof matrix. An old green run does not cover a
 new head.
 
-Use a **two-substantive-round rule**: after two review/fix rounds, or immediately after an architectural/product-scope
-reversal, stop issuing another narrow patch prompt. Re-baseline the authoritative issue, collapse or mark superseded
-guidance, and choose one of:
+After two substantive review/fix rounds, or immediately after an architecture/product reversal, stop stacking narrow
+prompts. Re-baseline the issue and choose one fresh comprehensive Cloud task, app-native local continuation on the same
+branch, or a human design decision.
 
-- one fresh comprehensive Cloud task against the current remote head;
-- unattended local Codex on the same branch when persistent artifacts, long builds, or repeated debugging matter;
-- a human decision/design pass before further coding.
-
-Switching to local Codex can reduce cold-start and task-window friction, but it does not repair an ambiguous
-specification. The preflight and proof matrix remain mandatory for both routes.
+Changing executor does not repair an ambiguous specification.
 
 ## 7. Operating model
 
-### Product Owner — Dmitry
+### Product owner — Dmitry
 
-- defines desired outcomes, user value, priorities, and release constraints;
-- makes product and compatibility decisions when trade-offs affect users;
-- accepts or rejects the result after review.
+- defines outcomes, value, priorities, and release constraints;
+- resolves product and compatibility trade-offs;
+- accepts or rejects the reviewed result;
+- is the only authority that may explicitly request merge from this automation workflow.
 
 ### Delivery lead — ChatGPT
 
-- owns the book of work in GitHub Projects and issues;
-- converts discussions into issues with explicit requirements, non-goals, acceptance criteria, and validation;
-- selects Cloud, unattended local Codex, or human-led execution;
-- dispatches ready tasks and tracks the trigger reaction/task link, remote branch, pull request, blockers, CI, reviews,
-  and follow-ups;
-- distinguishes dispatched, working, locally complete, published, ready for review, approved, and merged states; never
-  infers one state from another or from an agent summary;
+- owns the book of work and turns discussions into authoritative issues;
+- selects Cloud, app-native local, CLI fallback, or human execution;
+- tracks trigger acknowledgement, worker chat/task, branch, PR, SHA, blockers, CI, reviews, and follow-ups;
 - reviews implementation and architecture against the issue and `AGENTS.md`;
-- keeps project status and issue descriptions current;
-- prepares a weekly retrospective.
+- distinguishes dispatched, working, locally complete, published, ready for review, approved, and merged;
+- never infers remote state from a summary and never merges without explicit instruction;
+- prepares the weekly retrospective.
+
+### App-native dispatcher
+
+- lives in one persistent local-project chat with an in-chat 15-minute schedule;
+- reads and claims at most one eligible local issue;
+- creates no task/chat/worktree for an empty queue;
+- creates one one-time standalone worker task for an eligible issue;
+- rolls back a claim when child creation fails;
+- never edits source code.
+
+### App-native worker
+
+- owns one dedicated issue chat and isolated worktree;
+- handles fresh implementation or an explicitly re-queued existing PR branch;
+- implements, tests, publishes, and verifies GitHub state;
+- creates one in-chat follow-up schedule at 15 minutes, another 15 minutes, then hourly;
+- checks full diff, reviews, and CI before formal review;
+- pauses follow-up when complete or blocked;
+- never merges.
 
 ### Codex Cloud
 
-- executes well-defined, isolated tasks in parallel;
-- follows `AGENTS.md`, implements and validates the change, and returns a reviewable diff or pull request;
-- does not make unresolved product decisions;
-- reports precise blockers instead of waiting for an interactive answer.
+- executes isolated, fully specified tasks in parallel;
+- follows `AGENTS.md`, publishes when authorized, and reports precise blockers;
+- does not make unresolved product decisions.
 
-### Unattended local Codex
+### Unattended local CLI
 
-- handles tasks requiring a privileged or specialized disposable environment, unusual branch operations, existing PR surgery, or services unavailable in Cloud;
-- receives the same issue-driven specification and Definition of Done;
-- commits, pushes, and updates the draft pull request when explicitly authorized.
+- remains a fallback for specialized isolated environments or when app-native task composition is unavailable;
+- follows the same issue, proof, publication, and no-merge contracts;
+- does not produce an app-owned Remote chat lifecycle.
 
 ## 8. Book-of-work states
 
@@ -317,51 +308,62 @@ Recommended GitHub Project states:
 1. `Idea` — captured but not refined.
 2. `Needs product decision` — blocked on outcome, compatibility, or scope.
 3. `Ready for agent` — satisfies Definition of Ready.
-4. `In progress: cloud` or `In progress: local` — dispatched with a task/branch link.
-5. `Agent blocked` — exact blocker and requested decision recorded in the issue.
-6. `Review` — draft PR exists and checks/review are in progress.
-7. `Ready to merge` — acceptance criteria and required checks pass.
+4. `In progress: cloud` or `In progress: local` — dispatched with durable task/worker/branch evidence.
+5. `Agent blocked` — exact blocker and smallest decision recorded.
+6. `Review` — published PR exists and checks/review are in progress.
+7. `Ready to merge` — acceptance criteria, review, and required checks pass.
 8. `Done` — merged or intentionally closed with rationale.
 
-Useful labels include `agent:cloud`, `agent:local`, `agent:blocked`, `needs:product`, `needs:review`, and `security`. Labels describe routing and attention; the GitHub Project status remains the workflow source of truth.
+Useful labels include `agent:cloud`, `agent:local`, `agent:blocked`, `needs:product`, `needs:review`, `security`, and optional
+model-routing labels. Project status remains authoritative.
+
+A local claim comment should record dispatcher/worker identity, child task title, fresh/continuation mode, branch, existing
+PR when applicable, model/reasoning, and timestamp. This evidence helps detect stale `In progress` claims without silently
+creating duplicate workers.
 
 ## 9. Review and Definition of Done
 
 The delivery lead reviews:
 
-- whether the implementation matches every acceptance criterion;
-- whether a standard maintained tool or declarative composition covers the requirement, and any bespoke infrastructure
-  or new workflow/job has the issue-level approval and operational rationale required by `AGENTS.md`;
-- compatibility and public API impact;
+- every acceptance criterion and its proof;
+- standard tooling versus bespoke infrastructure rationale;
+- compatibility, public API, lifecycle, and resource safety;
 - module boundaries and unnecessary complexity;
-- test quality, discovery, execution, and whether tests were weakened or made flaky;
-- exact commands and JDKs used;
+- test quality, discovery, execution, and attempts to weaken or retry failures;
+- exact commands and JDKs;
 - dependency/security changes;
 - documentation and migration impact;
-- accidental generated files or unrelated edits;
-- remote branch, PR head, draft/ready state, review threads, and relevant CI logs.
+- generated or unrelated files;
+- remote branch, PR head, draft/ready state, review threads, and CI logs;
+- whether the formal reviewer identity is independent from the PR author.
 
-A task is done only when the implementation is published and remotely verified, the pull request has reached the
-requested review state, required checks pass, known limitations are documented, review findings are resolved or accepted
-explicitly, and the issue/project state is updated.
+A task is done only when implementation is published and remotely verified, the requested PR state is reached, required
+checks pass, known limitations are documented, review findings are resolved or explicitly accepted, project state is
+updated, and the continuation schedule is paused. Approval is not merge.
 
 ## 10. Incident retrospectives
 
 - [Issue #637 / PR #643: Codex Cloud delivery and publication](retrospectives/2026-07-16-codex-cloud-issue-637.md)
 - [Issue #238 / PR #633: JUnit Jupiter delivery](retrospectives/2026-07-issue-238-junit-jupiter.md)
+- [Docusaurus: Cloud versus local routing](retrospectives/2026-07-18-docusaurus-cloud-vs-local.md)
+
+Historical retrospectives describe the system at the time of the incident. Current operational rules live in `AGENTS.md`,
+this document, `docs/local-codex-worker.md`, and the canonical local prompt files.
 
 ## 11. Weekly retrospective
 
-The weekly retrospective should cover:
+Cover:
 
 - completed and merged work;
-- work started, still running, or blocked;
-- lead time from `Ready for agent` to draft PR and merge;
-- cloud vs local routing decisions and whether they were correct;
+- work dispatched, running, in review, or blocked;
+- lead time from `Ready for agent` to published PR and merge;
+- Cloud versus local routing quality;
+- dispatcher no-op cycles, spawned worker chats, stale claims, and duplicate/failed child creation;
+- first/second 15-minute checks and hourly continuations that exceeded expectations;
 - CI failures, escaped defects, and repeated review findings;
-- tasks that required human clarification and how to improve their issue specification;
-- changes needed in `AGENTS.md`, setup scripts, templates, or the test matrix;
-- number of substantive review/fix rounds, whether the two-round re-baseline rule was triggered, and why;
-- the next week's top priorities and capacity risks.
+- tasks needing human clarification and how the issue template should improve;
+- changes needed in `AGENTS.md`, setup, prompts, templates, or test matrix;
+- substantive review/fix rounds and re-baseline decisions;
+- next-week priorities and capacity risks.
 
-The retrospective should result in concrete issue/template/instruction changes, not only a narrative summary.
+The retrospective must produce concrete issue/template/instruction changes, not only narrative.

--- a/docs/local-codex-worker.md
+++ b/docs/local-codex-worker.md
@@ -2,152 +2,105 @@
 
 This runbook describes an always-on local worker that can host Sniffy and other repositories, execute privileged,
 long-running, or Docker-heavy tasks, and remain observable from the ChatGPT desktop and mobile apps. The security
-boundary is a disposable Windows virtual machine; the Codex agent and developer toolchain run in WSL2 inside that VM.
-Sniffy is the first concrete project configuration, not the boundary of the worker.
+boundary is a disposable Windows virtual machine; the native ChatGPT/Codex app runs on Windows while its Codex agent and
+developer toolchain run in WSL2 inside that VM.
 
-The design was last checked against the linked product documentation on 2026-07-17.
+The design was last checked against the linked product documentation on 2026-07-26.
 
 ## 1. Architecture and decisions
 
 ```mermaid
 flowchart TD
-    Host["Windows host<br/>Hyper-V"] --> VM["Windows 11 VM<br/>disposable boundary"]
-    Phone["ChatGPT mobile<br/>Remote"] --> App["ChatGPT desktop app<br/>Codex + Scheduled"]
-    VM --> App
+    Host["Windows host<br/>Hyper-V"] --> VM["Windows 11 worker VM<br/>disposable boundary"]
+    VM --> App["Native ChatGPT/Codex app<br/>Windows"]
+    Phone["ChatGPT mobile<br/>Remote"] --> App
+    App --> Dispatcher["Persistent Sniffy Dispatcher chat<br/>in-chat task every 15 minutes"]
+    Dispatcher -->|"eligible issue"| WorkerTask["One-time standalone task"]
+    WorkerTask --> WorkerChat["Dedicated issue worker chat"]
+    WorkerChat --> Worktree["Isolated app-managed worktree"]
+    Dispatcher -->|"empty queue"| NoOp["NO_CHANGE<br/>no new chat or worktree"]
     App --> WSL["Codex agent<br/>Ubuntu on WSL2"]
-    WSL --> Repo["Project checkouts<br/>repo-specific tools"]
+    Worktree --> WSL
+    WSL --> Repo["Git, gh, Java, Maven, Node"]
     WSL --> Docker["Docker Engine<br/>Playwright and services"]
+    WorkerChat --> FollowUp["In-chat PR follow-up<br/>15 min, 15 min, then hourly"]
 ```
 
 The important choices are:
 
-- Run the ChatGPT desktop app on Windows because the app supplies local projects, worktrees, Scheduled tasks, review
-  UI, and [Remote connections](https://learn.chatgpt.com/docs/remote-connections) from mobile.
-- Configure the app's Codex agent to run in WSL2. Local setup scripts then run in WSL, so Bash, `curl`, Linux Docker,
-  and the existing repository scripts work without Cygwin.
-- Treat the complete Windows VM as disposable and trusted by the agent. Full access inside the VM is acceptable only
-  because the VM has no access to host files, host credentials, or repositories outside the explicitly registered
-  worker portfolio.
-- Install Docker Engine inside WSL2. Containers are tools available to Codex, not the outer isolation boundary.
-- Use a dedicated GitHub identity and short-lived, owner- and repository-scoped credentials. GitHub branch rules
-  remain the final write boundary.
-- Use a ChatGPT desktop app Scheduled task as the dispatcher. A shell script can launch `codex exec`, but that is a CLI
-  run rather than a supported way to inject a new local task into the app UI.
+- Run the native ChatGPT/Codex desktop app on Windows because the app supplies local projects, worktrees, Scheduled tasks,
+  review UI, and [Remote connections](https://learn.chatgpt.com/docs/remote-connections) from mobile.
+- Configure the app's Codex agent and integrated terminal to use WSL2. Repository paths, Git, `gh`, Java, Maven, Node,
+  Docker, and tests then stay inside Linux.
+- Use one persistent **in-chat** Scheduled task as the dispatcher. Empty polling cycles return to that same chat and do
+  not create Remote-chat or worktree clutter.
+- For a real issue, let the dispatcher create one **one-time standalone** Scheduled task. That task creates one dedicated
+  worker chat and one isolated worktree, making implementation easy to follow from desktop or mobile.
+- Keep PR supervision in the same worker chat. The worker creates or updates an in-chat continuation task: first check
+  after 15 minutes, second check 15 minutes later, then hourly until completion or a human decision.
+- Do not use a recurring standalone dispatcher: it creates a new chat for every poll, including no-op polls.
+- Do not use Python observers, shell UI automation, `codex app-server`, or nested `codex exec` for the app-native path.
+- Treat the complete Windows VM as disposable and trusted by the agent. Full access is acceptable only because the VM has
+  no host files, host credentials, or unrelated repositories.
+- Use a dedicated GitHub identity and repository-scoped credentials. GitHub rulesets remain the final write boundary.
+- Never merge or enable auto-merge without an explicit command from Dmitry.
 
-This worker complements Codex Cloud. Route ordinary clean, bounded tasks to Cloud and use this worker when persistent
-artifacts, Docker, special networking, privileged tools, or long debugging sessions make a local environment preferable.
+This worker complements Codex Cloud. Route clean, bounded tasks to Cloud and use the local worker when persistent
+artifacts, Docker, special networking, privileged tools, existing-branch surgery, or long debugging sessions matter.
 
-## 2. Host and VM prerequisites
+## 2. Host and worker VM
 
-### 2.1. Host
+### 2.1. Host requirements
 
-The physical Hyper-V host must run Windows 11 Pro, Enterprise, or another edition that includes the full Hyper-V
-feature, as listed in Microsoft's [Hyper-V host requirements](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/host-hardware-requirements#operating-system-requirements).
-This host requirement does not require the Windows guest to use the same edition. Enable AMD-V/SVM in UEFI and enable
-Hyper-V from an elevated PowerShell session:
+The physical host must run a Windows edition that includes Hyper-V and have hardware virtualization enabled. Follow
+Microsoft's [Hyper-V host requirements](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/host-hardware-requirements#operating-system-requirements)
+and [nested virtualization](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/enable-nested-virtualization)
+guidance.
+
+Enable Hyper-V from elevated PowerShell and reboot:
 
 ```powershell
 Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 ```
 
-Restart the host and verify:
+Verify:
 
 ```powershell
 systeminfo.exe
 Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V-All
 ```
 
-Microsoft supports nested virtualization on Windows 11 hosts with AMD Ryzen or later processors. The outer VM must use
-configuration version 9.3 or later. See [Run Hyper-V in a virtual machine with nested
-virtualization](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/enable-nested-virtualization).
-
 ### 2.2. Recommended allocation
 
-For a Ryzen 9 9900X host with 64 GB RAM:
+For a Ryzen 9 9900X host with 64 GB RAM, start with:
 
 | Resource | Worker VM | Rationale |
 | --- | ---: | --- |
-| Virtual processors | 12 | Leaves half of the host's 24 logical processors available |
-| Memory | 32 GB static | Enough for Windows, WSL, Maven, Docker, and browser tests without nested-memory resizing |
-| System disk | 300 GB dynamically expanding | Room for Maven, npm, Docker layers, worktrees, and logs |
-| VM generation | 2 | Required for Windows 11 Secure Boot and virtual TPM |
-| Network | Hyper-V Default Switch initially | NAT outbound access without exposing host files |
+| Virtual processors | 12 | Leaves half of the host's logical processors available |
+| Memory | 32 GB static | Windows, WSL, Maven, Docker, and browser tests |
+| System disk | 300 GB dynamically expanding | Tool caches, Docker layers, worktrees, and logs |
+| VM generation | 2 | Windows 11 Secure Boot and virtual TPM |
+| Network | Hyper-V Default Switch | NAT outbound access without host shares |
 
-These are starting values, not a compatibility contract. Static memory removes one source of nested-virtualization
-surprises. Reduce Docker/WSL concurrency before assigning so much memory that the host starts paging.
+Use static memory initially because nested WSL and Docker are easier to reason about without two layers of dynamic
+memory. Reduce concurrency before allowing the physical host to page.
 
-### 2.3. Windows media and licensing
+### 2.3. Windows guest and licensing
 
-Choose the guest edition separately from the physical host edition:
+Windows 11 Home supports WSL2, but Pro is recommended for administration and RDP. A permanent Windows guest requires a
+license that permits the additional VM; the physical host license does not automatically license a second instance. The
+official Windows 11 Enterprise Evaluation is suitable for proving the setup, but rebuild or assign a valid license before
+its evaluation expires. Do not use activation bypasses or unofficial images.
 
-| Guest option | WSL2 | Full Hyper-V role | Licensing use |
-| --- | --- | --- | --- |
-| Windows 11 Enterprise Evaluation | Yes | Yes | Free, licensed 90-day evaluation; best for proving the setup |
-| Windows 11 Home | Yes | No | Smallest sufficient long-lived guest after assigning a valid Home license |
-| Windows 11 Pro | Yes | Yes | Recommended here for RDP and easier administration after assigning a valid Pro license |
+Use the stable names `bedrin-worker-1`, `bedrin-worker-2`, and store them under `C:\work\vms\<name>`. Keep the official
+installation image at `C:\work\iso\windows.iso`.
 
-Windows 11 Home is technically sufficient for the worker guest. Microsoft explicitly supports WSL2 on
-[Windows 11 Home](https://learn.microsoft.com/en-us/windows/wsl/faq#is-wsl-2-available-on-windows-10-home-and-windows-11-home).
-WSL2 uses the **Virtual Machine Platform** subset of Hyper-V, which is available on all Windows desktop editions; it
-does not require the guest to expose the complete Hyper-V management role. Microsoft also supports
-[WSL2 inside a Hyper-V VM](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/nested-virtualization#run-wsl2-in-a-hyper-v-vm-running-nested-on-hyper-v)
-when nested virtualization is enabled. The physical host still needs Pro or Enterprise because it creates and runs the
-outer VM.
-
-For the first build, either use the official
-[Windows 11 Enterprise 90-day evaluation](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-11-enterprise) or
-download Microsoft's normal [multi-edition Windows 11 ISO](https://www.microsoft.com/en-us/software-download/windows11)
-and install Pro. Home remains technically sufficient, but this runbook recommends Pro because accepting inbound RDP
-and using its administration tools are useful when operating an unattended worker. Treat the evaluation as disposable
-and plan to rebuild rather than assuming it can be converted in-place to Home or Pro later.
-
-The normal installer allows **I don't have a product key**, but an unactivated Home or Pro installation is not a free
-license. A host Windows license does not automatically license a second Windows instance in a VM. For a permanent
-licensed guest, assign a separate valid license that permits that VM. See [Activate
-Windows](https://support.microsoft.com/en-us/windows/activation/activate-windows) and the
-[Windows license terms](https://www.microsoft.com/en-us/useterms). Do not use activation bypasses or unofficial KMS
-services.
-
-If Microsoft's ISO page returns message code `715-123130` or says that anonymous or location-hiding technology is not
-allowed, retry from the normal unproxied connection without a VPN. On a Windows machine, the official **Create Windows
-11 Installation Media** option on the same download page can create an ISO instead. Do not substitute an unofficial
-mirror for a worker image that will hold credentials.
-
-## 3. Create the Hyper-V VM
-
-The Hyper-V Manager wizard is acceptable. The following PowerShell path makes the intended VM shape reproducible.
-
-### 3.1. Save and run the creation script
-
-Use the stable naming pattern `bedrin-worker-<number>`: the first VM and its Windows hostname are
-`bedrin-worker-1`, and a later independent worker becomes `bedrin-worker-2`. Keep every worker under
-`C:\work\vms\<vm-name>` and keep the reusable installation image at `C:\work\iso\windows.iso`.
-
-Open **Windows PowerShell as Administrator** on the physical host. Create the VM storage directory and open the reusable
-creation script in Notepad:
+A reproducible first VM can be created from elevated PowerShell:
 
 ```powershell
-New-Item -ItemType Directory -Force -Path "C:\work\vms"
-notepad.exe "C:\work\vms\create-bedrin-worker.ps1"
-```
-
-Accept Notepad's prompt to create the file, paste the complete script below, and save and close Notepad. Starting
-Notepad with the full `.ps1` path avoids accidentally saving `create-bedrin-worker.ps1.txt`.
-
-```powershell
-param(
-  [ValidateRange(1, 99)]
-  [int] $WorkerNumber = 1
-)
-
-$vmName = "bedrin-worker-$WorkerNumber"
-$vmRoot = Join-Path "C:\work\vms" $vmName
+$vmName = "bedrin-worker-1"
+$vmRoot = "C:\work\vms\$vmName"
 $isoPath = "C:\work\iso\windows.iso"
-$switchName = "Default Switch"
-
-if (-not (Test-Path -LiteralPath $isoPath -PathType Leaf)) {
-  throw "Windows ISO not found: $isoPath"
-}
 
 New-Item -ItemType Directory -Force -Path $vmRoot
 New-VM `
@@ -156,7 +109,7 @@ New-VM `
   -MemoryStartupBytes 32GB `
   -NewVHDPath "$vmRoot\system.vhdx" `
   -NewVHDSizeBytes 300GB `
-  -SwitchName $switchName
+  -SwitchName "Default Switch"
 
 Set-VMProcessor -VMName $vmName -Count 12 -ExposeVirtualizationExtensions $true
 Set-VMMemory -VMName $vmName -DynamicMemoryEnabled $false -StartupBytes 32GB
@@ -164,79 +117,17 @@ Set-VMFirmware -VMName $vmName -EnableSecureBoot On -SecureBootTemplate Microsof
 Set-VMKeyProtector -VMName $vmName -NewLocalKeyProtector
 Enable-VMTPM -VMName $vmName
 Set-VM -Name $vmName -AutomaticStartAction Start -AutomaticStopAction Save
-
 $dvd = Add-VMDvdDrive -VMName $vmName -Path $isoPath -Passthru
 Set-VMFirmware -VMName $vmName -FirstBootDevice $dvd
 ```
 
-The script deliberately creates the VM without starting it. In the same elevated PowerShell window, allow scripts only
-for that PowerShell process and execute the saved file:
+Install Windows with a dedicated low-value local account. Do not add host drive sharing, a personal browser profile,
+email, cloud drives, password managers, or employer credentials. Apply Windows Update, disable guest sleep, and create a
+clean pre-credential checkpoint.
 
-```powershell
-Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-& "C:\work\vms\create-bedrin-worker.ps1" -WorkerNumber 1
-```
+## 3. Install and constrain WSL2
 
-This creates `bedrin-worker-1` under `C:\work\vms\bedrin-worker-1`. To create the second worker later, run the
-same script with `-WorkerNumber 2`; do not clone a credential-bearing first VM. The process-scoped override does not
-weaken the permanent machine or user execution policy and disappears when the PowerShell window closes. Do not use a
-machine-wide `Unrestricted` policy for this runbook.
-
-Windows 11 VMs require Generation 2, Secure Boot, a virtual TPM, at least 4 GB RAM, two virtual processors, and 64 GB
-storage. See [Windows 11 requirements: virtual machine
-support](https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements#virtual-machine-support).
-
-### 3.2. Open Hyper-V Manager and boot the ISO
-
-Open the manager from Start by searching for **Hyper-V Manager**, or run:
-
-```powershell
-virtmgmt.msc
-```
-
-In Hyper-V Manager:
-
-1. Select the local host in the left pane. If it is absent, use **Action > Connect to Server > Local computer**.
-2. Find **bedrin-worker-1** in the center **Virtual Machines** pane.
-3. Right-click **bedrin-worker-1**, select **Connect**, and leave the VMConnect console in the foreground.
-4. Click **Start** in VMConnect.
-5. Immediately click inside the console and press **Space** repeatedly until Windows Setup appears.
-
-An official Windows ISO briefly displays **Press any key to boot from CD or DVD**. One keypress is technically enough
-after VMConnect has keyboard focus, but repeated Space presses are a reliable way to acquire focus and catch the
-short prompt. If the Hyper-V UEFI boot summary appears instead, click **Restart now**, click inside the console, and
-repeat the Space presses. On later installer-initiated reboots, do **not** press a key; let the VM boot from its virtual
-disk instead of restarting setup from the ISO.
-
-During Windows setup:
-
-1. Select Windows 11 Pro, not a regional `N` edition. Home supports WSL2, but Pro makes later RDP and administration
-   easier.
-2. Give Windows the same device name as the Hyper-V VM: `bedrin-worker-1`. Use `bedrin-worker-2` for the later
-   second worker.
-3. To create a local account during Windows 11 Pro OOBE, choose **Set up for work or school**, then
-   **Sign-in options > Domain join instead**. Despite the label, this path creates a local account and does not require
-   joining a domain.
-4. If that option is absent or OOBE has already passed it, finish setup with a dedicated temporary Microsoft account,
-   then use **Settings > Accounts > Your info > Sign in with a local account instead**. Microsoft documents this
-   conversion in [Change from a Microsoft account to a local
-   account](https://support.microsoft.com/en-US/accounts-billing/manage/change-from-a-local-account-to-a-microsoft-account-in-windows).
-   Remove the temporary identity from **Email & accounts** and unlink OneDrive afterward.
-5. Use a dedicated local Windows username such as `worker` and set a strong non-empty password because RDP will need
-   it. Do not use a personal or employer Microsoft account for this VM.
-6. Do not sign into GitHub, email, cloud drives, or password managers used on the host.
-7. Apply Windows Update and reboot until no important update remains.
-8. Disable sleep inside the guest. The host may still save the VM during shutdown.
-9. Do not enable shared host drives. Avoid clipboard and device redirection when using an enhanced session.
-10. Create a clean checkpoint before adding ChatGPT and GitHub credentials.
-
-Checkpoints and VM exports made after login contain cached credentials. Store them only on an encrypted host volume and
-treat them as secrets.
-
-## 4. Install and constrain WSL2
-
-In an elevated PowerShell terminal inside the Windows VM, update WSL, confirm that the explicitly versioned
-distribution is available, and install Ubuntu 26.04 LTS:
+Inside the Windows VM, use elevated PowerShell:
 
 ```powershell
 wsl --update
@@ -245,34 +136,20 @@ wsl --install -d Ubuntu-26.04
 wsl --set-default-version 2
 ```
 
-If the Microsoft Store path fails but `Ubuntu-26.04` appears in the online list, retry the install using WSL's web
-download path:
-
-```powershell
-wsl --install --web-download -d Ubuntu-26.04
-```
-
-Do not use the floating `Ubuntu` name in provisioning: an explicit distribution name keeps later workers on the same
-release. Microsoft documents the distribution list, named installs, and `--web-download` fallback in
-[Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Restart Windows, finish the Ubuntu user setup,
-and verify that the distribution is version 2:
+If the Store path fails, retry with `--web-download`. Restart Windows, finish the Linux user setup, and verify:
 
 ```powershell
 wsl --status
 wsl --list --verbose
 ```
 
-If WSL reports that virtualization is unavailable, stop the VM and re-run this command on the physical host:
+If nested virtualization is reported unavailable, stop the guest and run this on the physical host:
 
 ```powershell
 Set-VMProcessor -VMName "bedrin-worker-1" -ExposeVirtualizationExtensions $true
 ```
 
-Running WSL2 inside a Hyper-V VM is a supported nested-virtualization scenario. See Microsoft's
-[nested virtualization overview](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/nested-virtualization#run-wsl2-in-a-hyper-v-vm-running-nested-on-hyper-v).
-
-Optionally constrain the nested WSL VM in `%USERPROFILE%\.wslconfig` so that Windows retains resources for the desktop
-app:
+Optionally reserve resources for the Windows app in `%USERPROFILE%\.wslconfig`:
 
 ```ini
 [wsl2]
@@ -281,127 +158,60 @@ processors=10
 swap=8GB
 ```
 
-Apply changes with:
+Apply changes with `wsl --shutdown`. The outer Windows VM is the security boundary; WSL resource limits are not a
+security boundary.
 
-```powershell
-wsl --shutdown
-```
+## 4. Install the desktop app and Remote
 
-The outer Hyper-V VM remains the security boundary; `.wslconfig` is resource control, not security isolation.
+Install the current native Windows app inside the VM. Then:
 
-## 5. Install the ChatGPT desktop app and Remote
+1. Sign in with the same ChatGPT account and workspace used by the mobile app.
+2. In **Settings**, switch the Codex agent from Windows native to **WSL** and restart the app.
+3. Select WSL as the integrated terminal.
+4. Add Sniffy from `\\wsl$\Ubuntu-26.04\home\<worker>\src\sniffy\sniffy` as a local project.
+5. Use one app project per repository; do not point a project at a directory containing several repositories.
+6. Select **Set up Remote** in the sidebar and pair the phone with the displayed QR code.
+7. Enable launch at login, keep the Windows account signed in, and keep the app running.
 
-Install the current Windows app inside the VM:
+The current app and WSL behavior are documented in [ChatGPT desktop app for Windows](https://learn.chatgpt.com/docs/windows/windows-app).
+Remote host availability is documented in [Remote connections](https://learn.chatgpt.com/docs/remote-connections).
 
-```powershell
-winget install --id 9PLM9XGG6VKS -s msstore
-```
+For unattended reboots, either log in manually after maintenance or use automatic login only for the dedicated low-value
+worker account. Automatic login improves recovery but stores a reusable Windows credential inside the disposable VM.
 
-Then:
+## 5. Provision the WSL developer environment
 
-1. Sign in to the ChatGPT desktop app using the same ChatGPT account and workspace as the mobile app.
-2. Open **Settings**, switch the Codex agent from Windows native to **WSL**, and restart the app. The restart is required.
-3. Set WSL as the integrated terminal unless PowerShell is specifically needed.
-4. Add Sniffy from `\\wsl$\Ubuntu-26.04\home\<worker>\src\sniffy\sniffy` as the first local project.
-5. Add every later repository as a separate local project; do not point one app project at a directory containing
-   multiple repositories.
-6. Select **Set up Remote** in the sidebar and pair the phone using the displayed QR code.
-7. Enable launch at login and keep the Windows session signed in. Keep it unlocked when a task uses Computer Use.
+Run all project tooling inside Ubuntu. Keep repositories under `~/src/<owner>/<repository>`.
 
-The current Windows app and WSL behavior are documented in [ChatGPT desktop app for
-Windows](https://learn.chatgpt.com/docs/windows/windows-app). Remote setup and host availability are documented in
-[Remote connections](https://learn.chatgpt.com/docs/remote-connections).
-
-For an unattended machine, decide explicitly how reboots are handled:
-
-- **Supervised default:** log in manually after Windows Update or a host restart, then start the app.
-- **Always-on:** use a dedicated low-value local account with automatic login and app startup. This improves recovery
-  but stores a reusable Windows login secret inside the VM; it does not remove the need for least-privilege PATs.
-
-## 6. Provision the WSL developer environment
-
-Run all project tooling inside Ubuntu, not in native Windows. This avoids duplicate Git checkouts, path translation,
-file-watcher problems, and mixed Windows/Linux credentials. Use `~/src/<owner>/<repository>` so repositories with the
-same name cannot collide.
-
-### 6.1. Base packages and shared toolchain
-
-Use `apt` only for operating-system packages. Keep language and build-tool versions in `mise` so the same worker can
-host repositories with different requirements:
+Install shared packages and a version manager:
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y \
   bash bubblewrap build-essential ca-certificates curl git jq tar unzip zip gh
-```
 
-Install [`mise`](https://mise.jdx.dev/getting-started.html), activate it for Bash, and activate it in the current shell:
-
-```bash
 curl https://mise.run | sh
 echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
 eval "$(~/.local/bin/mise activate bash)"
-mise --version
-```
-
-Sniffy's frontend declares Node.js 24 or newer. Install Node 24 and the Maven 3.9 release line as machine defaults, then
-install the additional JDKs expected by the existing Sniffy scripts:
-
-```bash
 mise use --global node@24 maven@3.9
-
 for version in 11 17 21 25; do
   mise install "java@${version}"
 done
 ```
 
-Node includes `npm`; do not separately install Ubuntu's `nodejs` or `npm` packages. Do not use global npm installs such
-as `sudo npm install -g ...` for repository tools. Maven is machine-managed only until the repository adds a Maven Wrapper
-or pins it in a project `mise.toml`. A repository-level tool declaration must take precedence over these worker defaults.
-
-Verify the shared commands:
-
-```bash
-node --version
-npm --version
-mvn --version
-mise ls
-```
-
-The repository setup script installs Temurin JDK 8 itself. `bubblewrap` is required if the app is later switched back
-from full access to the Linux sandbox. See the `mise`
-[Node.js documentation](https://mise.jdx.dev/lang/node.html) for version selection and npm behavior.
-
-### 6.2. Docker Engine
-
-Install Docker Engine inside Ubuntu using the official [Docker Engine for Ubuntu
-instructions](https://docs.docker.com/engine/install/ubuntu/). Enable the service and allow the dedicated worker user to
-use the Docker socket:
-
-```bash
-systemctl is-system-running
-```
-
-If WSL does not have systemd enabled, enable it through `/etc/wsl.conf` using Microsoft's
-[WSL systemd instructions](https://learn.microsoft.com/en-us/windows/wsl/systemd), run `wsl --shutdown` from
-PowerShell, and reopen Ubuntu. Then continue:
+Install Docker Engine inside Ubuntu using the official
+[Docker Engine for Ubuntu](https://docs.docker.com/engine/install/ubuntu/) instructions. Enable systemd in WSL when
+needed, enable Docker, and add only the dedicated worker user to the Docker group:
 
 ```bash
 sudo systemctl enable --now docker
 sudo usermod -aG docker "$USER"
 ```
 
-Exit all WSL shells, run `wsl --shutdown` from PowerShell, reopen Ubuntu, and verify:
+Membership in the Docker group is effectively root inside WSL. That is acceptable only inside this disposable worker VM.
+Docker Desktop is not required.
 
-```bash
-docker version
-docker run --rm hello-world
-```
-
-Membership in the `docker` group is effectively root access inside WSL. That is intentional only because the whole VM
-is dedicated to the worker. Docker Desktop is not required.
-
-### 6.3. Clone and bootstrap Sniffy as the first project
+Clone and bootstrap Sniffy:
 
 ```bash
 mkdir -p ~/src/sniffy
@@ -409,46 +219,24 @@ cd ~/src/sniffy
 git clone https://github.com/sniffy/sniffy.git
 cd sniffy
 git switch develop
-```
-
-On a clean Ubuntu installation, `.codex/cloud/setup.sh` cannot be the very first command: it assumes `curl`, Git,
-Maven, `mise`, and JDK 11/17/21/25 are already available in the Codex universal image. After the bootstrap above, run:
-
-```bash
 bash .codex/cloud/setup.sh
-```
 
-Install the exact frontend dependency tree from the committed lockfile, then use that project-local Playwright CLI to
-install all browser engines used by `sniffy-ui/playwright.config.ts` plus their Ubuntu libraries:
-
-```bash
 cd sniffy-ui
 npm ci
 npx playwright install --with-deps chromium firefox webkit
-npx playwright --version
 cd ..
 ```
 
-Do not install `@playwright/test` or Playwright globally. The repository pins its Playwright package in
-`package-lock.json`, and every Playwright version expects matching browser binaries. `npx playwright` resolves the
-local CLI after `npm ci`; the downloaded browsers are shared across this WSL user's worktrees through Playwright's
-default Linux cache at `~/.cache/ms-playwright`. Re-run the `--with-deps` command after a Playwright upgrade or a
-fresh WSL installation. See Playwright's [browser installation
-documentation](https://playwright.dev/docs/browsers).
-
-This compatibility path reuses the existing JDK 8 installation, toolchain generation, GitHub CLI installation,
-environment file, and Maven cache warm-up. Verify both ends of the supported matrix:
+Verify both ends of the Java matrix:
 
 ```bash
 source .codex/cloud/use-jdk.sh 8
 mvn -version
-
 source .codex/cloud/use-jdk.sh 25
 mvn -version
 ```
 
-In the app's [local environment](https://learn.chatgpt.com/docs/environments/local-environment), use this setup command
-for new worktrees after the one-time machine bootstrap:
+Configure the app's local worktree setup command:
 
 ```bash
 bash .codex/cloud/maintenance.sh
@@ -459,52 +247,20 @@ bash .codex/cloud/maintenance.sh
 )
 ```
 
-The worktree setup intentionally omits `--with-deps`: Ubuntu browser libraries were installed once during machine
-bootstrap, while this idempotent command ensures browser binaries matching the worktree's locked Playwright version are
-present. If a Playwright upgrade requires new Ubuntu libraries, repeat the one-time `--with-deps` command manually.
+The one-time bootstrap installs OS libraries; the worktree setup ensures dependencies and browser binaries match the
+checked-out lockfiles.
 
-Local environment setup scripts execute in WSL when the app agent uses WSL. Configure the environment through the app
-and commit the generated `.codex` configuration only after it has been tested on a second clean worktree.
+## 6. GitHub identity, permissions, and branch protection
 
-### 6.4. Portable environment direction
-
-There is no single industry-standard file that installs Windows features, Ubuntu packages, language runtimes, Docker,
-and project dependencies across every platform. Keep the layers explicit:
-
-| Layer | Recommended source of truth |
-| --- | --- |
-| VM and Windows features | Hyper-V PowerShell/runbook, later an idempotent provisioning script |
-| OS packages | `winget` for Windows-only apps; `apt` for the WSL distribution |
-| Java/Node/Python versions | Repository `mise.toml` in a follow-up change |
-| Maven version and invocation | Maven Wrapper plus `pom.xml` |
-| Codex worktree setup/actions | App local environment configuration under `.codex` |
-| Agent conventions and checks | `AGENTS.md` |
-| Optional editor/container environment | Development Container specification |
-
-The next portability improvement should extract cloud-image assumptions from `.codex/cloud/setup.sh` into a shared,
-idempotent Linux toolchain script and add a small WSL bootstrap. A `mise.toml` and Maven Wrapper would make versions
-declarative. Keep Dev Containers as an optional reproducible development target, not as the outer boundary for this
-worker.
-
-Do not install Cygwin. WSL2 already supplies the Linux system that Bash scripts, `curl`, Docker, and Playwright expect.
-Git Bash may remain useful for an occasional native-Windows terminal, but the worker should not depend on it.
-
-## 7. GitHub identity and least privilege
-
-Prefer a dedicated machine account that is a member of the `sniffy` organization. Create a fine-grained PAT with:
+Prefer a dedicated machine account that belongs to the `sniffy` organization. Use a short-lived fine-grained PAT with:
 
 - resource owner `sniffy`;
 - repository access limited to `sniffy/sniffy`;
-- repository permissions: Metadata read, Contents read/write, Issues read/write, and Pull requests read/write;
-- organization permission: Projects read/write for the organization-owned book of work;
-- Workflows read/write only when authorized tasks may change `.github/workflows/`;
-- a short expiration and an explicit rotation reminder.
+- Metadata read, Contents read/write, Issues read/write, and Pull requests read/write;
+- organization Projects read/write for the organization-owned queue;
+- Workflows read/write only for issues explicitly authorized to modify `.github/workflows/`.
 
-GitHub documents both the [fine-grained PAT limitations](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens)
-and the organization-level [Projects permission](https://docs.github.com/en/rest/projects/projects). Fine-grained PATs do
-not support user-owned Projects, so keep the worker's book of work owned by the `sniffy` organization.
-
-Authenticate from WSL without putting the token in a command argument or Git remote URL:
+Authenticate from WSL without putting the token in a command argument or remote URL:
 
 ```bash
 read -rsp "GitHub PAT: " github_pat && echo
@@ -514,239 +270,152 @@ gh auth setup-git --hostname github.com
 gh auth status --hostname github.com
 ```
 
-Configure a distinct commit identity:
+Configure a distinct commit identity and validate effective access:
 
 ```bash
 git config --global user.name "Sniffy Codex Worker"
 git config --global user.email "<machine-account-noreply-address>"
-```
 
-Validate effective access instead of trusting the token settings page:
-
-```bash
 gh repo view sniffy/sniffy
 gh project list --owner sniffy
 git ls-remote https://github.com/sniffy/sniffy.git refs/heads/develop
 ```
 
-The `gh project` command documents `project` as the minimum classic-token scope. For a fine-grained token, the equivalent
-is the organization Projects permission. If the project commands fail, fix that one permission rather than replacing
-the token with an unrestricted classic PAT.
-
 Protect `develop` with a server-side ruleset requiring pull requests and disallowing force pushes and deletion. The
-machine account must not bypass the ruleset.
+worker identity must not bypass the ruleset.
 
-## 8. Codex permissions inside the VM
+The account that authors implementation PRs cannot submit a formal approval or Request Changes review on its own PR. For
+automated formal review, configure a separate reviewer identity in the app/connector. When no independent reviewer
+identity is available, the worker must leave precise review feedback and report the limitation rather than claim that a
+formal review was submitted.
 
-Use the app's permission selector to set **Full access** for this worker. The equivalent local Codex defaults are:
+## 7. Codex permissions inside the VM
+
+Use the app's permission selector to set **Full access** for this dedicated worker. Equivalent local defaults are:
 
 ```toml
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 ```
 
-The Windows app stores its configuration under `%USERPROFILE%\.codex`. Configure it in the app or through **Settings >
-Configuration**; do not copy this full-access configuration to a normal workstation. The app, CLI, and IDE share
-configuration layers, while a separate CLI installed inside WSL uses the WSL home directory unless `CODEX_HOME` is
-explicitly shared.
+Full access removes the inner Codex sandbox but does not bypass Hyper-V, the dedicated token, or GitHub branch
+protection. Preserve the outer controls:
 
-Full access removes the inner Codex sandbox. It does not bypass Windows/Hyper-V, the dedicated GitHub token, or GitHub
-branch protection. Preserve those outer controls:
+- no host mounts or unrelated credentials;
+- no personal browser profile;
+- no organization administration, secrets, packages, or workflow permission unless required;
+- no force push, merge, auto-merge, or branch-rule bypass;
+- no restoration of old credential-bearing checkpoints after token rotation.
 
-- no host filesystem mounts or unrelated credentials;
-- no personal browser profile inside the VM;
-- no PAT with organization administration, secrets, packages, or workflow permission unless required;
-- no force push, merge, or branch-rule bypass;
-- no unreviewed VM snapshot restore after token rotation.
+## 8. App-native task topology
 
-## 9. App-native task dispatch
+Scheduled tasks are configured through the desktop app and can be attached either to the current chat or to a standalone
+new-chat destination. The topology deliberately uses both modes.
 
-### 9.1. Why Scheduled tasks are the dispatcher
+### 8.1. Persistent dispatcher chat
 
-The supported app-native path is a [Scheduled task](https://learn.chatgpt.com/docs/automations) scoped to one or more
-local app projects. A run can use a dedicated background worktree, appears in the app's **Scheduled** inbox, and remains
-visible through Remote while the machine and desktop app are running. Use separate Scheduled tasks by default when
-repositories have different prompts, queues, schedules, or credential owners. The app also supports assigning one
-generic Scheduled task to several projects when their workflow is truly identical.
+Create one normal chat in the local Sniffy project and name it `Sniffy Dispatcher`. Create a Scheduled task attached to
+that current chat:
 
-There is currently no documented stable shell API that creates a new local task inside the ChatGPT desktop app UI.
-`codex exec` and `.codex/local/run-issue.sh` remain useful CLI fallbacks, but a CLI run is not the same app task. The
-experimental `codex app-server` is intended for development/debugging and should not be the production dispatcher.
+- cadence: every 15 minutes;
+- project: the normal local Sniffy checkout, not a new worktree;
+- destination: this existing chat;
+- prompt: [`.codex/local/scheduled-task-prompt.md`](../.codex/local/scheduled-task-prompt.md);
+- permissions: the isolated VM's configured unattended permissions.
 
-Therefore:
+The dispatcher only reads the queue, validates readiness, claims at most one issue, selects model/reasoning, and creates a
+child task. It never edits source code. With no eligible issue it returns `NO_CHANGE` and creates nothing.
 
-1. Create one Scheduled task in the ChatGPT desktop app.
-2. Attach it to the local Sniffy project.
-3. Select a dedicated background worktree.
-4. Start with a conservative interval such as every 30 minutes.
-5. Let each run claim at most one issue.
-6. Keep the VM powered on, the Windows account signed in, and the app running.
+A recurring standalone dispatcher is prohibited because every no-op poll creates another chat and usually another
+background worktree. The word “continuation” in a task name does not change its destination semantics.
 
-Scheduled tasks run unattended and use the default sandbox settings. Full access is intentional here only because the
-VM is disposable and isolated.
+### 8.2. One-time standalone worker
 
-### 9.2. Claim contract
+For an eligible issue, the dispatcher renders
+[`.codex/local/worker-task-prompt.md`](../.codex/local/worker-task-prompt.md) and creates one one-time standalone task:
+
+- run once as soon as possible;
+- title `Sniffy #N: <issue title>`;
+- destination: a new chat;
+- project: Sniffy;
+- environment: a new isolated app-managed worktree;
+- model and reasoning selected from issue/project routing;
+- fully rendered worker prompt with no unresolved placeholders.
+
+The dedicated chat is the complete implementation and PR history for that issue and remains visible through Remote. The
+dispatcher records the exact task title on the issue. If child creation fails, it rolls the claim back to `Ready for
+agent` and reports the exact error.
+
+### 8.3. Worker-chat continuation
+
+After publishing or updating the PR, the worker creates or updates one Scheduled task attached to its current worker
+chat. The cadence is stateful:
+
+1. first check after 15 minutes;
+2. second check 15 minutes after the first if still incomplete;
+3. hourly checks after the second incomplete check.
+
+Every check reads the latest full diff, issue, comments, review submissions, unresolved threads, head SHA, and relevant
+CI. It addresses current actionable feedback together, reruns the proof matrix, pushes, and verifies the remote head.
+When everything is correct and required CI is green, an independent reviewer identity approves; otherwise it submits an
+exact Request Changes review. If formal review is impossible because the active identity authored the PR, the task leaves
+the same precise comment and reports the limitation. It never merges.
+
+Pause the continuation schedule when the review cycle is complete or blocked on a human/product decision. Do not create a
+new standalone chat for follow-up checks.
+
+### 8.4. Claim contract
 
 The GitHub Project is the source of truth. An eligible item must:
 
 - be an Issue in `sniffy/sniffy`, not a draft item or pull request;
-- have project Status `Ready for agent` and Executor `Local Codex`;
+- have Status `Ready for agent` and Executor `Local Codex`;
 - satisfy the Definition of Ready in `docs/codex-workflow.md`;
-- be either:
-  - **fresh work** with no active local-worker claim and no implementation pull request; or
-  - an explicitly re-queued **continuation** with an existing local-worker claim, writable branch, and open
-    implementation pull request that has actionable maintainer feedback or failing required checks;
-- not require a product decision or permission absent from the worker token.
+- be fresh work without an active implementation, or an explicitly re-queued continuation with a writable existing local
+  branch/PR and actionable review feedback or failing required checks;
+- not require a product decision or permission absent from the worker identity.
 
-For continuation work, `Ready for agent` is an explicit lease renewal. Historical claim comments, the existing
-`agent/issue-N` branch, and the open pull request are required context rather than disqualifiers. An item whose
-Status is still `In progress` or `Review` is not eligible for another Scheduled run, which prevents two worker
-cycles from editing the same branch concurrently.
+For a single worker, claim by setting Status to `In progress`, adding the machine account and `agent:local`, and posting a
+claim comment before creating the child task. Roll back partial mutations if claim or child creation fails. GitHub Project
+field updates are not compare-and-swap: do not run several dispatchers against this protocol without an atomic lease or a
+single coordinator.
 
-For one worker, this claim sequence is sufficient:
+### 8.5. Required nested-task smoke test
 
-1. List at most 100 matching items. Prefer an explicitly re-queued continuation so review loops close before new
-   work starts, then choose deterministically by project Priority and oldest issue number.
-2. Re-read the selected issue, all comments, project fields, linked pull requests, review threads, and current CI
-   immediately before claiming.
-3. Classify the item as fresh work or a continuation. For a continuation, verify that the existing pull request is
-   open, its head branch is writable by the worker, and the latest maintainer instructions identify actionable
-   fixes or required failed checks.
-4. Set Status to `In progress`.
-5. Add the machine account as assignee and add `agent:local` when missing.
-6. For fresh work, post a claim comment containing the worker name, intended `agent/issue-N` branch, timestamp,
-   and Scheduled run link when available. For a continuation, post a continuation-claim comment containing the
-   existing branch, pull request, current head SHA, timestamp, and feedback scope.
-7. If any claim mutation fails, undo mutations that succeeded and stop without editing code.
+The desktop app can evolve independently of repository docs. Before enabling the recurring dispatcher, prove in the
+installed app version that an in-chat task can create a one-time standalone child task. Use a read-only prompt that runs
+`pwd` and `git status` and verify:
 
-Useful discovery commands are:
+- an empty queue creates no child chat;
+- one eligible item creates exactly one child chat and one worktree;
+- WSL paths and the expected project are used;
+- the worker task title contains the issue number;
+- failed child creation restores queue state.
 
-```bash
-project_number="<ORGANIZATION_PROJECT_NUMBER>"
+Repeat the smoke test after material Scheduled-task changes. If nested creation is unavailable, pause the dispatcher and
+create the one-time standalone worker manually in the app. Do not substitute Python, App Server, or UI-click automation
+without a separately approved design.
 
-gh project view "${project_number}" --owner sniffy --format json
-gh project field-list "${project_number}" --owner sniffy --format json
-gh project item-list "${project_number}" \
-  --owner sniffy \
-  --query 'repo:sniffy/sniffy status:"Ready for agent"' \
-  --limit 100 \
-  --format json
-```
+## 9. Add repositories and organizations
 
-To update the single-select Status field, resolve the project ID, item ID, Status field ID, and target option ID from
-the JSON above, then run:
+One VM may host several personal/open-source repositories in the same trust domain. Use another outer VM for corporate,
+client, unknown third-party, or legally separate work.
 
-```bash
-gh project item-edit \
-  --id "${item_id}" \
-  --project-id "${project_id}" \
-  --field-id "${status_field_id}" \
-  --single-select-option-id "${in_progress_local_option_id}"
-```
+For each repository:
 
-The command shapes are documented in the GitHub CLI manuals for
-[`gh project item-list`](https://cli.github.com/manual/gh_project_item-list),
-[`gh project field-list`](https://cli.github.com/manual/gh_project_field-list), and
-[`gh project item-edit`](https://cli.github.com/manual/gh_project_item-edit).
+1. clone into `~/src/<owner>/<repository>`;
+2. add it as its own desktop-app project;
+3. add repository-specific `AGENTS.md`, setup, tests, base branch, and readiness rules;
+4. configure and smoke-test its worktree setup;
+5. create one persistent dispatcher chat and in-chat dispatcher task;
+6. provide a repository-owned worker template;
+7. run one no-op cycle and one disposable issue end to end;
+8. stagger worker schedules and keep one coordinator per non-atomic queue.
 
-GitHub Projects field updates do not provide a compare-and-swap claim primitive. Do not run multiple workers against
-this simple protocol. Before adding a second worker, introduce a single coordinator or another atomic lease mechanism.
+Do not share one persistent dispatcher chat across unrelated repositories. It makes Remote history ambiguous and increases
+the risk of claiming in the wrong checkout.
 
-### 9.3. Scheduled task prompt
-
-Use [`.codex/local/scheduled-task-prompt.md`](../.codex/local/scheduled-task-prompt.md) as the single canonical prompt.
-Replace the project number if necessary, copy that file's prompt text into the ChatGPT Scheduled task, and test it
-manually before enabling the schedule.
-
-The worker performs the issue directly in the Scheduled task. It must not call `.codex/local/run-issue.sh`, because that
-would launch a second, nested CLI agent and lose the app-native task lifecycle.
-
-## 10. Add repositories and organizations
-
-### 10.1. Keep one real trust boundary
-
-One VM may host several personal or open-source repositories when all of them belong to the same trust domain. Full
-access means a task running for one repository can technically read every checkout and credential profile in the VM.
-Separate WSL users, distributions, and `GH_CONFIG_DIR` values improve organization but are not security boundaries
-against the full-access agent.
-
-Use another outer VM for corporate repositories, client work, unknown third-party code, or any organization that must
-not share credentials with the personal worker. Do not put employer credentials in this VM.
-
-Use this checkout layout inside the shared WSL distribution:
-
-```text
-~/src/
-  sniffy/sniffy/
-  nefi/nefi/
-  kerb4j/kerb4j/
-```
-
-### 10.2. Create one app project per repository
-
-For each additional repository:
-
-1. Clone it into `~/src/<owner>/<repository>`.
-2. Add that checkout root as a separate local project in the ChatGPT desktop app.
-3. Add repository-specific `AGENTS.md`, setup, test, base-branch, and Definition-of-Ready instructions.
-4. Configure and smoke-test its local worktree environment.
-5. Copy the Scheduled task prompt and substitute the repository's values, or attach a tested generic task shared by
-   projects with the same queue contract.
-6. Run one manual no-op cycle and one disposable issue end to end before enabling its schedule.
-7. Stagger schedules so Maven, Docker, browsers, and multiple worktree setups do not all start together.
-
-A Scheduled task may be assigned to more than one local project, but each run must stay inside the project and worktree
-selected by the app. The generic prompt must derive repository-specific values from that checkout. Do not claim an
-arbitrary repository and then clone or change directory into it: that loses the clean lifecycle and makes mobile review
-misleading.
-
-An organization-owned GitHub Project may contain issues from several repositories in that organization. Give every
-repository its own app project and retain the `repo:<owner>/<repository>` query filter whether the schedule is shared
-or separate. The runs can share status names and the same Project number while always claiming only their own
-repository.
-
-Record these values for every project instead of hard-coding Sniffy assumptions into a common machine script:
-
-| Setting | Sniffy example | Per-project value |
-| --- | --- | --- |
-| Checkout | `~/src/sniffy/sniffy` | `~/src/<owner>/<repository>` |
-| GitHub repository | `sniffy/sniffy` | `<owner>/<repository>` |
-| Queue owner | `sniffy` | Organization that owns the Project |
-| Project number | `<PROJECT_NUMBER>` | Organization Project number |
-| Base branch | `develop` | Repository integration branch |
-| Readiness contract | `docs/codex-workflow.md` | Repository-owned instructions |
-| Worktree setup | `.codex/cloud/maintenance.sh` | Repository-owned local setup |
-| Ready/in-progress/review states | Sniffy Project options | Queue-specific option IDs and names |
-| Worker label and assignee | `agent:local`, machine account | Repository-specific values |
-
-Machine provisioning installs only shared capabilities such as WSL, Docker, Git, `gh`, `mise`, and common language
-runtimes. Each repository remains responsible for exact versions, setup commands, tests, and agent guidance.
-
-### 10.3. Scope credentials by resource owner
-
-A fine-grained PAT can access repositories owned by only
-[one user or organization](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens).
-Choose the credential layout from the actual ownership boundaries:
-
-| Repository portfolio | Recommended credential model |
-| --- | --- |
-| Several repositories in one organization | One dedicated machine account and one fine-grained PAT limited to selected repositories |
-| Repositories in several personal organizations | One fine-grained PAT and one `gh` profile per resource owner |
-| Many organizations or automated token rotation | A narrowly permissioned GitHub App installed only on selected repositories |
-| Different security or legal trust domains | Separate outer worker VMs and separate identities |
-
-Do not solve the multi-organization limitation by issuing one broad classic PAT. Store each owner profile outside every
-checkout, select it explicitly for that project's `gh` and Git commands, and test repository plus Project access before
-enabling the schedule. `GH_CONFIG_DIR` can keep the `gh` profiles separate, but the full-access agent can still read
-all profiles in the same VM; the separation prevents accidental credential selection, not deliberate cross-access.
-
-For a small hobby portfolio, start with one fine-grained PAT per owner. Move to a GitHub App only when installation
-tokens, centralized permission management, or rotation justify the additional bootstrap code.
-
-### 10.4. Parameterize the queue contract, not the VM
-
-Keep the Sniffy prompt in section 9 as a working example. A new repository changes the prompt values and repository
-instructions, not the Windows image. At minimum parameterize:
+Parameterize at least:
 
 ```text
 OWNER
@@ -760,29 +429,26 @@ REVIEW_STATUS
 BLOCKED_STATUS
 WORKER_ASSIGNEE
 WORKER_LABEL
+DEFAULT_MODEL
+DEFAULT_REASONING
+REVIEWER_IDENTITY
+DISPATCHER_CHAT_NAME
+WORKER_TASK_TITLE
 ```
 
-Keep each organization's book of work in an organization-owned Project for the initial implementation. For multiple
-organizations, run the corresponding repository tasks against their owner's Project and credential profile. A future
-central coordinator may present a unified portfolio view, but it must not replace the app's per-repository task and
-worktree boundary.
+A fine-grained PAT can access repositories owned by only one resource owner. Use a separate PAT and `gh` profile per
+owner, or a narrowly installed GitHub App when centralized rotation justifies it. `GH_CONFIG_DIR` separates accidental
+credential selection but is not a security boundary against a full-access agent.
 
-## 11. Validation checklist
+## 10. Validation checklist
 
-### 11.1. VM and WSL
-
-From the physical host:
+### 10.1. VM, WSL, and tools
 
 ```powershell
 Get-VM -Name "bedrin-worker-1"
 Get-VMProcessor -VMName "bedrin-worker-1" | Format-List Count,ExposeVirtualizationExtensions
 Get-VMMemory -VMName "bedrin-worker-1"
 Get-VMTPM -VMName "bedrin-worker-1"
-```
-
-Inside the Windows VM and WSL:
-
-```powershell
 wsl --status
 wsl --list --verbose
 ```
@@ -797,70 +463,64 @@ npm --version
 mvn -version
 ```
 
-### 11.2. Repository toolchains
+### 10.2. Repository toolchains
 
 ```bash
 cd ~/src/sniffy/sniffy
-
 source .codex/cloud/use-jdk.sh 8
 mvn -version
-
 source .codex/cloud/use-jdk.sh 25
 mvn -version
-
 cd sniffy-ui
 npm ci
 npx playwright --version
 npx playwright install --list
-npm run test:e2e
 cd ..
-
 git diff --check
 ```
 
-Run one small focused Maven test and one Docker smoke test. Do not treat a cache warm-up as proof that the full reactor
-passes.
+Run one focused Maven test, one Docker smoke test, and one Playwright smoke test. A cache warm-up is not proof that the
+full reactor passes.
 
-### 11.3. GitHub publication
+### 10.3. App, dispatcher, worker, and mobile
 
-First run the reversible remote-ref validation prompt from `docs/codex-workflow.md`. Verify that the PAT can also read
-and update the organization Project. Delete the probe branch and confirm that no remote ref remains.
+1. Start a manual read-only task and confirm `pwd`, `uname`, Git, and tests run inside WSL.
+2. Pair Remote and inspect a normal local chat, terminal output, and diff from mobile.
+3. Run the dispatcher manually with no eligible issue; confirm it stays in the same chat and creates no worktree.
+4. Run the nested-task smoke test; confirm exactly one child chat/worktree and the expected title.
+5. Add one disposable ready issue; verify claim fields, dedicated worker chat, worktree, branch, PR, and `Review` state.
+6. Verify the worker creates an in-chat follow-up task, performs checks at 15 minutes and another 15 minutes, then changes
+   to hourly if incomplete.
+7. Verify every follow-up reads the latest head, complete diff, review threads, and CI before approval or Request Changes.
+8. Verify no task can merge or enable auto-merge.
+9. Archive the completed worker run and confirm its worktree can be cleaned without affecting the persistent dispatcher.
+10. Revoke/rotate the test PAT and confirm the old token no longer authenticates.
 
-### 11.4. App, Scheduled, and mobile
+Do not enable the recurring dispatcher until all applicable checks pass.
 
-1. Start a manual read-only task in the local WSL project and confirm commands execute in Linux.
-2. Create a disposable worktree task and confirm the local environment setup completes.
-3. Pair Remote and inspect the running task, diff, and terminal output from the mobile app.
-4. Run the worker prompt manually against a project view with no eligible issues; it must produce a no-op.
-5. Add one disposable ready issue, run the task once, and verify claim fields, branch, PR, and `Review` transition.
-6. Revoke or rotate the test PAT and confirm the old token no longer authenticates.
-7. For each additional repository, verify that its Scheduled task cannot claim an issue for another repository.
-8. For each additional resource owner, verify the selected credential profile can access only its intended repositories
-   and Project.
+## 11. Operations and recovery
 
-Do not enable a recurring schedule until all applicable checks pass.
-
-## 12. Operations and recovery
-
-- Keep Windows, WSL, the ChatGPT desktop app, Docker, `gh`, and toolchains updated during a defined maintenance window.
-- Review the first several Scheduled runs. Pause the schedule after unexpected claims, repeated no-op errors, or a
-  publication mismatch.
-- Archive old Scheduled runs so their background worktrees can be cleaned up.
-- Monitor free disk space in the outer VHDX, the WSL virtual disk, Maven cache, Docker storage, and Git worktrees.
+- Keep Windows, WSL, the desktop app, Docker, `gh`, and toolchains updated during a defined maintenance window.
+- Keep one persistent dispatcher chat; archive completed worker chats after their durable GitHub links are recorded.
+- Do not pin completed worker runs unless their worktree must be retained. Frequent pinned runs prevent cleanup.
+- Monitor free space in the outer VHDX, WSL virtual disk, Maven/npm caches, Docker storage, and Git worktrees.
+- Pause the dispatcher after unexpected claims, duplicate child chats, repeated no-op errors, or publication mismatch.
+- Detect stale `In progress` claims that lack a confirmed worker task comment; report them for human recovery rather than
+  silently dispatching a duplicate.
+- Re-run the nested-task smoke test after significant app or Scheduled-task updates.
 - Reboot and revalidate after changes to Hyper-V, WSL, Docker, app agent mode, PAT permissions, or `.codex` setup files.
-- On suspected compromise: stop the VM, revoke the PAT, disconnect Remote, invalidate active ChatGPT sessions if needed,
-  and rebuild from the pre-credential checkpoint or clean media.
-- Do not restore an old credential-bearing checkpoint after revocation without rotating every secret it contains.
-- When an Enterprise Evaluation approaches expiry, rebuild or assign an appropriate licensed guest. A Home guest does
-  not expire after activation, but it still needs its own valid license. Activation bypass is not part of this design.
+- On suspected compromise, stop the VM, revoke the PAT, disconnect Remote, invalidate active sessions when needed, and
+  rebuild from clean media or the pre-credential checkpoint.
+- Never restore a credential-bearing checkpoint after revocation without rotating every secret in it.
 
-## 13. Explicit non-goals
+## 12. Explicit non-goals
 
-- This runbook does not make unactivated Windows a licensed permanent installation.
+- This runbook does not make an unactivated Windows guest a licensed permanent installation.
 - It does not expose the physical host filesystem or Docker daemon to Codex.
-- It does not use Cygwin as a compatibility layer.
-- It does not require Docker Desktop or a Dev Container to contain the agent.
-- It does not use UI automation to click through the ChatGPT desktop app.
-- It does not make a multi-worker GitHub Project claim protocol safe.
-- It does not authorize the worker to merge pull requests, bypass branch rules, or manage repositories outside the
-  explicitly registered portfolio.
+- It does not use Cygwin, Docker Desktop, or a Dev Container as the outer agent boundary.
+- It does not use UI automation, external Python observers, `codex app-server`, or nested `codex exec` for app dispatch.
+- It does not create a chat or worktree for an empty polling cycle.
+- It does not use a recurring standalone task as the dispatcher.
+- It does not create a second standalone chat for PR continuation.
+- It does not make the non-atomic GitHub Project claim protocol safe for multiple dispatchers.
+- It does not authorize merge, auto-merge, branch-rule bypass, or repositories outside the registered portfolio.


### PR DESCRIPTION
## Summary

- keep queue polling in one persistent in-chat `Sniffy Dispatcher` Scheduled task
- create no chat or worktree for an empty queue
- spawn one one-time standalone Scheduled task, dedicated chat, and isolated worktree per eligible issue
- add a canonical worker prompt with fresh/continuation behavior and PR supervision in the same worker chat
- codify the 15-minute, second 15-minute, then hourly follow-up cadence
- require full diff, review-thread, and CI inspection before approval or precise Request Changes
- preserve WSL execution and native Windows-app Remote visibility without an external Python observer, App Server integration, or UI automation
- document cleanup, stale-claim recovery, reviewer-identity limits, and a required nested-task smoke test

## Why

A recurring standalone Scheduled task creates a new app/Remote chat for every polling run, including no-op runs, and may accumulate background worktrees. The documented topology now combines the two native task destinations deliberately: one persistent in-chat dispatcher plus one one-time standalone worker per real issue.

## Files

- `.codex/local/scheduled-task-prompt.md` — persistent dispatcher prompt
- `.codex/local/worker-task-prompt.md` — new one-time worker template
- `docs/local-codex-worker.md` — Windows App, WSL, Remote, dispatcher/worker, validation, and operations runbook
- `docs/codex-workflow.md` — routing, roles, queue states, follow-up, and Definition-of-Done alignment

Historical retrospectives remain unchanged because they describe the process at the time of each incident.

## Validation

- reviewed the complete branch diff for topology and terminology consistency
- checked all changed Markdown files for balanced fences, trailing whitespace, tabs, and unresolved accidental TODO/TBD markers
- checked internal links between the dispatcher prompt, worker template, local-worker runbook, and workflow document
- docs-only change; no product or build tests run

## Operational caveat

The app supports in-chat and standalone Scheduled-task destinations and chat-driven task creation, but child-task creation from a scheduled dispatcher run must still be smoke-tested in the installed desktop-app version before the recurring dispatcher is enabled. The runbook fails closed: pause the dispatcher and create the one-time child manually if nested creation is unavailable.

## Safety

This change does not authorize merge or auto-merge. Formal approval or Request Changes requires an independent reviewer identity; a PR author must not pretend to have reviewed its own PR.