### PR TITLE
Add copy-paste ChatGPT scheduled task prompt

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -1,0 +1,85 @@
+# Sniffy ChatGPT Scheduled Task prompt
+
+Create a fileless ChatGPT Project named `AI Delivery Event Loop`. Inside that Project, create four hourly Scheduled Tasks whose
+destination is **new chat**:
+
+```text
+Event Loop 00 -> every hour at :00
+Event Loop 15 -> every hour at :15
+Event Loop 30 -> every hour at :30
+Event Loop 45 -> every hour at :45
+```
+
+Paste the following block **unchanged** into each task. The four tasks use exactly the same prompt; only their schedules and names
+differ.
+
+```text
+Run one stateless Sniffy AI Delivery Event Loop tick now.
+
+Repository: sniffy/sniffy
+Book of work: organization project 2, https://github.com/orgs/sniffy/projects/2
+Base branch: develop
+Executor: ChatGPT
+GitHub assignee: bedrin-gpt
+
+Use current GitHub state as the source of truth. Before any claim or mutation, read the current versions of:
+- https://github.com/sniffy/sniffy/blob/develop/AGENTS.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/README.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/lifecycle.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/event-loop.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/pull-request-intake.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/routing.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/supervision.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/verification.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/executors/chatgpt.md
+
+This occurrence is one fresh, self-contained tick. Do not rely on previous chats, ChatGPT Project files, implicit memory, or an
+unpublished local state. Do not create another Scheduled Task, child ChatGPT task, or promise future/background work. Use the
+current Scheduled Task name as the dispatcher slot; if it is unavailable, use this chat/task identifier plus the current UTC
+timestamp.
+
+Perform the following protocol:
+
+1. Reconcile external pull-request intake before ordinary queue work. Find eligible open sniffy/sniffy dependency PRs missing
+   from Project 2, verify their actual author, labels, target, draft state, and exact head, and materialize them idempotently as
+   documented. Intake is not approval.
+2. Before claiming new work, inspect any ChatGPT-owned `Execution = In progress` item whose recorded worker, CI, external
+   dispatch, or monitoring follow-up is due. Continue or recover that existing ownership rather than starting a duplicate.
+3. Otherwise select at most one Project 2 item where:
+   - `Execution = Ready`;
+   - `Executor = ChatGPT`;
+   - `Assignee` is empty or `bedrin-gpt`;
+   - `Status` is Planning, Implementation, Review, or Verification;
+   - the current ChatGPT tools and identity can truthfully complete the lifecycle turn or reach a safe durable handoff now.
+4. Select deterministically using security priority, Project priority, ready timestamp, then repository and item number. Never
+   create a duplicate Project item, worker, branch, or pull request.
+5. Claim using the best-effort protocol in event-loop.md: re-read Status, Execution, Executor, Assignee, generation, branch, PR,
+   worker reference, and existing claims; publish a unique claim intent; determine the winning intent; set
+   `Execution = In progress`, `Assignee = bedrin-gpt`, claim/lease metadata, and this tick's concrete reference; then re-read and
+   verify ownership before doing work. If the claim cannot be established, make no work mutation.
+6. Perform exactly one lifecycle turn according to the current issue or PR and the repository policy:
+   - Planning: resolve the outcome, decisions, non-goals, risk axes, Implementer, Verifier, and proof obligations, then publish a
+     precise handoff.
+   - Implementation: only perform a focused change when source, dependencies, tests, publication, and identity are genuinely
+     available in this execution. Otherwise route to a capable Implementer without pretending implementation occurred.
+   - Review: inspect the complete exact-head diff, issue decisions, tests, review comments and threads, and matching-head CI.
+     Submit APPROVE only when the implementation is acceptable and the GitHub identity is independent from the PR author.
+     Otherwise submit one precise REQUEST_CHANGES or record the identity limitation. Never approve bedrin-gpt's own PR.
+   - Verification: validate the observable result against the authoritative issue using the exact published head or artifact in
+     a representative environment. Do not relabel unit tests or green CI as system verification.
+7. Publish durable evidence in GitHub before ending the tick. Update the next `Status`, `Execution`, `Executor`, and `Assignee`,
+   clear completed claim/lease ownership, and record exact branch, PR, SHA, commands, CI, artifacts, review, verification, and
+   limitations as applicable.
+8. Use `Execution = Blocked` only when Dmitry must decide or act. Keep the current Status, set `Executor = Human`,
+   `Assignee = bedrin`, and record the smallest exact requested action. Routine waiting for a concrete CI run, worker, or
+   external operation remains `In progress` only when a durable reference and next monitoring point are recorded. Never leave
+   `In progress` without real current ownership or observable work.
+9. Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged
+   repository/hosting operations without Dmitry's explicit instruction.
+10. If no eligible intake, due continuation, claimable lifecycle turn, or meaningful reconciliation exists, make no GitHub or
+    source mutation and reply only `NO_CHANGE`. Otherwise finish with a compact summary containing the selected item, performed
+    lifecycle turn, durable evidence, and resulting Status / Execution / Executor / Assignee.
+```
+
+After creating the four tasks, smoke-test one empty tick and one disposable/read-only eligible item before relying on the loop.
+Deleting a task's defining chat pauses that task; keep the four task-definition chats stable.

--- a/docs/ai-delivery/README.md
+++ b/docs/ai-delivery/README.md
@@ -59,7 +59,7 @@ Dmitry + ChatGPT decide outcome, risk, routing, and proof
 
 Dmitry owns product decisions, accepted risk, privileged repository/hosting operations, final acceptance, and merge
 authorization. ChatGPT owns issue refinement, external-PR intake, routing proposals, supervision, code review, verification
-coordination, and clear handoff. An executor owns only the phase and proof explicitly routed to it.
+coordination, and clear handoff. An executor owns only the lifecycle turn and proof explicitly routed to it.
 
 ## Sources of truth
 
@@ -80,6 +80,8 @@ why rules exist but do not override current policy.
 - [`lifecycle.md`](lifecycle.md) — lifecycle statuses, three execution states, planned routing fields, directed/pool Ready, and
   corrections.
 - [`event-loop.md`](event-loop.md) — reusable clock/dispatcher/claim design, stateless ChatGPT ticks, and headless Codex CLI.
+- [`.chatgpt/scheduled-task-prompt.md`](../../.chatgpt/scheduled-task-prompt.md) — exact copy-paste prompt and setup for the four
+  ChatGPT Scheduled Tasks.
 - [`pull-request-intake.md`](pull-request-intake.md) — external PRs, GitHub Project auto-add/backfill, Dependabot review,
   rebase, verification, and replacement flow.
 - [`chat-retention.md`](chat-retention.md) — permanent task-definition chats, disposable tick chats, manual archive policy,
@@ -95,7 +97,7 @@ why rules exist but do not override current policy.
 - [`../retrospectives/`](../retrospectives/README.md) — historical incidents and durable lessons incorporated here.
 
 The current ChatGPT event-loop adapter uses four hourly Scheduled Tasks offset by 15 minutes. Every occurrence starts a new,
-stateless chat and performs at most one phase turn directly; Scheduled Task executions cannot create child Scheduled Tasks.
+stateless chat and performs at most one lifecycle turn directly; Scheduled Task executions cannot create child Scheduled Tasks.
 All durable context therefore lives in GitHub and repository-owned Markdown, not in ChatGPT Project memory or prior tick chats.
 
 Dependabot PRs are first-class Project items rather than shadow issues. GitHub's built-in auto-add workflow discovers newly
@@ -104,6 +106,7 @@ author, and routes any required compatibility implementation to a linked agent-o
 
 ## Provider-specific files
 
+- `.chatgpt/` contains copy-paste ChatGPT Scheduled Task prompts, not durable delivery state.
 - `.codex/` contains Codex environment scripts and launch prompts, not general repository policy.
 - `.github/copilot-instructions.md` is a small Copilot adapter pointing to `AGENTS.md` and this directory.
 - `.agents/skills/` contains optional reusable procedures that an executor invokes only when applicable.

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -54,6 +54,10 @@ slot-30 -> hourly at :30 -> new chat
 slot-45 -> hourly at :45 -> new chat
 ```
 
+Copy the exact same prompt into all four tasks from
+[`.chatgpt/scheduled-task-prompt.md`](../../.chatgpt/scheduled-task-prompt.md). The file includes complete setup instructions and
+a prompt with no placeholders; only the four task names and schedules differ.
+
 Together they form one logical 15-minute clock while consuming four active tasks. Configure every task to start in a **new
 chat** inside one dedicated scheduler Project. Each occurrence is a fresh, stateless dispatcher/worker tick; it does not reuse
 or append to a long-lived dispatcher conversation.

--- a/docs/ai-delivery/executors/chatgpt.md
+++ b/docs/ai-delivery/executors/chatgpt.md
@@ -57,7 +57,11 @@ See:
 
 Use four hourly Scheduled Tasks at `:00`, `:15`, `:30`, and `:45`, all configured with destination **new chat** inside one
 fileless `AI Delivery Event Loop` Project. Together they provide a logical 15-minute poll cadence. Every occurrence is a fresh
-stateless dispatcher/phase-worker tick and performs at most one phase turn.
+stateless dispatcher/lifecycle-worker tick and performs at most one lifecycle turn.
+
+The exact setup instructions and one prompt that can be pasted unchanged into all four tasks live in
+[`.chatgpt/scheduled-task-prompt.md`](../../../.chatgpt/scheduled-task-prompt.md). Only the task names and schedules differ; do
+not create four divergent prompt copies.
 
 Manual tests on 2026-07-28 established that the available scheduler cannot target an arbitrary different Project and a
 Scheduled Task execution cannot create another Scheduled Task. Child spawning is therefore unsupported. Each task prompt must


### PR DESCRIPTION
Adds a single source-of-truth prompt that can be copied unchanged into all four ChatGPT Scheduled Tasks.

- creates `.chatgpt/scheduled-task-prompt.md` with complete Project setup, schedules, and a placeholder-free event-loop prompt;
- makes the prompt self-contained with current `develop` policy links and the Status / Execution claim protocol;
- documents continuation monitoring, exact-head review, durable handoff, Blocked escalation, and the no-merge boundary;
- links the prompt from the AI delivery README, event-loop design, and ChatGPT executor runbook.

Documentation-only change. The four tasks use the same prompt; only their names and schedules differ.