### PR TITLE
Rename AI delivery lifecycle fields to Status and Execution

### DIFF
--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -19,29 +19,30 @@ launch nested CLI agents, review the worker's PR, merge, or enable auto-merge.
 1. Read AGENTS.md and docs/ai-delivery/{README,lifecycle,event-loop,routing,supervision,verification}.md plus this prompt and
    the worker template.
 2. Inspect project 2 and choose at most one sniffy/sniffy item where:
-   - Status = Ready;
+   - Execution = Ready;
    - Executor = Local Codex app;
-   - Phase = Implementation or Verification;
+   - Status = Implementation or Verification;
    - Assignee is empty or already matches the dedicated local-worker identity.
-3. Re-read the issue, routing, proof matrix, Phase/Status/Implementer/Verifier/Executor, branch/PR, existing claims, worker
+3. Re-read the issue, routing, proof matrix, Status/Execution/Implementer/Verifier/Executor, branch/PR, existing claims, worker
    references, review state, and CI. Prefer a valid re-queued continuation over fresh work. Never create a duplicate worker.
 4. If no eligible item exists, create no task, conversation, worktree, branch, comment, or field mutation. Reply only
    NO_CHANGE.
 5. Select a deterministic candidate by Project priority, ready timestamp, then issue number. Classify fresh versus
    continuation and choose model/reasoning from explicit routing.
 6. Claim using docs/ai-delivery/event-loop.md: create a unique intent for the current dispatch generation, verify the winning
-   intent, then set Status = In progress, concrete Assignee, claim token/lease, and provisional worker state. If any claim
-   mutation or later child creation fails, release to Ready or record an exact Blocked reason.
-7. Render every placeholder in .codex/local/worker-task-prompt.md, including <PHASE>, <IMPLEMENTER>, and <VERIFIER>.
-8. Create exactly one NEW one-time standalone app-owned task named "Sniffy #<issue-number> <phase>: <issue-title>" using the
+   intent, then set Execution = In progress, concrete Assignee, claim token/lease, and provisional worker state. If any claim
+   mutation or later child creation fails, release to Ready. Set Blocked only when Dmitry must decide or act; then set
+   Executor = Human, Assignee = bedrin, and record the exact requested action.
+7. Render every placeholder in .codex/local/worker-task-prompt.md, including <STATUS>, <IMPLEMENTER>, and <VERIFIER>.
+8. Create exactly one NEW one-time standalone app-owned task named "Sniffy #<issue-number> <status>: <issue-title>" using the
    current local project, a new isolated worktree, selected model/reasoning, and the rendered prompt. Never create it in this
    dispatcher conversation.
 9. Do not use shell UI automation, Python observers, codex app-server, codex exec, or .codex/local/run-issue.sh for this
    app-native adapter.
-10. After confirming the child task exists, record its exact title/reference, claim token, phase, worktree, branch, and
-    timestamp. If child creation fails, leave no In progress item without a worker reference.
+10. After confirming the child task exists, record its exact title/reference, claim token, lifecycle status, worktree, branch,
+    and timestamp. If child creation fails, leave no In progress item without a worker reference.
 
-Never dispatch the same phase generation twice. Never merge or enable auto-merge.
+Never dispatch the same lifecycle generation twice. Never merge or enable auto-merge.
 ```
 
 ## Required smoke test
@@ -50,10 +51,10 @@ Before enabling the recurring dispatcher, prove with disposable/read-only items 
 
 - an empty tick stays in this conversation and creates no worktree;
 - one eligible item creates exactly one standalone worker conversation and isolated WSL worktree;
-- the worker receives the intended Phase and routing fields;
+- the worker receives the intended Status and routing fields;
 - concurrent dispatcher attempts produce one winning claim;
 - failed child creation releases the claim;
-- a completed worker hands off to the next phase rather than creating its own reviewer conversation.
+- a completed worker hands off to the next lifecycle status rather than creating its own reviewer conversation.
 
 Repeat after material Codex automation changes. If nested one-time task creation is unavailable, pause this adapter and use a
 manual app worker or the headless Linux adapter; do not substitute external UI automation.

--- a/.codex/local/worker-task-prompt.md
+++ b/.codex/local/worker-task-prompt.md
@@ -1,14 +1,16 @@
-# Sniffy app-native Local Codex phase-worker template
+# Sniffy app-native Local Codex lifecycle-worker template
 
 The dispatcher renders this template into one standalone app-owned worker conversation and isolated worktree. The worker owns
-one phase turn only. Shared policy lives in `AGENTS.md` and `docs/ai-delivery/`.
+one lifecycle turn only. Shared policy lives in `AGENTS.md` and `docs/ai-delivery/`.
 
 ```text
-Work autonomously on one phase of Sniffy issue #<ISSUE_NUMBER> in this dedicated worker conversation and isolated worktree.
+Work autonomously on one lifecycle status of Sniffy issue #<ISSUE_NUMBER> in this dedicated worker conversation and isolated
+worktree.
 
 Issue title: <ISSUE_TITLE>
 Issue URL: <ISSUE_URL>
-Phase: <PHASE>
+Status: <STATUS>
+Execution: In progress
 Mode: <WORK_MODE>
 Base branch: develop
 Branch: <BRANCH_NAME>
@@ -24,9 +26,10 @@ Before any mutation, read the complete issue/comments, lifecycle and routing fie
 submissions and unresolved threads, current CI, remote develop, nearest AGENTS.md, and
 `docs/ai-delivery/{lifecycle,supervision,verification}.md`. Verify this task still owns the exact claim token/generation.
 
-Stop and set the current phase to Blocked when a required product, API, architecture, compatibility, permission, credential,
-privileged operation, external service, or bespoke-infrastructure decision is missing. Record the smallest next action. Do
-not invent a decision or create a replacement worker.
+Stop autonomous work when a required product, API, architecture, compatibility, permission, credential, privileged operation,
+external service, or bespoke-infrastructure decision is missing. Keep the current Status, set Execution = Blocked,
+Executor = Human, and Assignee = bedrin. Record the smallest decision or action Dmitry must take. Do not invent a decision or
+create a replacement worker. Routine waiting for CI or another observable operation this worker started remains In progress.
 
 Branch rules:
 - fresh Implementation: verify no branch/PR/worker already owns the issue and create <BRANCH_NAME> from current origin/develop;
@@ -35,7 +38,7 @@ Branch rules:
   replacement implementation branch;
 - never reset, rebase, force-push, replace an existing PR, discard unrelated work, or merge.
 
-If <PHASE> is Implementation:
+If <STATUS> is Implementation:
 1. Convert every acceptance criterion into implementer-owned proof and implement the smallest coherent solution.
 2. Run focused tests first, broader applicable checks separately, and directly available runtime/browser checks. Confirm named
    tests actually ran; record unsupported proof honestly.
@@ -44,35 +47,37 @@ If <PHASE> is Implementation:
    implementation or locally available proof is incomplete.
 5. Verify the remote branch, full SHA, PR URL, base/head refs, draft state, and matching PR head.
 6. Publish exact commands/results/limitations and hand off:
-   - Phase = Review;
-   - Status = Ready;
+   - Status = Review;
+   - Execution = Ready;
    - Executor = ChatGPT;
    - Assignee = bedrin-gpt;
    - clear this worker/lease after the handoff is durably recorded.
 7. Do not review or approve your own implementation and do not create a follow-up reviewer task. The shared event loop owns
-   the Review phase.
+   the Review lifecycle status.
 
-If <PHASE> is Verification:
+If <STATUS> is Verification:
 1. Re-read the authoritative issue and later discussion. Identify the observable user/developer journey, negative cases,
    exact implementation head/artifact, and representative environment.
 2. Perform outcome-centric system/integration/browser/compatibility proof. Do not merely repeat unit tests or trust the
    implementer summary. Record runtime actions, logs, browser errors/requests, screenshots, cleanup, and artifact identity as
    applicable.
 3. Classify the result:
-   - pass -> Phase = Approval, Status = Ready, Executor = Human, Assignee = bedrin;
-   - implementation defect -> Phase = Implementation, Status = Ready, Executor = <IMPLEMENTER>, Assignee empty unless directed;
-   - verification harness/evidence defect -> Phase = Verification, Status = Ready, Executor = <VERIFIER>;
-   - requirement/architecture defect -> Phase = Planning, Status = Ready, Executor = ChatGPT, Assignee = bedrin-gpt;
-   - external blocker -> keep Phase = Verification, Status = Blocked with exact reason.
+   - pass -> Status = Approval, Execution = Ready, Executor = Human, Assignee = bedrin;
+   - implementation defect -> Status = Implementation, Execution = Ready, Executor = <IMPLEMENTER>, Assignee empty unless
+     directed;
+   - verification harness/evidence defect -> Status = Verification, Execution = Ready, Executor = <VERIFIER>;
+   - requirement/architecture defect -> Status = Planning, Execution = Ready, Executor = ChatGPT, Assignee = bedrin-gpt;
+   - decision/action required from Dmitry -> keep Status = Verification, set Execution = Blocked, Executor = Human,
+     Assignee = bedrin, and record the exact request.
 4. Publish exact environment, source/artifact identity, commands/actions, results, and failure classification before handoff.
 5. Do not modify production code as an unrecorded shortcut. A required implementation correction must return to Implementation.
 
-For either phase:
+For either lifecycle status:
 - update lifecycle fields, Assignee, worker reference, and claim/lease on a best-effort atomic basis;
 - leave no In progress item with a finished or missing worker;
 - never close the issue, merge, enable auto-merge, bypass protection, or perform privileged operations without Dmitry's
   explicit instruction;
-- finish by reporting the final phase handoff and exact remote/evidence state in this worker conversation.
+- finish by reporting the final lifecycle handoff and exact remote/evidence state in this worker conversation.
 ```
 
 ## Placeholder contract
@@ -82,7 +87,7 @@ For either phase:
 | `<ISSUE_NUMBER>` | Numeric Sniffy issue number |
 | `<ISSUE_TITLE>` | Current issue title |
 | `<ISSUE_URL>` | Resolvable issue URL |
-| `<PHASE>` | `Implementation` or `Verification` |
+| `<STATUS>` | `Implementation` or `Verification` |
 | `<WORK_MODE>` | `fresh` or `continuation` for Implementation; `published-head` for Verification |
 | `<BRANCH_NAME>` | Fresh branch or exact existing PR head |
 | `<PR_URL_OR_NONE>` | Existing/published PR or `none` for fresh Implementation |

--- a/docs/ai-delivery/README.md
+++ b/docs/ai-delivery/README.md
@@ -27,11 +27,11 @@ agent host; the selected Copilot, Codex, Junie, or other coding product is the e
 
 ## Lifecycle summary
 
-Phases describe the kind of work; statuses describe whether the next action can run:
+`Status` describes the kind of work; `Execution` describes whether the next action can run:
 
 ```text
-Phase:  Draft -> Planning -> Implementation -> Review -> Verification (when required) -> Approval -> Done
-Status: Ready | In progress | Blocked
+Status:    Draft -> Planning -> Implementation -> Review -> Verification (when required) -> Approval -> Done
+Execution: Ready | In progress | Blocked
 ```
 
 Planning records both `Implementer` and `Verifier`. `Executor` materializes who performs the next current action, while
@@ -77,7 +77,8 @@ why rules exist but do not override current policy.
 
 ## Documentation map
 
-- [`lifecycle.md`](lifecycle.md) — phases, three statuses, planned routing fields, directed/pool Ready, and corrections.
+- [`lifecycle.md`](lifecycle.md) — lifecycle statuses, three execution states, planned routing fields, directed/pool Ready, and
+  corrections.
 - [`event-loop.md`](event-loop.md) — reusable clock/dispatcher/claim design, stateless ChatGPT ticks, and headless Codex CLI.
 - [`pull-request-intake.md`](pull-request-intake.md) — external PRs, GitHub Project auto-add/backfill, Dependabot review,
   rebase, verification, and replacement flow.

--- a/docs/ai-delivery/chat-retention.md
+++ b/docs/ai-delivery/chat-retention.md
@@ -13,8 +13,8 @@ Keep these two classes distinct:
   GitHub handoff is complete.
 
 Use stable Scheduled Task names such as `Event Loop 00`, `Event Loop 15`, `Event Loop 30`, and `Event Loop 45`. At the start of
-each tick, print a compact run header containing slot, UTC timestamp, selected repository/work item/phase, or `NO_CHANGE`.
-Do not rely on the generated chat title as the only identifier.
+each tick, print a compact run header containing slot, UTC timestamp, selected repository/work item/lifecycle status, or
+`NO_CHANGE`. Do not rely on the generated chat title as the only identifier.
 
 ## Durable-state rule
 
@@ -26,7 +26,7 @@ mutation.
 A chat is eligible for archive only when:
 
 - no active claim or lease points to it;
-- the next Phase/Status/Executor/Assignee is durably recorded when work was claimed;
+- the next Status/Execution/Executor/Assignee is durably recorded when work was claimed;
 - any PR review, evidence, blocker, or external dispatch is visible in GitHub;
 - the tick is complete rather than waiting for CI or another result inside that chat.
 
@@ -70,7 +70,7 @@ ordering, to decide what remains active.
 Manual per-chat archive is unlikely to scale indefinitely at the maximum 96-chat/day rate. If cleanup is not sustainable, do
 not hide the problem behind unsupported automation. Choose deliberately among reducing the polling window/cadence, accepting a
 persistent-chat shard, or moving the clock to the headless Local Codex adapter so ChatGPT runs only when work actually requires
-a ChatGPT phase.
+a ChatGPT lifecycle turn.
 
 ## Future automation boundary
 
@@ -78,5 +78,5 @@ A future maintenance worker may archive completed tick chats only after OpenAI e
 Project-scoped capability and that capability is smoke-tested. Do not implement browser-click automation, private endpoints,
 or destructive bulk deletion merely to control sidebar clutter.
 
-Chat retention remains independent from delivery lifecycle: archiving or deleting a transcript must never alter GitHub Phase,
-Status, claims, issues, pull requests, reviews, or evidence.
+Chat retention remains independent from delivery lifecycle: archiving or deleting a transcript must never alter GitHub Status,
+Execution, claims, issues, pull requests, reviews, or evidence.

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -10,18 +10,18 @@ Clock
   -> Dispatcher tick
       -> Intake adapters
           -> Claim protocol
-              -> Phase worker
+              -> Lifecycle worker
 ```
 
 - **Clock** starts one dispatcher tick. It knows only cadence and slot identity.
 - **Dispatcher tick** loads one or more project profiles, queries eligible work, and selects a deterministic candidate.
 - **Intake adapters** materialize external work such as Dependabot pull requests into the same lifecycle.
 - **Claim protocol** provides best-effort cross-dispatcher ownership.
-- **Phase worker** performs one phase turn, publishes evidence, and hands the task to the next phase as `Ready`.
+- **Lifecycle worker** performs one lifecycle turn, publishes evidence, and hands the task to the next status as `Ready`.
 
 Some adapters may split dispatch and work into separate processes or conversations. Others, including the current ChatGPT
-adapter, execute the claimed phase directly in the same fresh tick. Child-worker spawning is optional, not a requirement of the
-generic protocol.
+adapter, execute the claimed lifecycle turn directly in the same fresh tick. Child-worker spawning is optional, not a
+requirement of the generic protocol.
 
 A no-op tick creates no GitHub mutation, source branch, worktree, or worker claim. A provider may still create an execution
 transcript such as a fresh ChatGPT chat for that tick.
@@ -64,9 +64,9 @@ ChatGPT child-task spawning as `unsupported` in the current adapter. The schedul
 1. read its self-contained prompt and external project profiles;
 2. run idempotent intake/reconciliation for eligible external pull requests when configured;
 3. inspect GitHub issues, pull requests, lifecycle fields, claims, and evidence;
-4. select and best-effort claim at most one eligible phase turn;
-5. perform that phase directly in the same fresh chat, or make a supported external handoff such as a Codex Cloud dispatch;
-6. durably write the next Phase, Status, Executor, Assignee, evidence, and cleared claim;
+4. select and best-effort claim at most one eligible lifecycle turn;
+5. perform that turn directly in the same fresh chat, or make a supported external handoff such as a Codex Cloud dispatch;
+6. durably write the next Status, Execution, Executor, Assignee, evidence, and cleared claim;
 7. return `NO_CHANGE` when there is no eligible work.
 
 A tick must never claim work that cannot reasonably finish or reach a safe durable handoff within that scheduled execution.
@@ -169,14 +169,14 @@ several workers only when each owns a distinct claim and isolated worktree.
 A dispatcher queries the materialized current route, not planned roles alone:
 
 ```text
-Status = Ready
+Execution = Ready
 Executor = <dispatcher executor type>
 Assignee is empty OR Assignee belongs to this dispatcher pool
 ```
 
-The work item may be an issue or a pull request. The dispatcher also checks phase compatibility, required access, worker-pool
-capacity, existing branch/PR ownership, and absence of a live claim. `Implementer` and `Verifier` are future routing decisions;
-phase transitions copy the relevant value into `Executor`.
+The work item may be an issue or a pull request. The dispatcher also checks lifecycle-status compatibility, required access,
+worker-pool capacity, existing branch/PR ownership, and absence of a live claim. `Implementer` and `Verifier` are future routing
+decisions; lifecycle transitions copy the relevant value into `Executor`.
 
 Use deterministic selection such as security priority, project priority, `readySince`, then repository/item number. A
 dispatcher should claim at most its available capacity and must not create duplicate workers or Project items.
@@ -186,14 +186,15 @@ dispatcher should claim at most its available capacity and must not create dupli
 GitHub comments and Project field updates are not one transaction. Use a claim generation and ordered intent protocol:
 
 1. Query an eligible `Ready` item.
-2. Re-read its Phase, Status, Executor, Assignee, dispatch generation, branch, PR, and existing claim immediately.
+2. Re-read its Status, Execution, Executor, Assignee, dispatch generation, branch, PR, and existing claim immediately.
 3. Post a claim-intent comment containing a unique token, generation, dispatcher slot, executor, and timestamp.
 4. Re-read valid intents for the same generation. The lowest GitHub comment ID wins.
-5. Only the winner writes `Status = In progress`, the concrete Assignee, claim token, lease time, and worker/tick reference.
+5. Only the winner writes `Execution = In progress`, the concrete Assignee, claim token, lease time, and worker/tick reference.
 6. Re-read and verify that its token/generation still owns the task.
-7. Perform the phase directly or confirm a supported external dispatch.
+7. Perform the lifecycle turn directly or confirm a supported external dispatch.
 8. Record the concrete chat/task/process, branch/worktree, and expected PR or artifact.
-9. If execution/dispatch cannot start, release the claim and restore `Ready`, or set `Blocked` with the exact external reason.
+9. If execution/dispatch cannot start, release the claim and restore `Ready`. Set `Blocked` only when Dmitry must decide or act;
+   then set `Executor = Human`, `Assignee = bedrin`, and record the exact requested action.
 
 This is best-effort coordination, not a distributed database transaction, but it prevents ordinary duplicate polls from both
 starting work. A same-host `flock` complements rather than replaces the GitHub-level protocol.
@@ -212,17 +213,17 @@ lastObservableEvidence
 
 Before expiring a lease, inspect the worker record, issue, branch, PR, commits, and CI. Lack of a recent comment alone does not
 prove inactivity. Recover the existing branch/worker where possible. Release to `Ready` only when ownership is genuinely
-stale; mark `Blocked` when a human or external capability is required.
+stale. Routine external waiting remains `In progress`; use `Blocked` only when Dmitry must intervene.
 
 ## Worker contract
 
-One worker or stateless tick owns one phase turn. It must:
+One worker or stateless tick owns one lifecycle turn. It must:
 
 - re-read the authoritative issue or PR, current lifecycle fields, nearest `AGENTS.md`, branch/PR, and exact head;
 - verify its claim before mutating GitHub or source;
-- perform only the routed phase responsibility;
-- publish exact evidence and update the next Phase, Status, Executor, and Assignee atomically on a best-effort basis;
-- stop without spawning a replacement worker when blocked;
+- perform only the routed lifecycle responsibility;
+- publish exact evidence and update the next Status, Execution, Executor, and Assignee atomically on a best-effort basis;
+- stop without spawning a replacement worker when blocked and route the exact next action to Dmitry;
 - never merge or enable auto-merge without explicit authorization.
 
 ## Generic core versus project profile
@@ -237,8 +238,8 @@ project:
   baseBranch: develop
   githubProject: sniffy/2
 fields:
-  phase: Phase
   status: Status
+  execution: Execution
   implementer: Implementer
   verifier: Verifier
   executor: Executor
@@ -256,12 +257,13 @@ intake:
     enabled: true
     projectAutoAddFilter: "is:pr is:open label:dependencies"
     backfillExisting: true
-    initialPhase: Review
+    initialStatus: Review
     reviewer: ChatGPT
 branches:
   newWorkPrefix: agent/
 ```
 
 Profiles may add filters, model routing, capacity, issue templates, or required evidence, but must not redefine the shared
-meaning of Phase, Status, claims, publication, verification, or merge authority. Start with documented/declarative profiles;
-do not build a bespoke dispatcher framework until platform composition has been smoke-tested and a concrete gap remains.
+meaning of Status, Execution, claims, publication, verification, or merge authority. Start with documented/declarative
+profiles; do not build a bespoke dispatcher framework until platform composition has been smoke-tested and a concrete gap
+remains.

--- a/docs/ai-delivery/executors/codex-cloud.md
+++ b/docs/ai-delivery/executors/codex-cloud.md
@@ -2,7 +2,7 @@
 
 Use Codex Cloud for clean, isolated, fully specified tasks whose required context and deterministic proof are available in
 the Cloud environment. Shared engineering policy lives in `AGENTS.md`; this document covers Cloud-specific setup,
-credentials, publication, phase handoff, and failure handling.
+credentials, publication, lifecycle handoff, and failure handling.
 
 Codex Cloud may be selected as `Implementer` or `Verifier`. It does not perform Review of its own implementation unless a
 separate independent reviewer identity and explicit route exist.
@@ -65,7 +65,7 @@ Before relying on a new or changed environment, run a small reversible validatio
 
 A dry-run push is not proof of effective write permission.
 
-## Implementation phase contract
+## Implementation lifecycle contract
 
 A Cloud implementation task reads the authoritative issue/thread, lifecycle/routing fields, current `develop`, applicable
 `AGENTS.md`, and delivery docs before editing. It must:
@@ -78,14 +78,14 @@ A Cloud implementation task reads the authoritative issue/thread, lifecycle/rout
 6. create/update the intended PR, using draft only while implementation or Cloud-available proof is incomplete;
 7. verify the remote branch, full SHA, PR URL, base/head refs, draft state, and matching PR head;
 8. reconcile the PR description with the current head, commands, limitations, artifacts, and CI;
-9. hand off to `Phase = Review`, `Status = Ready`, `Executor = ChatGPT`, and the configured ChatGPT Assignee;
+9. hand off to `Status = Review`, `Execution = Ready`, `Executor = ChatGPT`, and the configured ChatGPT Assignee;
 10. clear the Cloud worker/lease only after the handoff is durably recorded;
 11. never review/approve its own implementation, merge, or enable auto-merge.
 
 If `origin` is absent, configure an explicit repository URL. If publication access fails, stop and preserve/recover the
 existing workspace or commit instead of recreating the implementation.
 
-## Verification phase contract
+## Verification lifecycle contract
 
 When selected as `Verifier`, Cloud must use the exact published implementation head or artifact named by Review. It performs
 outcome-centric proof that the Cloud environment genuinely supports—such as same-artifact compatibility, a service/browser
@@ -97,7 +97,8 @@ It then classifies and hands off:
 - implementation defect -> `Implementation / Ready / Executor := Implementer`;
 - verification harness/evidence defect -> `Verification / Ready / Executor := Verifier`;
 - requirement/architecture defect -> `Planning / Ready / ChatGPT`;
-- missing external capability -> `Verification / Blocked` with the exact reason or an explicitly rerouted Verifier.
+- capability unavailable in Cloud but available elsewhere -> keep `Execution = Ready` and reroute `Executor`/`Verifier`;
+- decision or action required from Dmitry -> `Verification / Blocked / Human / bedrin` with the exact request.
 
 Do not modify production code inside Verification as an unrecorded shortcut.
 

--- a/docs/ai-delivery/executors/codex-local.md
+++ b/docs/ai-delivery/executors/codex-local.md
@@ -23,7 +23,7 @@ persistent dispatcher conversation
   -> eligible issue: one one-time standalone worker task
        -> one dedicated issue conversation
        -> one isolated app-managed worktree
-       -> worker publishes phase evidence and handoff
+       -> worker publishes lifecycle evidence and handoff
 ```
 
 The native ChatGPT/Codex app runs on the disposable Windows VM. Its coding agent, terminal, repository, GitHub CLI, Java,
@@ -50,11 +50,11 @@ The canonical compatibility paths remain `.codex/local/scheduled-task-prompt.md`
 systemd timer or cron
   -> flock / host-local dispatcher lock
   -> load one or more project profiles
-  -> query Phase + Status + Executor
+  -> query Status + Execution + Executor
   -> GitHub best-effort claim
   -> isolated git worktree
-  -> codex exec with rendered phase prompt
-  -> tests, publication, evidence, and next-phase handoff
+  -> codex exec with rendered lifecycle prompt
+  -> tests, publication, evidence, and next-status handoff
 ```
 
 The Codex CLI can read, modify, and run local code, and `codex exec` is intended for shell workflows. See:
@@ -71,7 +71,7 @@ Each worker owns:
 - one claim token and lifecycle generation;
 - one isolated worktree;
 - one branch and intended PR;
-- one rendered prompt for the current phase;
+- one rendered prompt for the current lifecycle status;
 - one structured log/evidence directory;
 - a bounded process timeout and cleanup path.
 
@@ -82,17 +82,18 @@ explicitly configured. Never let two workers own the same task/branch.
 
 Both adapters use [`../event-loop.md`](../event-loop.md). The dispatcher:
 
-- reads `Status = Ready` items routed to its executor type;
+- reads `Execution = Ready` items routed to its executor type;
 - respects directed Assignee or empty pool ownership;
-- checks phase, project profile, access, capacity, branch/PR, and existing claims;
+- checks lifecycle status, project profile, access, capacity, branch/PR, and existing claims;
 - claims on a best-effort atomic basis before creating a worker;
 - records the concrete conversation/task or process/worktree reference;
-- releases to `Ready` or sets an exact `Blocked` reason when spawn fails;
+- releases to `Ready` when spawn fails;
+- sets `Blocked` only when Dmitry must decide or act, with `Executor = Human`, `Assignee = bedrin`, and the exact request;
 - creates no source mutation for an empty queue.
 
 ## Worker contract
 
-A Local Codex worker performs only the routed phase:
+A Local Codex worker performs only the routed lifecycle status:
 
 - Planning is unusual and should normally remain ChatGPT/human-owned;
 - Implementation changes code, runs implementer-owned tests/browser checks, inspects the diff, commits, pushes, and verifies

--- a/docs/ai-delivery/lifecycle.md
+++ b/docs/ai-delivery/lifecycle.md
@@ -5,7 +5,7 @@ same model applies to ChatGPT, Codex Cloud, Local Codex, IDE-hosted agents, auto
 
 ## Fields
 
-### Phase
+### Status
 
 - `Draft` — captured but not activated.
 - `Planning` — refine outcome, decisions, non-goals, proof, implementation route, and verification route.
@@ -15,24 +15,29 @@ same model applies to ChatGPT, Codex Cloud, Local Codex, IDE-hosted agents, auto
 - `Approval` — Dmitry performs final human acceptance and decides whether to merge or close.
 - `Done` — the PR was actually merged or the task was deliberately closed with rationale.
 
-### Status
+### Execution
 
-- `Ready` — the next action in the current phase can start now.
+- `Ready` — the next action in the current status can start now.
 - `In progress` — a concrete actor owns and is performing the next action, including waiting for checks that actor started.
-- `Blocked` — the next action cannot continue without an external decision, permission, service, credential, or capability.
+- `Blocked` — the autonomous workflow cannot safely continue and requires Dmitry's decision or action.
 
-`Review` is a phase, not a status: it is substantive work with its own actor, inputs, outcomes, and correction transitions.
-`Blocked` is a status, not a phase: preserving the current phase records where work should resume after the blocker clears.
+`Review` is a lifecycle status, not an execution state: it is substantive work with its own actor, inputs, outcomes, and
+correction transitions. `Blocked` is an execution state, not a lifecycle status: preserving the current status records where
+work should resume after Dmitry clears the blocker.
 
-`Draft` and `Done` do not need a status. They are lifecycle endpoints outside the claim loop.
+`Draft` and `Done` do not need an execution value. They are lifecycle endpoints outside the claim loop.
+
+Routine waiting is not `Blocked`. A worker waiting for CI, an already-dispatched agent, or another observable operation it owns
+remains `In progress` and is monitored. Set `Blocked` only when the automation must stop, assign `Executor = Human` and
+`Assignee = bedrin`, record the exact decision or action required, and notify Dmitry.
 
 ## Planned routing and current ownership
 
-Planning chooses future roles before those phases begin:
+Planning chooses future roles before those lifecycle statuses begin:
 
-- `Implementer` — executor selected for the `Implementation` phase, or the external author/automation that already supplied a
-  pull request.
-- `Verifier` — executor responsible for coordinating the `Verification` phase and its evidence.
+- `Implementer` — executor selected for `Implementation`, or the external author/automation that already supplied a pull
+  request.
+- `Verifier` — executor responsible for coordinating `Verification` and its evidence.
 
 Current routing is materialized separately:
 
@@ -41,7 +46,7 @@ Current routing is materialized separately:
 - `Worker reference` — concrete chat, task, process, worktree, branch, PR, or tick ownership record after claim.
 
 Keeping both planned and current routing is intentional. `Implementer` and `Verifier` are decisions made during Planning or
-external-PR intake; `Executor` lets every dispatcher use the same query for the current phase without reimplementing
+external-PR intake; `Executor` lets every dispatcher use the same query for the current lifecycle status without reimplementing
 transition logic.
 
 Transition invariants include:
@@ -59,16 +64,16 @@ from the PR author.
 
 ## Ready semantics
 
-`Ready` means: **the next action in the current phase is ready for the current executor/assignee**. It does not mean only an
-unassigned implementation queue.
+`Ready` means: **the next action in the current lifecycle status is ready for the current executor/assignee**. It does not mean
+only an unassigned implementation queue.
 
 ### Pool Ready
 
 A worker pool must claim the task:
 
 ```text
-Phase: Implementation
-Status: Ready
+Status: Implementation
+Execution: Ready
 Implementer: Local Codex
 Verifier: ChatGPT
 Executor: Local Codex
@@ -78,8 +83,8 @@ Assignee: empty
 After claim:
 
 ```text
-Phase: Implementation
-Status: In progress
+Status: Implementation
+Execution: In progress
 Executor: Local Codex
 Assignee: bedrin-codex-local
 Worker reference: <task/process/worktree>
@@ -90,8 +95,8 @@ Worker reference: <task/process/worktree>
 A known actor has a personal next action:
 
 ```text
-Phase: Planning
-Status: Ready
+Status: Planning
+Execution: Ready
 Executor: Human
 Assignee: bedrin
 ```
@@ -99,7 +104,7 @@ Assignee: bedrin
 This means the plan is prepared and Dmitry may review it. The task remains in Planning because implementation is not yet
 authorized.
 
-A phase may therefore contain several directed turns:
+A lifecycle status may therefore contain several directed turns:
 
 ```text
 Planning / Ready / ChatGPT
@@ -109,14 +114,14 @@ Planning / Ready / ChatGPT
   -> Implementation / Ready / Implementer   (approved)
 ```
 
-The apparent `In progress -> Ready` transition is a handoff to the next actor in the same collaborative phase, not a reversal
-of progress.
+The apparent `In progress -> Ready` transition is a handoff to the next actor in the same collaborative lifecycle status, not a
+reversal of progress.
 
 The same directed semantics apply to final acceptance:
 
 ```text
-Phase: Approval
-Status: Ready
+Status: Approval
+Execution: Ready
 Executor: Human
 Assignee: bedrin
 ```
@@ -131,8 +136,8 @@ A work item may be an issue or a pull request. When Dependabot or another extern
 PR itself to the Project and normally initialize it as:
 
 ```text
-Phase: Review
-Status: Ready
+Status: Review
+Execution: Ready
 Implementer: <PR author>
 Verifier: <selected verifier>
 Executor: ChatGPT
@@ -144,9 +149,9 @@ This skips Draft, Planning, and Implementation only when the scope is understand
 or policy decision is missing. Otherwise route the PR item to `Planning / Ready`.
 
 An acceptable PR advances to Verification or Approval. A stale Dependabot head stays in Review while the bot rebases. A PR
-requiring repository-specific compatibility code becomes `Review / Blocked` and links to a new issue routed through Planning
-and Implementation; the source PR remains the work item for the original proposal until superseded or closed. See
-[`pull-request-intake.md`](pull-request-intake.md).
+requiring repository-specific compatibility code becomes `Review / Blocked`, assigns the next action to Dmitry, and links to a
+new issue routed through Planning and Implementation; the source PR remains the work item for the original proposal until
+superseded or closed. See [`pull-request-intake.md`](pull-request-intake.md).
 
 ## Lifecycle
 
@@ -185,8 +190,9 @@ stateDiagram-v2
     Done --> [*]
 ```
 
-At any active phase, `Ready` or `In progress` may become `Blocked`. Clearing the blocker returns the task to `Ready` in the
-same phase or a deliberately corrected earlier phase.
+At any active lifecycle status, `Execution` may move between `Ready` and `In progress`. `Blocked` stops autonomous processing and
+routes the next action to Dmitry. Clearing the blocker returns the task to `Ready` in the same lifecycle status or a deliberately
+corrected earlier status.
 
 ## Correction limits
 
@@ -200,6 +206,6 @@ Track substantive correction rounds separately from scheduler retries and infras
 
 ## Completion
 
-There is no separate `Ready to merge` lifecycle phase. A task remains `Approval / Ready` until Dmitry accepts it and the PR is
+There is no separate `Ready to merge` lifecycle status. A task remains `Approval / Ready` until Dmitry accepts it and the PR is
 actually merged (or the task is deliberately closed). Add a separate queue later only if approved-but-unmerged work becomes a
 real operational backlog, such as a release train.

--- a/docs/ai-delivery/pull-request-intake.md
+++ b/docs/ai-delivery/pull-request-intake.md
@@ -9,8 +9,8 @@ new independently owned implementation.
 A newly discovered external pull request normally enters as:
 
 ```text
-Phase: Review
-Status: Ready
+Status: Review
+Execution: Ready
 Implementer: <PR author or automation, for example Dependabot>
 Verifier: <chosen during intake>
 Executor: ChatGPT
@@ -51,8 +51,8 @@ initialization, author verification, missed-item reconciliation, and review.
 
 ## Event-loop intake adapter
 
-Before selecting ordinary `Ready` work, a tick may scan for eligible open pull requests that are not yet represented in the
-Project. Intake should:
+Before selecting ordinary `Execution = Ready` work, a tick may scan for eligible open pull requests that are not yet represented
+in the Project. Intake should:
 
 1. verify repository, open state, bot/external author, labels, target branch, draft state, and exact head;
 2. add or locate the PR Project item idempotently;
@@ -84,9 +84,10 @@ Route the reviewed exact head as follows:
 - **Stale base or merge conflict:** use `@dependabot rebase` when appropriate, keep the item in Review, and restart exact-head
   review only after Dependabot publishes a new head. Dependabot normally stops automatic rebasing after extra commits are
   pushed to its branch.
-- **Implementation incompatibility:** create a linked issue for the compatibility change or replacement update, select a real
-  Implementer/Verifier, and route that issue through Planning and Implementation. Keep the bot PR `Review / Blocked` until
-  the replacement supersedes it, then close the bot PR with rationale.
+- **Implementation incompatibility:** set the bot PR to `Review / Blocked / Human / bedrin` and ask Dmitry to authorize a linked
+  compatibility issue or replacement update. After he chooses the path and the linked work starts, keep the source PR in Review
+  with `Execution = In progress` and a worker reference to the linked task until the replacement supersedes it; then close the
+  bot PR with rationale.
 - **Requirement, major-version, or policy ambiguity:** move the PR item to `Planning / Ready` for ChatGPT or Dmitry.
 - **Intentional rejection or ignore:** record the reason. Prefer visible repository configuration in `.github/dependabot.yml`
   over a centrally stored one-off ignore when the policy should be shared by maintainers.

--- a/docs/ai-delivery/routing.md
+++ b/docs/ai-delivery/routing.md
@@ -37,8 +37,8 @@ The current lifecycle materializes:
 - `Assignee` — concrete identity or human responsible now.
 - `Worker reference` — concrete chat, process, task, branch/worktree, PR, or tick ownership after claim.
 
-`Implementer` and `Verifier` must remain visible before their phases begin. `Executor` is intentionally denormalized so every
-dispatcher can use one query such as `Status = Ready AND Executor = Local Codex`.
+`Implementer` and `Verifier` must remain visible before their lifecycle statuses begin. `Executor` is intentionally denormalized
+so every dispatcher can use one query such as `Execution = Ready AND Executor = Local Codex`.
 
 ## Executor matrix
 
@@ -128,15 +128,18 @@ escalations for later cost calibration.
 
 Recommended lifecycle and routing fields:
 
-- `Phase`: Draft, Planning, Implementation, Review, Verification, Approval, Done.
-- `Status`: Ready, In progress, Blocked.
+- `Status`: Draft, Planning, Implementation, Review, Verification, Approval, Done.
+- `Execution`: Ready, In progress, Blocked.
 - `Implementer`: planned implementation executor or external PR author.
 - `Verifier`: planned verification executor.
 - `Executor`: current action executor.
 - `Assignee`: use GitHub assignment as the concrete current identity/human.
 - `Origin`: optional source such as issue, Dependabot PR, contributor PR, alert, or manual request.
 - `Correction rounds`: substantive review/verification returns, excluding infrastructure noise.
-- `Blocked reason`: exact external blocker and next action.
+- `Blocked reason`: exact action or decision Dmitry must provide before autonomous processing resumes.
+
+`Blocked` always routes the next action to `Executor = Human` and `Assignee = bedrin`. Routine waits for CI, a dispatched agent,
+or another observable operation remain `In progress`.
 
 GitHub assignees are technical identities, not executor products. Existing `agent:local` and `agent:cloud` labels are
 transitional metadata and must not override Project routing fields. Project work items may be issues or pull requests.

--- a/docs/ai-delivery/supervision.md
+++ b/docs/ai-delivery/supervision.md
@@ -5,15 +5,16 @@ automation such as Dependabot, or a human contributor using the AI-assisted deli
 
 ## Lifecycle authority
 
-Use [`lifecycle.md`](lifecycle.md) as the canonical Phase/Status model:
+Use [`lifecycle.md`](lifecycle.md) as the canonical Status/Execution model:
 
 ```text
-Phase:  Draft -> Planning -> Implementation -> Review -> Verification? -> Approval -> Done
-Status: Ready | In progress | Blocked
+Status:    Draft -> Planning -> Implementation -> Review -> Verification? -> Approval -> Done
+Execution: Ready | In progress | Blocked
 ```
 
-`Ready` applies to the next action in the current phase. It may be pool-ready for a worker or directed-ready for a specific
-assignee such as Dmitry. `Review` is a phase. `Blocked` preserves the phase where work should resume.
+`Ready` applies to the next action in the current lifecycle status. It may be pool-ready for a worker or directed-ready for a
+specific assignee such as Dmitry. `Review` is a lifecycle status. `Blocked` preserves where work should resume, stops autonomous
+processing, and routes the next action to Dmitry.
 
 Do not replace these fields with optimistic prose. Track supporting delivery facts independently:
 
@@ -26,9 +27,9 @@ Do not replace these fields with optimistic prose. Track supporting delivery fac
 
 A local commit is not publication; publication is not review; review is not verification; verification is not merge.
 
-## Phase handoff
+## Lifecycle handoff
 
-A worker completes one phase turn and writes the next route:
+A worker completes one lifecycle turn and writes the next route:
 
 - Planning records `Implementer` and `Verifier`; handoff to Dmitry stays `Planning / Ready / Human`.
 - Planning approval writes `Implementation / Ready / Executor := Implementer`.
@@ -48,11 +49,12 @@ Every handoff clears stale worker ownership and sets the intended Assignee or le
 - An app-native Local Codex item is dispatched only after claim plus confirmed worker task/chat/worktree.
 - A headless Local Codex item is dispatched only after claim plus confirmed process/worktree/branch record.
 - An IDE agent is working only while the human explicitly owns the interactive session or remote evidence proves activity.
-- A ChatGPT scheduled tick is working only after its fresh chat has won a claim and begun the exact intended phase operation.
+- A ChatGPT scheduled tick is working only after its fresh chat has won a claim and begun the exact intended lifecycle operation.
 - A ChatGPT direct-execution task is working only after the exact intended GitHub or sandbox operation has begun.
 
 `In progress` with no verified claim/current tick/worker reference is invalid. When execution or external dispatch cannot start,
-release to `Ready` or record an exact `Blocked` reason.
+release to `Ready`. Set `Blocked` only when Dmitry must decide or act; set `Executor = Human`, `Assignee = bedrin`, and record the
+exact requested action.
 
 ## Queue polling and worker monitoring
 
@@ -67,7 +69,7 @@ different concerns:
   while incomplete.
 
 The current ChatGPT adapter uses four hourly Scheduled Tasks offset by 15 minutes. Every occurrence opens a fresh chat, reads
-all durable state from GitHub/repository Markdown, and performs at most one phase turn directly. It cannot create a child
+all durable state from GitHub/repository Markdown, and performs at most one lifecycle turn directly. It cannot create a child
 Scheduled Task and must not rely on previous tick chats. A no-op still creates a chat transcript but creates no GitHub/source
 mutation. Keep the four task-definition chats stable; archive completed tick transcripts according to
 [`chat-retention.md`](chat-retention.md). Chat cleanup never changes lifecycle state.
@@ -83,7 +85,7 @@ claim/worker record, expected branch and PR, acknowledgement or new head, review
 meaningful progress, completion, or a real blocker.
 
 A review or dispatch comment does not prove work started. Verify acknowledgement or new remote evidence. Stop worker
-monitoring when the phase handoff completes or a human/external blocker owns the next action.
+monitoring when the lifecycle handoff completes or Dmitry owns a blocked next action.
 
 ## Branch and PR continuity
 
@@ -104,7 +106,7 @@ For Dependabot and other automation-owned PRs:
 
 ## Review and correction
 
-The Review phase audits the whole acceptance-to-proof matrix, not only the visible delta. Inspect:
+The Review lifecycle status audits the whole acceptance-to-proof matrix, not only the visible delta. Inspect:
 
 - complete exact-head diff and scope;
 - architecture, module/API ownership, compatibility, lifecycle, and resource safety;
@@ -137,5 +139,5 @@ exact-head review.
 
 No agent or supervising ChatGPT workflow may merge, enable auto-merge, bypass protection, rewrite shared history, or perform
 privileged repository/hosting operations without Dmitry's explicit instruction. `Approval / Ready` is the human acceptance
-queue; there is no separate Ready-to-merge phase unless an approved-but-unmerged backlog becomes a real need. This boundary
-also applies to Dependabot even though GitHub supports Dependabot commands and auto-merge.
+queue; there is no separate Ready-to-merge lifecycle status unless an approved-but-unmerged backlog becomes a real need. This
+boundary also applies to Dependabot even though GitHub supports Dependabot commands and auto-merge.

--- a/docs/ai-delivery/verification.md
+++ b/docs/ai-delivery/verification.md
@@ -1,6 +1,6 @@
 # Implementation, review, and verification evidence
 
-Implementation, Review, and Verification are different phases with different questions. The issue chooses both an
+Implementation, Review, and Verification are different lifecycle statuses with different questions. The issue chooses both an
 `Implementer` and a `Verifier` during Planning. Skipping duplicate work is allowed; collapsing the responsibilities into one
 unexamined summary is not.
 
@@ -19,9 +19,9 @@ The Implementer owns the code/configuration change and the proof available in it
 - run `git diff --check`;
 - publish the exact branch/SHA/PR and report commands, results, skipped obligations, and capability limitations honestly.
 
-The Implementer must not use a later Verification phase as permission to skip ordinary local tests or a directly available
-browser check. Conversely, it must not claim a source build, integration run, package download, or browser session it could
-not perform.
+The Implementer must not use a later Verification lifecycle status as permission to skip ordinary local tests or a directly
+available browser check. Conversely, it must not claim a source build, integration run, package download, or browser session it
+could not perform.
 
 ### Reviewer: decide whether the implementation is acceptable code
 
@@ -58,8 +58,8 @@ published exact head or exact artifact in the most representative available envi
 - inspect runtime logs, browser errors, failed requests, screenshots, persisted state, cleanup, and externally visible output;
 - compare actual behavior with both the issue and explicit thread decisions;
 - record exact source/artifact identity, environment, commands/actions, and result;
-- classify failure as implementation defect, verification-harness defect, requirement/architecture defect, external blocker,
-  or infrastructure noise.
+- classify failure as implementation defect, verification-harness defect, requirement/architecture defect, missing capability,
+  decision/action required from Dmitry, or infrastructure noise.
 
 Examples include:
 
@@ -76,8 +76,8 @@ a failure, but its acceptance decision is based on observable behavior against t
 ### Approval: human acceptance
 
 Dmitry performs final acceptance in `Approval / Ready`. He may rely on the Review and Verification packets, inspect the result
-subjectively, request more Planning/Implementation/Verification work, or merge/close. No automated phase may infer merge from
-technical approval.
+subjectively, request more Planning/Implementation/Verification work, or merge/close. No automated lifecycle status may infer
+merge from technical approval.
 
 ## Proof matrix
 
@@ -117,8 +117,9 @@ Examples:
   host security and credentials policy must explicitly allow them.
 - A human remains required for protected settings, secrets, subjective product acceptance, and destructive operations.
 
-When capability is absent, record the exact missing obligation and change `Verifier`/`Executor` or set `Blocked`. Do not
-reinterpret an easier check as equivalent evidence.
+When capability is absent, record the exact missing obligation and change `Verifier`/`Executor` while keeping
+`Execution = Ready`. Set `Execution = Blocked` only when Dmitry must decide or act; then set `Executor = Human`,
+`Assignee = bedrin`, and record the exact request. Do not reinterpret an easier check as equivalent evidence.
 
 ## Exact-head rule
 
@@ -176,7 +177,7 @@ Before `Approval / Ready`, record:
 - complete diff reviewed and review identity limitation, if any;
 - implementer tests actually run;
 - exact-head CI jobs/logs inspected;
-- verifier environment and observable actions/results, or rationale for safely skipping a separate Verification phase;
+- verifier environment and observable actions/results, or rationale for safely skipping a separate Verification status;
 - comments/threads resolved;
 - limitations and residual risk;
 - no pending automated worker or stale claim.

--- a/docs/local-codex-worker.md
+++ b/docs/local-codex-worker.md
@@ -15,17 +15,17 @@ flowchart TD
     Host["Windows host / Hyper-V"] --> VM["Disposable Windows worker VM"]
     VM --> App["Native Codex app"]
     App --> Dispatcher["Persistent dispatcher conversation"]
-    Dispatcher -->|"eligible claimed phase"| Worker["One-time standalone phase worker"]
+    Dispatcher -->|"eligible claimed lifecycle status"| Worker["One-time standalone lifecycle worker"]
     Dispatcher -->|"no eligible work"| NoOp["NO_CHANGE"]
     Worker --> Worktree["Isolated app-managed WSL worktree"]
     Worktree --> Tools["Git, gh, Java, Maven, Node, Docker, browsers"]
-    Worker --> Handoff["Next Phase / Ready"]
+    Worker --> Handoff["Next Status / Ready"]
 ```
 
 Important boundaries:
 
 - The dispatcher polls and claims only; it never edits source or reviews the worker's PR.
-- One standalone worker owns one `Implementation` or `Verification` phase turn.
+- One standalone worker owns one `Implementation` or `Verification` lifecycle turn.
 - Implementation hands off to `Review / Ready / ChatGPT`; it does not create its own reviewer/follow-up task.
 - Verification hands off according to the outcome classification in
   [`verification.md`](ai-delivery/verification.md).
@@ -186,36 +186,37 @@ Preserve the outer controls:
 - repository-scoped credentials and server-side branch protection;
 - token rotation and rebuild after suspected compromise.
 
-## App-native dispatcher and phase worker
+## App-native dispatcher and lifecycle worker
 
 Use the compatibility paths:
 
 - [`.codex/local/scheduled-task-prompt.md`](../.codex/local/scheduled-task-prompt.md) — persistent dispatcher;
-- [`.codex/local/worker-task-prompt.md`](../.codex/local/worker-task-prompt.md) — one-phase worker template.
+- [`.codex/local/worker-task-prompt.md`](../.codex/local/worker-task-prompt.md) — one-status worker template.
 
 The dispatcher selects only items matching:
 
 ```text
-Status = Ready
+Execution = Ready
 Executor = Local Codex app
-Phase = Implementation or Verification
+Status = Implementation or Verification
 Assignee is empty or matches the local worker identity
 ```
 
 It follows the best-effort claim and lease protocol in [`event-loop.md`](ai-delivery/event-loop.md), then creates exactly one
-one-time standalone worker with an isolated worktree. Failed child creation releases the claim or records an exact blocker.
+one-time standalone worker with an isolated worktree. Failed child creation releases the claim. `Blocked` is used only when
+Dmitry must decide or act, with `Executor = Human` and `Assignee = bedrin`.
 
 Implementation workers publish exact branch/SHA/PR evidence and hand off to:
 
 ```text
-Phase: Review
-Status: Ready
+Status: Review
+Execution: Ready
 Executor: ChatGPT
 Assignee: bedrin-gpt
 ```
 
 They do not schedule a self-review continuation. The shared Review event loop owns the next action. Verification workers use
-the classification and handoffs embedded in the phase-worker template.
+the classification and handoffs embedded in the lifecycle-worker template.
 
 ## Required smoke tests
 
@@ -223,10 +224,10 @@ Before enabling recurring dispatch, prove:
 
 1. a manual read-only task runs inside WSL and sees the expected project;
 2. an empty dispatcher tick stays in its conversation and creates no worktree;
-3. one eligible item creates exactly one standalone phase worker and isolated worktree;
-4. the child receives Phase, Implementer, Verifier, claim token, and generation;
+3. one eligible item creates exactly one standalone lifecycle worker and isolated worktree;
+4. the child receives Status, Implementer, Verifier, claim token, and generation;
 5. concurrent claim attempts produce one winning worker;
-6. failed child creation restores `Ready` or records an exact blocker;
+6. failed child creation restores `Ready` or escalates a real decision/action to Dmitry as `Blocked`;
 7. Implementation hands off to `Review / Ready / ChatGPT` without self-review;
 8. Verification produces the correct classified handoff;
 9. no task can merge or enable auto-merge.


### PR DESCRIPTION
Renames the GitHub Project lifecycle fields throughout the AI delivery documentation and Local Codex prompt templates.

- `Phase` becomes the built-in `Status` field.
- the previous operational `Status` becomes `Execution`.
- `Blocked` is defined as an escalation to Dmitry; routine waiting remains `In progress`.

Project values:

- Status: Draft, Planning, Implementation, Review, Verification, Approval, Done
- Execution: Ready, In progress, Blocked

Documentation-only change. No merge or auto-merge behavior is added.