### PR TITLE
Prevent runbook-only Maven deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
       - develop
     paths-ignore:
       - .github/workflows/website-deploy.yml
+      - docs/website-architecture.md
       - docs/website-deployment.md
       - sniffy-ui/apps/site/**
       - sniffy-ui/packages/theme/**

--- a/sniffy-ui/apps/site/src/site.test.ts
+++ b/sniffy-ui/apps/site/src/site.test.ts
@@ -326,6 +326,7 @@ describe('release workflow push filter contract', () => {
     expect(pushTrigger).toMatch(/branches:\n\s+- develop/);
     expect(ignoredPaths).toEqual([
       '.github/workflows/website-deploy.yml',
+      'docs/website-architecture.md',
       'docs/website-deployment.md',
       'sniffy-ui/apps/site/**',
       'sniffy-ui/packages/theme/**',
@@ -333,10 +334,17 @@ describe('release workflow push filter contract', () => {
     expect(
       workflowRunsForPush([
         '.github/workflows/website-deploy.yml',
+        'docs/website-architecture.md',
         'docs/website-deployment.md',
         'sniffy-ui/apps/site/src/pages/index.tsx',
         'sniffy-ui/packages/theme/src/base.css',
       ]),
+    ).toBe(false);
+  });
+
+  it('ignores the exact production-runbook docs-only merge path set', () => {
+    expect(
+      workflowRunsForPush(['docs/website-architecture.md', 'docs/website-deployment.md']),
     ).toBe(false);
   });
 


### PR DESCRIPTION
Closes #739

## Problem

Merged runbook PR #742 changed only `docs/website-deployment.md` and `docs/website-architecture.md`, yet it started unsafe **Build and deploy** run [30441408058](https://github.com/sniffy/sniffy/actions/runs/30441408058). PR #741 ignored the deployment runbook but omitted its equally website-owned architecture companion.

## Design

Add only `docs/website-architecture.md` to the existing GitHub-native `push.paths-ignore` set in `.github/workflows/deploy.yml`. Extend the established static contract to reproduce PR #742's exact two-document change set.

GitHub skips a `paths-ignore` workflow only when every changed path matches the ignore set, so mixed website + Maven/releasable pushes still start **Build and deploy**. Broad `docs/**`, shared frontend inputs, POMs, Java sources/tests, release inputs, and every other repository path remain release-triggering.

The `release` and `workflow_dispatch` triggers, jobs, matrices, permissions, secrets, caches, and Maven publication commands are unchanged.

## Compatibility and dependencies

- No runtime, Java API, artifact, Maven-coordinate, dependency, website, Pages, DNS, domain, environment, credential, or publication-setting change.
- Two authorized files changed: the existing release workflow and its focused contract.

## Local proof

- Focused release-workflow contract: 21/21 passed in pinned Node 24.18.0 Bookworm.
- Full frontend Vitest/Storybook suite: 28 files / 185 tests passed.
- Site contracts: 15 files / 126 tests passed; exact Bookworm Playwright run: 128/128 passed.
- Frontend install, lint, typecheck, Storybook build, production build, generated-resource reproducibility, and bundle checks passed.
- YAML parsing and `git diff --check` passed.
- actionlint 1.7.7 produced only the unchanged repository baseline for future runner labels and the existing `matrix.language` expression.
- Full clean Maven reactor on Java 21: 40/40 modules passed. An earlier Java 17.0.2 host run hit its environment-specific JDK cgroup initialization NPE in the Tomcat 9 test; no code was changed for it.

## Published head

`7129c1e736a052539be54084a041187495c3f1b5`

## Exact-head CI

- [Dynamic dependency submission 30443427517](https://github.com/sniffy/sniffy/actions/runs/30443427517): success.
- [Check Pull Request 30443457390](https://github.com/sniffy/sniffy/actions/runs/30443457390): success, 26/26 jobs at the published head.
- Codecov project and patch checks for backend and frontend: success.
- CodeQL analysis job: success; its informational aggregate check concluded neutral.
- Reviewable website artifact: `sniffy-website-7129c1e736a052539be54084a041187495c3f1b5` (artifact 8720541142, 6,459,266 bytes, unexpired). The Website job also verified its downloaded preview.

Auto-merge is disabled. This PR must not be merged by the local worker.