### PR TITLE
Fix Pages artifact canonical verification

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -163,6 +163,7 @@ jobs:
 
       - name: Verify GitHub Pages artifact
         env:
+          SNIFFY_SITE_URL: ${{ steps.pages.outputs.origin }}
           SNIFFY_SITE_BASE_URL: ${{ format('{0}/', steps.pages.outputs.base_path) }}
         run: npm run verify:site-artifact
 

--- a/sniffy-ui/apps/site/scripts/verify-artifact.mjs
+++ b/sniffy-ui/apps/site/scripts/verify-artifact.mjs
@@ -8,10 +8,12 @@ import { URL } from 'node:url';
 import { chromium } from '@playwright/test';
 
 const build = resolve(import.meta.dirname, '../build');
+const siteUrl = process.env.SNIFFY_SITE_URL?.trim() || 'https://sniffy.io';
 const baseUrl = process.env.SNIFFY_SITE_BASE_URL?.trim() || '/';
 if (!baseUrl.startsWith('/') || !baseUrl.endsWith('/') || baseUrl.includes('//')) {
   throw new Error(`SNIFFY_SITE_BASE_URL must have one leading and trailing slash: ${baseUrl}`);
 }
+const canonicalSiteUrl = new URL(baseUrl, siteUrl).toString();
 const packagedPreview = resolve(build, 'preview.mjs');
 const previewScript = existsSync(packagedPreview)
   ? packagedPreview
@@ -52,6 +54,7 @@ const browser = await chromium.launch();
 try {
   const previewSiteUrl = new URL(baseUrl, previewUrl).toString();
   const previewRoute = (route) => new URL(route, previewSiteUrl).toString();
+  const configuredRoute = (route) => new URL(route, canonicalSiteUrl).toString();
   const canonicalRoute = (route) => new URL(route, 'https://sniffy.io/').toString();
   const page = await browser.newPage();
   const pageErrors = [];
@@ -154,7 +157,7 @@ try {
   await page.goto(previewRoute('docs/3.1/'), { waitUntil: 'networkidle' });
   if (
     (await page.locator('link[rel="canonical"]').getAttribute('href')) !==
-      canonicalRoute('docs/3.1/') ||
+      configuredRoute('docs/3.1/') ||
     !(
       await page.getByRole('complementary', { name: 'Archived documentation notice' }).textContent()
     )?.includes('unsupported version')

--- a/sniffy-ui/apps/site/src/site.test.ts
+++ b/sniffy-ui/apps/site/src/site.test.ts
@@ -175,6 +175,9 @@ describe('@sniffy/site workspace contract', () => {
     expect(preview).not.toMatch(/from ['"][^n.]/);
     expect(verification).toContain("import { chromium } from '@playwright/test';");
     expect(verification).toContain("page.goto(url, { waitUntil: 'networkidle' })");
+    expect(verification).toContain("process.env.SNIFFY_SITE_URL?.trim() || 'https://sniffy.io'");
+    expect(verification).toContain('new URL(baseUrl, siteUrl).toString()');
+    expect(verification).toContain("new URL(route, 'https://sniffy.io/').toString()");
     expect(verification).toContain('Search current Sniffy documentation');
     expect(verification).toContain('traffic capture');
     expect(verification).toContain('use-cases/database-query-testing/');
@@ -372,6 +375,9 @@ describe('website deployment workflow contract', () => {
     expect(workflow).toContain('name: sniffy-pages-${{ steps.revision.outputs.sha }}');
     expect(workflow).toContain('> apps/site/build/.sniffy-deployment.json');
     expect(workflow).toContain('content_digest=');
+    expect(workflow).toMatch(
+      /- name: Verify GitHub Pages artifact\n\s+env:\n\s+SNIFFY_SITE_URL: \$\{\{ steps\.pages\.outputs\.origin \}\}\n\s+SNIFFY_SITE_BASE_URL:/,
+    );
     expect(workflow.indexOf('- name: Verify GitHub Pages artifact')).toBeLessThan(
       workflow.indexOf('- name: Record immutable artifact identity'),
     );


### PR DESCRIPTION
## Problem

The automatic `Deploy website` run for merged commit `2447faa6ce95cb96bcf8409c676422a202122aa3` failed in `Verify GitHub Pages artifact` after every preceding validation step passed. The exact Pages-shaped reproduction showed that archived Docusaurus documentation emits its canonical URL from the official Pages origin and base path, while the verifier expected the production root domain unconditionally.

Run: https://github.com/sniffy/sniffy/actions/runs/30328690678

Refs #669.

## Root cause and fix

- pass `actions/configure-pages`' official `origin` output into the exact artifact verifier, alongside its existing `base_path`
- derive the archived-documentation canonical expectation from that configured origin/base path
- preserve the authored use-case canonical contract on `https://sniffy.io/`
- add a focused workflow/script contract for the origin wiring and the two distinct canonical behaviors

The official Pages actions, full-SHA and `origin/develop` ancestry guards, validation-before-upload, permissions, protected environment, concurrency, artifact identity, deployment URL, rollback semantics, Maven/release isolation, and domain boundaries are unchanged.

## Exact published revision

`f42a625d0781070bd775c3d6380a0b3ad0ed79eb`

## Validation

- reproduced run 30328690678 from exact commit `2447faa6ce95cb96bcf8409c676422a202122aa3` in the pinned Node 24 Bookworm-slim container: failure at archived 3.1 canonical verification
- corrected Pages-shaped build/verifier with live configuration `http://sniffy.io` + `/sniffy/`: representative routes, archived 3.1 metadata/banner/search, assets, legacy redirect, branded 404, authored use-case metadata, and search navigation passed
- focused `site.test.ts`: 17/17 passed
- full site unit suite: 15 files / 122 tests passed
- full site Playwright suite: 128/128 passed, including desktop/mobile and visual baselines
- default packaged artifact verifier passed
- full workspace lint and Prettier passed
- TypeScript workspace typecheck passed
- Storybook build passed
- production frontend build passed
- generated-resource reproducibility passed (7 files)
- bundle validation passed
- actionlint 1.7.7 passed
- `git diff --check` passed

## Boundaries

No deployment, merge, auto-merge, Pages/environment/repository setting, DNS, custom-domain, `CNAME`, HTTPS, Maven/release, Java/runtime, or `sniffy/sniffy.github.io` change was performed. Production deployment and rollback evidence remain post-merge work.