### PR TITLE
Document ChatGPT website preview workflow

### DIFF
--- a/docs/chatgpt-project-setup.md
+++ b/docs/chatgpt-project-setup.md
@@ -1,0 +1,44 @@
+# ChatGPT project setup for Sniffy
+
+This document describes the one-time setup for a ChatGPT Project used to supervise and review work in
+[`sniffy/sniffy`](https://github.com/sniffy/sniffy). It intentionally points at repository-owned instructions instead of
+copying them into ChatGPT, so policy and runbooks do not drift between the repository and the project configuration.
+
+## Project instruction to add
+
+Add the following text to the ChatGPT Project instructions:
+
+```text
+For every sniffy/sniffy task, first read and follow the current repository instructions at
+https://github.com/sniffy/sniffy/blob/develop/AGENTS.md .
+
+For website preview, browser inspection, and screenshots, also read and follow
+https://github.com/sniffy/sniffy/blob/develop/docs/chatgpt-site-preview.md .
+
+Treat the current GitHub issue, pull request, exact head SHA, reviews, and CI as the source of truth. Use the GitHub
+connector when the shell sandbox cannot reach github.com. Never claim that source was checked out, npm was run, a site
+was built, or a browser opened a real HTTP page unless that exact action completed and its output was inspected. Never
+merge or enable auto-merge without Dmitry's explicit command.
+```
+
+Re-read the linked files at the start of each repository task. Do not pin the project instruction to a commit SHA: the
+purpose of the link is to follow the current `develop` policy. Exact-head review and artifact evidence must still use the
+immutable pull-request SHA being reviewed.
+
+## Recommended project context
+
+The ChatGPT Project may also contain a short project overview describing Sniffy's purpose, current initiatives, and the
+maintainer's operating preferences. That overview is context, not an engineering-policy replacement. When it conflicts
+with the repository, the current issue, `AGENTS.md`, and the exact reviewed GitHub state take precedence.
+
+Do not store GitHub tokens, package-registry credentials, browser policy backups, downloaded artifacts, or generated
+screenshots in the ChatGPT Project instructions. Credentials stay in their dedicated connector or agent environment;
+temporary files stay in the disposable task sandbox.
+
+## Why the preview runbook is separate
+
+The browser available to a ChatGPT sandbox may be managed with a global `URLBlocklist`. The preview runbook records the
+safe, reproducible procedure for downloading an exact-head website artifact, serving it over real localhost HTTP, adding
+only a temporary exact localhost allowlist exception, using Playwright with the installed system Chromium, collecting
+browser evidence, and restoring the original policy. Keeping this procedure in the repository makes it reviewable and
+prevents ad hoc HTML, CSS, or image inlining from being presented as a real site preview.

--- a/docs/chatgpt-site-preview.md
+++ b/docs/chatgpt-site-preview.md
@@ -1,0 +1,329 @@
+# ChatGPT website preview and screenshot runbook
+
+Use this runbook when a ChatGPT review needs to inspect a Sniffy website pull request in a real browser. The goal is to
+serve an immutable exact-head build over localhost HTTP, load it normally in Chromium, and capture reproducible evidence
+without pretending that a downloaded artifact was locally built or that an inlined document was the real site.
+
+## Evidence and truthfulness contract
+
+Before starting, record:
+
+- repository and pull-request number;
+- exact head SHA being reviewed;
+- route or routes to inspect;
+- CI run and website artifact name, ID, digest, and `head_sha` when using an artifact;
+- requested viewport, theme, browser, and interaction state.
+
+Never:
+
+- inline the built CSS, JavaScript, images, or markup into a substitute HTML document;
+- edit generated output to make it render;
+- call a downloaded CI artifact a local npm build;
+- call a `curl` response a browser test;
+- reuse screenshots from a different head without saying so;
+- clear all Chromium enterprise policies or leave a changed policy behind;
+- publish screenshots without identifying route, viewport, theme, browser, and exact SHA.
+
+If real localhost HTTP navigation cannot be made to work, stop and report that limitation. Use the exact-head CI visual
+artifact or ask an agent with a supported browser environment to publish the evidence instead of fabricating a preview.
+
+## Choose the input
+
+### Preferred review path: exact-head CI artifact
+
+For independent review, prefer the packaged website artifact produced by the exact-head `Website` job. This proves the
+same bytes that CI packaged and verified.
+
+1. Fetch the pull request and record its immutable `head_sha`.
+2. Fetch workflow runs for that SHA and select the successful exact-head pull-request run.
+3. Fetch the artifact named `sniffy-website-<head_sha>`.
+4. Verify that the artifact metadata points to the same `head_sha`, is not expired, and has a digest.
+5. Download it through the GitHub connector to a temporary path such as `/mnt/data/sniffy-site-<head_sha>.zip`.
+6. Extract it to a fresh directory such as `/mnt/data/sniffy-site-<head_sha>/`.
+
+Do not use an artifact from the base commit, a prior pull-request head, a rerun for another SHA, or an unverified local
+folder.
+
+### Source-build path
+
+Use a source build only when the shell can actually obtain the repository at the exact SHA. Show and retain the command
+results:
+
+```bash
+git clone https://github.com/sniffy/sniffy.git /tmp/sniffy
+cd /tmp/sniffy
+git checkout --detach <exact-head-sha>
+git rev-parse HEAD
+cd sniffy-ui
+node --version
+npm --version
+npm ci
+npm run build:site
+npm run package:site-artifact
+npm run verify:site-artifact
+```
+
+The checked-out SHA must equal the reviewed head. If DNS or outbound networking prevents `git clone` or package download,
+do not claim that these commands ran. Fall back to the GitHub connector and the exact-head CI artifact.
+
+## Serve the unmodified artifact over HTTP
+
+Prefer the dependency-free preview launcher included in the packaged artifact when present and follow its README. A
+portable fallback is:
+
+```bash
+site_dir=/mnt/data/sniffy-site-<exact-head-sha>
+port=4173
+python3 -m http.server "$port" \
+  --bind 127.0.0.1 \
+  --directory "$site_dir" \
+  >/tmp/sniffy-site-preview.log 2>&1 &
+server_pid=$!
+```
+
+Before opening a browser, prove the server and target route respond:
+
+```bash
+curl --fail --silent --show-error \
+  --output /dev/null \
+  --write-out 'HTTP %{http_code}\n' \
+  "http://127.0.0.1:${port}/use-cases/example/"
+```
+
+A `200` response proves only HTTP serving. Browser rendering, scripts, styles, assets, console output, and failed requests
+must still be checked in Chromium.
+
+## Allow only the exact localhost preview in managed Chromium
+
+The ChatGPT sandbox may install a managed Chromium policy containing:
+
+```json
+{
+  "URLBlocklist": ["*"]
+}
+```
+
+Do not remove or empty that blocklist. In a disposable sandbox where the process runs as root, temporarily add an exact
+`URLAllowlist` exception for the chosen localhost port, keep every other policy unchanged, start a new Chromium process,
+and restore the original file on every exit path.
+
+The current sandbox policy is normally `/etc/chromium/policies/managed/000_policy_merge.json`. Discover and inspect it
+rather than assuming:
+
+```bash
+policy_file=/etc/chromium/policies/managed/000_policy_merge.json
+test -f "$policy_file"
+python3 -m json.tool "$policy_file"
+```
+
+Use an exact port; an IP-address filter does not accept a wildcard port in Chromium's URL filter grammar.
+
+```bash
+policy_backup=$(mktemp)
+cp --preserve=all "$policy_file" "$policy_backup"
+
+restore_policy() {
+  cp --preserve=all "$policy_backup" "$policy_file" 2>/dev/null || true
+  rm -f "$policy_backup"
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+  fi
+}
+trap restore_policy EXIT INT TERM
+
+python3 - "$policy_file" "$port" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+port = int(sys.argv[2])
+with open(path, encoding="utf-8") as source:
+    policy = json.load(source)
+
+if policy.get("URLBlocklist") != ["*"]:
+    raise SystemExit("Refusing to modify an unexpected URLBlocklist policy")
+
+allowed = list(policy.get("URLAllowlist", []))
+for url in (f"http://127.0.0.1:{port}", f"http://localhost:{port}"):
+    if url not in allowed:
+        allowed.append(url)
+policy["URLAllowlist"] = allowed
+
+with open(path, "w", encoding="utf-8") as destination:
+    json.dump(policy, destination, indent=2)
+    destination.write("\n")
+PY
+```
+
+This exception is safer than setting `URLBlocklist` to an empty list: all non-local navigation remains blocked. Never do
+this on a user's workstation, a persistent shared host, or an environment whose policy ownership is unclear. Without root
+or an exact reversible policy file, stop and use CI evidence.
+
+After the browser exits, verify restoration explicitly:
+
+```bash
+python3 - "$policy_file" <<'PY'
+import json
+import sys
+policy = json.load(open(sys.argv[1], encoding="utf-8"))
+assert policy.get("URLBlocklist") == ["*"]
+assert "URLAllowlist" not in policy or all(
+    not entry.startswith("http://127.0.0.1:") and not entry.startswith("http://localhost:")
+    for entry in policy["URLAllowlist"]
+)
+print('Chromium URL policy restored')
+PY
+```
+
+## Open the real page with Playwright
+
+The Python Playwright package can drive the installed `/usr/bin/chromium`; downloading another browser is unnecessary
+when outbound DNS is unavailable.
+
+The following script captures desktop/mobile and light/dark full-page screenshots from normal HTTP navigation. Adjust the
+route and output directory, but do not alter the built site.
+
+```bash
+export SNIFFY_PREVIEW_URL="http://127.0.0.1:${port}/use-cases/example/"
+export SNIFFY_PREVIEW_SHA="<exact-head-sha>"
+export SNIFFY_SCREENSHOT_DIR="/mnt/data/sniffy-preview-${SNIFFY_PREVIEW_SHA}"
+mkdir -p "$SNIFFY_SCREENSHOT_DIR"
+
+python3 <<'PY'
+import json
+import os
+from pathlib import Path
+from playwright.sync_api import sync_playwright
+
+url = os.environ["SNIFFY_PREVIEW_URL"]
+sha = os.environ["SNIFFY_PREVIEW_SHA"]
+out = Path(os.environ["SNIFFY_SCREENSHOT_DIR"])
+
+variants = [
+    ("desktop", 1440, 900),
+    ("mobile", 390, 844),
+]
+themes = ["light", "dark"]
+results = []
+
+with sync_playwright() as playwright:
+    browser = playwright.chromium.launch(
+        executable_path="/usr/bin/chromium",
+        headless=True,
+        args=["--no-sandbox"],
+    )
+
+    for viewport_name, width, height in variants:
+        for theme in themes:
+            context = browser.new_context(
+                viewport={"width": width, "height": height},
+                color_scheme=theme,
+                device_scale_factor=1,
+            )
+            page = context.new_page()
+            console_errors = []
+            failed_requests = []
+            page.on(
+                "console",
+                lambda message: console_errors.append(message.text)
+                if message.type == "error"
+                else None,
+            )
+            page.on(
+                "requestfailed",
+                lambda request: failed_requests.append(
+                    {"url": request.url, "failure": request.failure}
+                ),
+            )
+            page.add_init_script(
+                "theme => localStorage.setItem('theme', theme)",
+                theme,
+            )
+
+            response = page.goto(url, wait_until="networkidle")
+            if response is None or response.status != 200:
+                raise RuntimeError(f"Navigation failed for {url}: {response}")
+
+            page.locator("h1").first.wait_for(state="visible")
+            title = page.title()
+            heading = page.locator("h1").first.inner_text()
+            dimensions = page.evaluate(
+                """() => ({
+                    documentWidth: document.documentElement.scrollWidth,
+                    viewportWidth: window.innerWidth,
+                    documentHeight: document.documentElement.scrollHeight,
+                    theme: document.documentElement.dataset.theme
+                })"""
+            )
+            if dimensions["documentWidth"] > dimensions["viewportWidth"]:
+                raise RuntimeError(
+                    f"Horizontal overflow: {dimensions['documentWidth']} > "
+                    f"{dimensions['viewportWidth']}"
+                )
+            if dimensions["theme"] != theme:
+                raise RuntimeError(
+                    f"Theme mismatch: expected {theme}, rendered {dimensions['theme']}"
+                )
+            if console_errors or failed_requests:
+                raise RuntimeError(
+                    json.dumps(
+                        {
+                            "consoleErrors": console_errors,
+                            "failedRequests": failed_requests,
+                        },
+                        indent=2,
+                    )
+                )
+
+            filename = out / f"site-{sha}-{viewport_name}-{theme}.png"
+            page.screenshot(path=str(filename), full_page=True)
+            results.append(
+                {
+                    "sha": sha,
+                    "url": url,
+                    "browser": "system Chromium via Playwright",
+                    "viewport": {"name": viewport_name, "width": width, "height": height},
+                    "theme": theme,
+                    "title": title,
+                    "h1": heading,
+                    "dimensions": dimensions,
+                    "consoleErrors": console_errors,
+                    "failedRequests": failed_requests,
+                    "screenshot": str(filename),
+                }
+            )
+            context.close()
+
+    browser.close()
+
+(out / "evidence.json").write_text(json.dumps(results, indent=2) + "\n")
+print(json.dumps(results, indent=2))
+PY
+```
+
+If `page.add_init_script` uses a different Playwright binding version, pass the script as a single JavaScript string with
+the theme value JSON-encoded. Do not fall back to editing generated HTML.
+
+## Review and report
+
+Open every generated PNG and inspect it rather than relying only on dimensions or a screenshot-test exit code. Report:
+
+- exact head SHA and artifact identity;
+- whether input was a CI artifact or a locally built checkout;
+- server command and HTTP result;
+- browser executable and Playwright binding;
+- route, viewport, theme, title, H1, document width, and viewport width;
+- console errors and failed requests;
+- screenshot paths;
+- policy restoration result;
+- any difference from the repository's asserted visual baselines.
+
+The screenshots may be shown in ChatGPT with sandbox links. Publishing them into a GitHub pull request requires a GitHub
+attachment-capable path or an agent environment that supports the repository screenshot publishing helper. Do not imply
+that a local ChatGPT sandbox image was attached to GitHub when it was only shown in the conversation.
+
+## Cleanup
+
+The `trap` must restore the browser policy and stop the server even when Playwright fails. Then remove temporary extracted
+artifacts and browser profiles when they are no longer needed. Retain only evidence intentionally shared with the
+maintainer.

--- a/docs/chatgpt-site-preview.md
+++ b/docs/chatgpt-site-preview.md
@@ -1,8 +1,8 @@
 # ChatGPT website preview and screenshot runbook
 
-Use this runbook when a ChatGPT review needs to inspect a Sniffy website pull request in a real browser. Serve immutable
-exact-head output over localhost HTTP, load it normally in Chromium, and capture reproducible evidence. Do not substitute
-an altered or inlined document for the built site.
+Use this runbook when ChatGPT needs to inspect a Sniffy website pull request in a real browser. Serve immutable exact-head
+output over localhost HTTP, load it normally in Chromium, and capture reproducible evidence. Never substitute an altered
+or inlined document for the built site.
 
 ## Evidence and truthfulness contract
 
@@ -17,7 +17,7 @@ Never:
 - call a `curl` response a browser test;
 - reuse screenshots from a different head without saying so;
 - empty the managed Chromium `URLBlocklist` or leave a changed policy behind;
-- claim that a screenshot was attached to GitHub when it was only shown in ChatGPT.
+- claim that an image was attached to GitHub when it was only shown in ChatGPT.
 
 If real localhost HTTP navigation cannot be made to work, stop and use exact-head CI evidence or an agent with a supported
 browser environment. Do not fabricate a preview.
@@ -64,20 +64,29 @@ Prefer the dependency-free preview launcher and README included in the packaged 
 
 ```bash
 site_dir=/mnt/data/sniffy-site-<exact-head-sha>
+route=/use-cases/example/
 port=4173
+
 python3 -m http.server "$port" \
   --bind 127.0.0.1 \
   --directory "$site_dir" \
   >/tmp/sniffy-site-preview.log 2>&1 &
 server_pid=$!
 
+for attempt in $(seq 1 50); do
+  if curl --fail --silent "http://127.0.0.1:${port}${route}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
 curl --fail --silent --show-error \
   --output /dev/null \
   --write-out 'HTTP %{http_code}\n' \
-  "http://127.0.0.1:${port}/use-cases/example/"
+  "http://127.0.0.1:${port}${route}"
 ```
 
-A `200` response proves only HTTP serving. Chromium must still load scripts, styles, images, and the page itself.
+A `200` response proves only HTTP serving. Chromium must still load the actual scripts, styles, images, and page.
 
 ## Allow only the exact localhost preview in managed Chromium
 
@@ -141,10 +150,11 @@ evidence.
 ## Open the real page with Playwright
 
 Python Playwright can drive the installed `/usr/bin/chromium`; no browser download is required when outbound DNS is
-unavailable. The script below uses normal HTTP navigation and captures desktop/mobile × light/dark full-page screenshots.
+unavailable. This tested procedure captures desktop/mobile × light/dark full-page screenshots from normal HTTP
+navigation.
 
 ```bash
-export SNIFFY_PREVIEW_URL="http://127.0.0.1:${port}/use-cases/example/"
+export SNIFFY_PREVIEW_URL="http://127.0.0.1:${port}${route}"
 export SNIFFY_PREVIEW_SHA="<exact-head-sha>"
 export SNIFFY_SCREENSHOT_DIR="/mnt/data/sniffy-preview-${SNIFFY_PREVIEW_SHA}"
 mkdir -p "$SNIFFY_SCREENSHOT_DIR"
@@ -153,11 +163,14 @@ python3 <<'PY'
 import json
 import os
 from pathlib import Path
+from urllib.parse import urlsplit
 from playwright.sync_api import sync_playwright
 
 url = os.environ["SNIFFY_PREVIEW_URL"]
 sha = os.environ["SNIFFY_PREVIEW_SHA"]
 out = Path(os.environ["SNIFFY_SCREENSHOT_DIR"])
+parts = urlsplit(url)
+origin = f"{parts.scheme}://{parts.netloc}"
 variants = [("desktop", 1440, 900), ("mobile", 390, 844)]
 themes = ["light", "dark"]
 results = []
@@ -177,6 +190,7 @@ with sync_playwright() as playwright:
             )
             page = context.new_page()
             console_errors = []
+            page_errors = []
             failed_requests = []
             page.on(
                 "console",
@@ -184,21 +198,27 @@ with sync_playwright() as playwright:
                 if message.type == "error"
                 else None,
             )
+            page.on("pageerror", lambda error: page_errors.append(str(error)))
             page.on(
                 "requestfailed",
                 lambda request: failed_requests.append(
-                    {"url": request.url, "failure": request.failure}
+                    {
+                        "url": request.url,
+                        "failure": request.failure,
+                        "sameOrigin": request.url.startswith(origin),
+                    }
                 ),
             )
             page.add_init_script(
                 f"localStorage.setItem('theme', {json.dumps(theme)});"
             )
 
-            response = page.goto(url, wait_until="networkidle")
+            response = page.goto(url, wait_until="load", timeout=15_000)
             if response is None or response.status != 200:
                 raise RuntimeError(f"Navigation failed for {url}: {response}")
+            page.locator("h1").first.wait_for(state="visible", timeout=10_000)
+            page.wait_for_timeout(500)
 
-            page.locator("h1").first.wait_for(state="visible")
             dimensions = page.evaluate(
                 """() => ({
                     documentWidth: document.documentElement.scrollWidth,
@@ -207,6 +227,7 @@ with sync_playwright() as playwright:
                     theme: document.documentElement.dataset.theme
                 })"""
             )
+            local_failures = [item for item in failed_requests if item["sameOrigin"]]
             if dimensions["documentWidth"] > dimensions["viewportWidth"]:
                 raise RuntimeError(
                     f"Horizontal overflow: {dimensions['documentWidth']} > "
@@ -216,12 +237,12 @@ with sync_playwright() as playwright:
                 raise RuntimeError(
                     f"Theme mismatch: expected {theme}, rendered {dimensions['theme']}"
                 )
-            if console_errors or failed_requests:
+            if page_errors or local_failures:
                 raise RuntimeError(
                     json.dumps(
                         {
-                            "consoleErrors": console_errors,
-                            "failedRequests": failed_requests,
+                            "pageErrors": page_errors,
+                            "sameOriginRequestFailures": local_failures,
                         },
                         indent=2,
                     )
@@ -244,6 +265,7 @@ with sync_playwright() as playwright:
                     "h1": page.locator("h1").first.inner_text(),
                     "dimensions": dimensions,
                     "consoleErrors": console_errors,
+                    "pageErrors": page_errors,
                     "failedRequests": failed_requests,
                     "screenshot": str(filename),
                 }
@@ -256,7 +278,8 @@ print(json.dumps(results, indent=2))
 PY
 ```
 
-Do not work around a browser failure by editing or inlining the generated site.
+Console errors and failed external requests are retained in `evidence.json` for inspection. JavaScript page errors and
+failed same-origin requests are blockers. Do not work around a browser failure by editing or inlining the generated site.
 
 ## Restore and verify policy
 
@@ -281,7 +304,7 @@ Open every generated PNG and inspect it. Report:
 - server command and HTTP result;
 - browser executable and Playwright binding;
 - route, viewport, theme, title, H1, document width, and viewport width;
-- console errors and failed requests;
+- console errors, JavaScript page errors, and failed requests;
 - screenshot and `evidence.json` paths;
 - byte-for-byte policy restoration result;
 - any difference from repository visual baselines.

--- a/docs/chatgpt-site-preview.md
+++ b/docs/chatgpt-site-preview.md
@@ -1,59 +1,51 @@
 # ChatGPT website preview and screenshot runbook
 
-Use this runbook when a ChatGPT review needs to inspect a Sniffy website pull request in a real browser. The goal is to
-serve an immutable exact-head build over localhost HTTP, load it normally in Chromium, and capture reproducible evidence
-without pretending that a downloaded artifact was locally built or that an inlined document was the real site.
+Use this runbook when a ChatGPT review needs to inspect a Sniffy website pull request in a real browser. Serve immutable
+exact-head output over localhost HTTP, load it normally in Chromium, and capture reproducible evidence. Do not substitute
+an altered or inlined document for the built site.
 
 ## Evidence and truthfulness contract
 
-Before starting, record:
-
-- repository and pull-request number;
-- exact head SHA being reviewed;
-- route or routes to inspect;
-- CI run and website artifact name, ID, digest, and `head_sha` when using an artifact;
-- requested viewport, theme, browser, and interaction state.
+Record the repository, pull request, exact head SHA, route, viewport, theme, browser, and interaction state. When using CI
+output, also record the workflow run and artifact name, ID, digest, and `head_sha`.
 
 Never:
 
-- inline the built CSS, JavaScript, images, or markup into a substitute HTML document;
+- inline CSS, JavaScript, images, or markup into a substitute HTML document;
 - edit generated output to make it render;
 - call a downloaded CI artifact a local npm build;
 - call a `curl` response a browser test;
 - reuse screenshots from a different head without saying so;
-- clear all Chromium enterprise policies or leave a changed policy behind;
-- publish screenshots without identifying route, viewport, theme, browser, and exact SHA.
+- empty the managed Chromium `URLBlocklist` or leave a changed policy behind;
+- claim that a screenshot was attached to GitHub when it was only shown in ChatGPT.
 
-If real localhost HTTP navigation cannot be made to work, stop and report that limitation. Use the exact-head CI visual
-artifact or ask an agent with a supported browser environment to publish the evidence instead of fabricating a preview.
+If real localhost HTTP navigation cannot be made to work, stop and use exact-head CI evidence or an agent with a supported
+browser environment. Do not fabricate a preview.
 
 ## Choose the input
 
 ### Preferred review path: exact-head CI artifact
 
-For independent review, prefer the packaged website artifact produced by the exact-head `Website` job. This proves the
-same bytes that CI packaged and verified.
+For independent review, prefer the packaged website artifact produced by the exact-head `Website` job:
 
 1. Fetch the pull request and record its immutable `head_sha`.
 2. Fetch workflow runs for that SHA and select the successful exact-head pull-request run.
 3. Fetch the artifact named `sniffy-website-<head_sha>`.
-4. Verify that the artifact metadata points to the same `head_sha`, is not expired, and has a digest.
-5. Download it through the GitHub connector to a temporary path such as `/mnt/data/sniffy-site-<head_sha>.zip`.
-6. Extract it to a fresh directory such as `/mnt/data/sniffy-site-<head_sha>/`.
+4. Verify that its metadata has the same `head_sha`, a digest, and has not expired.
+5. Download it through the GitHub connector to `/mnt/data/sniffy-site-<head_sha>.zip`.
+6. Extract it into a fresh `/mnt/data/sniffy-site-<head_sha>/` directory.
 
-Do not use an artifact from the base commit, a prior pull-request head, a rerun for another SHA, or an unverified local
-folder.
+Do not use an artifact from the base commit, an earlier PR head, or another SHA.
 
 ### Source-build path
 
-Use a source build only when the shell can actually obtain the repository at the exact SHA. Show and retain the command
-results:
+Use a source build only when the shell can actually obtain the repository at the exact SHA. Preserve the output of:
 
 ```bash
 git clone https://github.com/sniffy/sniffy.git /tmp/sniffy
 cd /tmp/sniffy
 git checkout --detach <exact-head-sha>
-git rev-parse HEAD
+test "$(git rev-parse HEAD)" = "<exact-head-sha>"
 cd sniffy-ui
 node --version
 npm --version
@@ -63,13 +55,12 @@ npm run package:site-artifact
 npm run verify:site-artifact
 ```
 
-The checked-out SHA must equal the reviewed head. If DNS or outbound networking prevents `git clone` or package download,
-do not claim that these commands ran. Fall back to the GitHub connector and the exact-head CI artifact.
+If DNS or outbound networking prevents checkout or package download, do not claim these commands ran. Use the GitHub
+connector and exact-head CI artifact instead.
 
 ## Serve the unmodified artifact over HTTP
 
-Prefer the dependency-free preview launcher included in the packaged artifact when present and follow its README. A
-portable fallback is:
+Prefer the dependency-free preview launcher and README included in the packaged artifact. A portable fallback is:
 
 ```bash
 site_dir=/mnt/data/sniffy-site-<exact-head-sha>
@@ -79,36 +70,22 @@ python3 -m http.server "$port" \
   --directory "$site_dir" \
   >/tmp/sniffy-site-preview.log 2>&1 &
 server_pid=$!
-```
 
-Before opening a browser, prove the server and target route respond:
-
-```bash
 curl --fail --silent --show-error \
   --output /dev/null \
   --write-out 'HTTP %{http_code}\n' \
   "http://127.0.0.1:${port}/use-cases/example/"
 ```
 
-A `200` response proves only HTTP serving. Browser rendering, scripts, styles, assets, console output, and failed requests
-must still be checked in Chromium.
+A `200` response proves only HTTP serving. Chromium must still load scripts, styles, images, and the page itself.
 
 ## Allow only the exact localhost preview in managed Chromium
 
-The ChatGPT sandbox may install a managed Chromium policy containing:
+The ChatGPT sandbox may have `/etc/chromium/policies/managed/000_policy_merge.json` with
+`"URLBlocklist": ["*"]`. Do not remove or empty it. In a disposable sandbox running as root, temporarily append exact
+`URLAllowlist` entries for the selected port while preserving every other policy.
 
-```json
-{
-  "URLBlocklist": ["*"]
-}
-```
-
-Do not remove or empty that blocklist. In a disposable sandbox where the process runs as root, temporarily add an exact
-`URLAllowlist` exception for the chosen localhost port, keep every other policy unchanged, start a new Chromium process,
-and restore the original file on every exit path.
-
-The current sandbox policy is normally `/etc/chromium/policies/managed/000_policy_merge.json`. Discover and inspect it
-rather than assuming:
+Discover and inspect the file rather than assuming it:
 
 ```bash
 policy_file=/etc/chromium/policies/managed/000_policy_merge.json
@@ -116,20 +93,21 @@ test -f "$policy_file"
 python3 -m json.tool "$policy_file"
 ```
 
-Use an exact port; an IP-address filter does not accept a wildcard port in Chromium's URL filter grammar.
+Use an exact port. Chromium's URL filter grammar does not accept a wildcard port for an IP address.
 
 ```bash
 policy_backup=$(mktemp)
 cp --preserve=all "$policy_file" "$policy_backup"
+original_policy_hash=$(sha256sum "$policy_file" | cut -d' ' -f1)
 
-restore_policy() {
+cleanup() {
   cp --preserve=all "$policy_backup" "$policy_file" 2>/dev/null || true
   rm -f "$policy_backup"
   if [[ -n "${server_pid:-}" ]]; then
     kill "$server_pid" 2>/dev/null || true
   fi
 }
-trap restore_policy EXIT INT TERM
+trap cleanup EXIT INT TERM
 
 python3 - "$policy_file" "$port" <<'PY'
 import json
@@ -155,33 +133,15 @@ with open(path, "w", encoding="utf-8") as destination:
 PY
 ```
 
-This exception is safer than setting `URLBlocklist` to an empty list: all non-local navigation remains blocked. Never do
-this on a user's workstation, a persistent shared host, or an environment whose policy ownership is unclear. Without root
-or an exact reversible policy file, stop and use CI evidence.
-
-After the browser exits, verify restoration explicitly:
-
-```bash
-python3 - "$policy_file" <<'PY'
-import json
-import sys
-policy = json.load(open(sys.argv[1], encoding="utf-8"))
-assert policy.get("URLBlocklist") == ["*"]
-assert "URLAllowlist" not in policy or all(
-    not entry.startswith("http://127.0.0.1:") and not entry.startswith("http://localhost:")
-    for entry in policy["URLAllowlist"]
-)
-print('Chromium URL policy restored')
-PY
-```
+Start a new Chromium process after changing the policy. This exact allowlist exception is safer than clearing the
+blocklist: non-local navigation remains blocked. Never modify browser policy on a user's workstation, a persistent shared
+host, or an environment whose policy ownership is unclear. Without root and a reversible policy file, stop and use CI
+evidence.
 
 ## Open the real page with Playwright
 
-The Python Playwright package can drive the installed `/usr/bin/chromium`; downloading another browser is unnecessary
-when outbound DNS is unavailable.
-
-The following script captures desktop/mobile and light/dark full-page screenshots from normal HTTP navigation. Adjust the
-route and output directory, but do not alter the built site.
+Python Playwright can drive the installed `/usr/bin/chromium`; no browser download is required when outbound DNS is
+unavailable. The script below uses normal HTTP navigation and captures desktop/mobile × light/dark full-page screenshots.
 
 ```bash
 export SNIFFY_PREVIEW_URL="http://127.0.0.1:${port}/use-cases/example/"
@@ -198,11 +158,7 @@ from playwright.sync_api import sync_playwright
 url = os.environ["SNIFFY_PREVIEW_URL"]
 sha = os.environ["SNIFFY_PREVIEW_SHA"]
 out = Path(os.environ["SNIFFY_SCREENSHOT_DIR"])
-
-variants = [
-    ("desktop", 1440, 900),
-    ("mobile", 390, 844),
-]
+variants = [("desktop", 1440, 900), ("mobile", 390, 844)]
 themes = ["light", "dark"]
 results = []
 
@@ -212,7 +168,6 @@ with sync_playwright() as playwright:
         headless=True,
         args=["--no-sandbox"],
     )
-
     for viewport_name, width, height in variants:
         for theme in themes:
             context = browser.new_context(
@@ -236,8 +191,7 @@ with sync_playwright() as playwright:
                 ),
             )
             page.add_init_script(
-                "theme => localStorage.setItem('theme', theme)",
-                theme,
+                f"localStorage.setItem('theme', {json.dumps(theme)});"
             )
 
             response = page.goto(url, wait_until="networkidle")
@@ -245,8 +199,6 @@ with sync_playwright() as playwright:
                 raise RuntimeError(f"Navigation failed for {url}: {response}")
 
             page.locator("h1").first.wait_for(state="visible")
-            title = page.title()
-            heading = page.locator("h1").first.inner_text()
             dimensions = page.evaluate(
                 """() => ({
                     documentWidth: document.documentElement.scrollWidth,
@@ -282,10 +234,14 @@ with sync_playwright() as playwright:
                     "sha": sha,
                     "url": url,
                     "browser": "system Chromium via Playwright",
-                    "viewport": {"name": viewport_name, "width": width, "height": height},
+                    "viewport": {
+                        "name": viewport_name,
+                        "width": width,
+                        "height": height,
+                    },
                     "theme": theme,
-                    "title": title,
-                    "h1": heading,
+                    "title": page.title(),
+                    "h1": page.locator("h1").first.inner_text(),
                     "dimensions": dimensions,
                     "consoleErrors": console_errors,
                     "failedRequests": failed_requests,
@@ -293,7 +249,6 @@ with sync_playwright() as playwright:
                 }
             )
             context.close()
-
     browser.close()
 
 (out / "evidence.json").write_text(json.dumps(results, indent=2) + "\n")
@@ -301,29 +256,35 @@ print(json.dumps(results, indent=2))
 PY
 ```
 
-If `page.add_init_script` uses a different Playwright binding version, pass the script as a single JavaScript string with
-the theme value JSON-encoded. Do not fall back to editing generated HTML.
+Do not work around a browser failure by editing or inlining the generated site.
+
+## Restore and verify policy
+
+After Playwright completes, restore before reporting success:
+
+```bash
+cleanup
+trap - EXIT INT TERM
+restored_policy_hash=$(sha256sum "$policy_file" | cut -d' ' -f1)
+test "$restored_policy_hash" = "$original_policy_hash"
+echo 'Chromium policy restored byte-for-byte'
+```
+
+The cleanup path must also run after a failed browser launch, timeout, or interrupted task.
 
 ## Review and report
 
-Open every generated PNG and inspect it rather than relying only on dimensions or a screenshot-test exit code. Report:
+Open every generated PNG and inspect it. Report:
 
 - exact head SHA and artifact identity;
-- whether input was a CI artifact or a locally built checkout;
+- whether the input was a CI artifact or a locally built checkout;
 - server command and HTTP result;
 - browser executable and Playwright binding;
 - route, viewport, theme, title, H1, document width, and viewport width;
 - console errors and failed requests;
-- screenshot paths;
-- policy restoration result;
-- any difference from the repository's asserted visual baselines.
+- screenshot and `evidence.json` paths;
+- byte-for-byte policy restoration result;
+- any difference from repository visual baselines.
 
-The screenshots may be shown in ChatGPT with sandbox links. Publishing them into a GitHub pull request requires a GitHub
-attachment-capable path or an agent environment that supports the repository screenshot publishing helper. Do not imply
-that a local ChatGPT sandbox image was attached to GitHub when it was only shown in the conversation.
-
-## Cleanup
-
-The `trap` must restore the browser policy and stop the server even when Playwright fails. Then remove temporary extracted
-artifacts and browser profiles when they are no longer needed. Retain only evidence intentionally shared with the
-maintainer.
+Screenshots may be shown in ChatGPT with sandbox links. Publishing into a GitHub PR requires an attachment-capable GitHub
+path or the repository screenshot publishing helper in an agent environment.


### PR DESCRIPTION
## Problem

A regular ChatGPT review can access GitHub through the connector even when its shell sandbox cannot resolve `github.com`. The sandbox's installed Chromium may also be managed by `URLBlocklist: ["*"]`. Without a repository-owned runbook, this led to ad hoc preview attempts and made it too easy to confuse a downloaded CI artifact, a local npm build, a `curl` check, an inlined document, and a real browser render.

## Changes

- Add `docs/chatgpt-project-setup.md` with the exact small instruction block to place in the Sniffy ChatGPT Project. It links to current `develop` copies of `AGENTS.md` and the preview runbook instead of duplicating policy in ChatGPT.
- Add `docs/chatgpt-site-preview.md` covering:
  - exact-head source-build versus CI-artifact evidence;
  - truthful fallback to the GitHub connector when shell DNS is unavailable;
  - serving the unmodified packaged site over real localhost HTTP;
  - retaining `URLBlocklist: ["*"]` while adding only exact temporary localhost `URLAllowlist` entries for the selected port;
  - byte-for-byte policy backup and restoration on success, failure, interruption, or timeout;
  - Playwright-driven system Chromium screenshots for desktop/mobile and light/dark;
  - same-origin request failure, JavaScript error, overflow, theme, title, H1, console, and evidence recording;
  - explicit prohibition on HTML/CSS/image inlining or misrepresenting artifact/build/publication state.

## Validation

The documented localhost allowlist and Playwright procedure was executed in the ChatGPT sandbox against the exact-head packaged website artifact from PR #709:

- real HTTP navigation returned 200;
- desktop 1440×900 and mobile 390×844 passed in light and dark themes;
- document width matched viewport width in all four variants;
- no JavaScript page errors or same-origin failed requests occurred;
- the original managed Chromium policy was restored byte-for-byte.

Repository comparison against current `develop` shows only the two new Markdown files. A shell checkout was not available because the ChatGPT shell could not resolve `github.com`, so no claim is made that `git diff --check` or an npm build ran for this documentation-only PR.

## Risk

Documentation only. The runbook permits temporary policy modification solely in a disposable root-owned ChatGPT sandbox, retains the global blocklist, allowlists only the exact localhost port, and requires byte-for-byte restoration. It explicitly forbids applying the procedure on a user's workstation or persistent/shared host.

Never merge or enable auto-merge without Dmitry's explicit command.