### PR TITLE
Prevent website-only pushes from triggering Maven deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - develop
+    paths-ignore:
+      - .github/workflows/website-deploy.yml
+      - docs/website-deployment.md
+      - sniffy-ui/apps/site/**
+      - sniffy-ui/packages/theme/**
   release:
     types: [ created ]
 env:

--- a/sniffy-ui/apps/site/src/site.test.ts
+++ b/sniffy-ui/apps/site/src/site.test.ts
@@ -306,6 +306,58 @@ describe('website validation workflow contract', () => {
   });
 });
 
+describe('release workflow push filter contract', () => {
+  const workflow = readFileSync(resolve(repository, '.github/workflows/deploy.yml'), 'utf8');
+  const pushTrigger = workflow.match(/ {2}push:\n([\s\S]*?)(?=\n {2}release:\n)/)?.[1];
+  const ignoredPaths =
+    pushTrigger
+      ?.match(/ {4}paths-ignore:\n([\s\S]*)/)?.[1]
+      .split('\n')
+      .map((line) => line.match(/^\s+- (.+)$/)?.[1])
+      .filter((path): path is string => path !== undefined) ?? [];
+  const pathIsIgnored = (path: string) =>
+    ignoredPaths.some((pattern) =>
+      pattern.endsWith('/**') ? path.startsWith(pattern.slice(0, -2)) : path === pattern,
+    );
+  const workflowRunsForPush = (changedPaths: string[]) => !changedPaths.every(pathIsIgnored);
+
+  it('ignores only the narrow website-owned path set on develop pushes', () => {
+    expect(pushTrigger).toBeDefined();
+    expect(pushTrigger).toMatch(/branches:\n\s+- develop/);
+    expect(ignoredPaths).toEqual([
+      '.github/workflows/website-deploy.yml',
+      'docs/website-deployment.md',
+      'sniffy-ui/apps/site/**',
+      'sniffy-ui/packages/theme/**',
+    ]);
+    expect(
+      workflowRunsForPush([
+        '.github/workflows/website-deploy.yml',
+        'docs/website-deployment.md',
+        'sniffy-ui/apps/site/src/pages/index.tsx',
+        'sniffy-ui/packages/theme/src/base.css',
+      ]),
+    ).toBe(false);
+  });
+
+  it('still runs for mixed and Maven-releasable pushes', () => {
+    expect(
+      workflowRunsForPush([
+        'sniffy-ui/apps/site/src/pages/index.tsx',
+        'sniffy-core/src/main/java/io/sniffy/Sniffy.java',
+      ]),
+    ).toBe(true);
+    expect(workflowRunsForPush(['pom.xml'])).toBe(true);
+    expect(workflowRunsForPush(['sniffy-ui/package-lock.json'])).toBe(true);
+    expect(workflowRunsForPush(['sniffy-core/src/test/java/io/sniffy/SniffyTest.java'])).toBe(true);
+  });
+
+  it('preserves manual dispatch and release triggers', () => {
+    expect(workflow).toMatch(/on:\n {2}workflow_dispatch:\n {2}push:/);
+    expect(workflow).toMatch(/ {2}release:\n {4}types: \[ created \]/);
+  });
+});
+
 describe('website deployment workflow contract', () => {
   const workflow = readFileSync(
     resolve(repository, '.github/workflows/website-deploy.yml'),


### PR DESCRIPTION
Closes #739

## Problem

Website-only merge `ccc62a13b5a7b8e5e6a976b1448f5f772cea78b2` started the legacy **Build and deploy** run [30405754903](https://github.com/sniffy/sniffy/actions/runs/30405754903). That run reached `Publish to the Maven Central Repository` and queued `Publish to GitHub Packages`, even though the dedicated Pages workflow is intended to isolate website deployment from library publication.

## Design

Add GitHub-native `push.paths-ignore` filtering to `.github/workflows/deploy.yml` for the four narrowly website-owned paths:

- `.github/workflows/website-deploy.yml`
- `docs/website-deployment.md`
- `sniffy-ui/apps/site/**`
- `sniffy-ui/packages/theme/**`

GitHub skips a `paths-ignore` workflow only when every changed path matches the ignore set. A mixed website + Maven/releasable push therefore still starts **Build and deploy**. Shared frontend inputs (`package.json`, lockfile, TypeScript/Vitest/ESLint configuration), Maven POMs, Java snippets, tests, and all other repository paths remain release-triggering inputs.

The existing `release` and `workflow_dispatch` triggers, jobs, matrices, permissions, secrets, caches, and Maven publication commands are unchanged.

## Compatibility and dependencies

- No runtime, Java API, artifact, Maven-coordinate, dependency, or website behavior change.
- No Pages, DNS, custom-domain, CNAME, HTTPS, environment, repository-setting, or credential mutation.
- No dependency changes.

## Proof

- Focused workflow contract: 20/20 tests passed; covers exact ignored paths, website-only pushes, mixed website + Java pushes, normal Maven pushes, shared lockfile/test inputs, and unchanged manual/release triggers.
- YAML parsing passed and reported the exact intended trigger object.
- `actionlint 1.7.7` passed after excluding only pre-existing findings reproduced unchanged on `origin/develop` (future runner labels and the existing undefined `matrix.language`).
- Frontend lint/formatting and TypeScript validation passed.
- Full frontend Vitest/Storybook browser suite: 28 files, 184 tests passed.
- Storybook build, production frontend build, generated-resource reproducibility (7 files), and bundle checks passed.
- Site verification: 15 files / 125 unit tests and 128 Playwright tests passed.
- Full Maven reactor: 40/40 modules passed `clean verify` with the repository CI profile.
- `git diff --check` passed.

## Published head

`c3a3ce33af61696dd14772d894a85defe5bd7f58`

## Exact-head CI

- **Check Pull Request** run [30431326647](https://github.com/sniffy/sniffy/actions/runs/30431326647) completed successfully at the published head with 26/26 jobs green after one infrastructure-only rerun.
- The initial Windows JDK 8 attempt failed before the build when `setup-maven` hit `read ECONNRESET`; no code change was made, and the same-head failed-job rerun completed green.
- **Automatic Dependency Submission** run [30431289475](https://github.com/sniffy/sniffy/actions/runs/30431289475) succeeded at the same head.
- The PR rollup has 31 successful checks and one neutral informational check; Codecov reports every modified coverable line covered.

The PR remains open and Draft for maintainer review. Auto-merge is disabled. No deployment or publication workflow was dispatched.