### PR TITLE
Handle multiline project-status comments

### DIFF
--- a/.github/workflows/project-status.yml
+++ b/.github/workflows/project-status.yml
@@ -35,7 +35,8 @@ jobs:
             const organization = 'sniffy';
             const projectNumber = 2;
             const commandPrefix = '/project-status ';
-            const requestedStatus = context.payload.comment.body
+            const commandLine = context.payload.comment.body.split(/\r?\n/, 1)[0];
+            const requestedStatus = commandLine
               .slice(commandPrefix.length)
               .trim();
 


### PR DESCRIPTION
## Problem

The `Update project status` workflow treated everything after `/project-status ` as the requested status. A comment whose first line was `/project-status Ready for agent` and which contained additional dispatch instructions therefore failed with an unknown multiline status.

Triggered by:
- failed run: https://github.com/sniffy/sniffy/actions/runs/30383480856/job/90356829843
- comment: https://github.com/sniffy/sniffy/issues/669#issuecomment-5107569941

## Change

Parse the status from the command's first line only, supporting both LF and CRLF comments. Additional paragraphs remain available for human or agent instructions and no longer become part of the project status.

## Compatibility and impact

- Existing single-line `/project-status <status>` comments behave unchanged.
- Multi-word statuses remain supported.
- No permissions, project configuration, status options, or unrelated workflows changed.
- No dependency changes.

## Validation

Ran focused parsing checks with Node.js 22 for:
- an existing single-line command;
- the failing multiline shape;
- CRLF input;
- trailing whitespace before additional text.

All cases passed.

Exact published head: `f6e317964cf1e44adaac0cab4043d608dade5d57`