### PR TITLE
Requeue pull requests when their reviewed head changes

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -58,23 +58,29 @@ Perform this protocol:
 1. Reconcile external pull-request intake before ordinary queue work. Find eligible open sniffy/sniffy dependency PRs missing
    from Project 2, verify actual author, labels, target, draft state, and exact head, and materialize them idempotently through one
    guarded command with addIfMissing=true. Intake is not approval.
-2. Before claiming new work, inspect ChatGPT-owned Execution=In progress items whose worker, CI, external dispatch, or monitoring
+2. Reconcile stale exact-head lifecycle state before continuing workers or claiming ordinary queue work. Inspect every open
+   Project PR whose current Review, Verification, Approval, or derived Blocked/Human handoff relies on completed exact-head
+   evidence. If its current head differs from the head supporting that state, use one guarded command expecting the current
+   Status, Execution, Executor, and current head to set Review / Ready / ChatGPT and clear stale Worker reference. Verify the
+   terminal reaction and resulting Project state. This supervisory reconciliation may select Approval or Blocked items that are
+   not otherwise in the ordinary ChatGPT queue and consumes at most one item in the tick.
+3. Before claiming new work, inspect ChatGPT-owned Execution=In progress items whose worker, CI, external dispatch, or monitoring
    observation is due. Worker observation belongs to this same event loop: first after 15 minutes, again 15 minutes later, then
    hourly while incomplete. Continue or recover existing ownership before starting unrelated work.
-3. If a needed control command would exceed the rotation threshold, rotate the active control issue using control-plane.md, then
+4. If a needed control command would exceed the rotation threshold, rotate the active control issue using control-plane.md, then
    continue this tick. Do not create a separate cleanup scheduler.
-4. Otherwise select at most one Project 2 item where:
+5. Otherwise select at most one Project 2 item where:
    - Execution = Ready;
    - Executor = ChatGPT;
    - Assignee is empty or bedrin-gpt;
    - Status is Planning, Implementation, Review, or Verification;
    - current ChatGPT tools and identity can truthfully complete the lifecycle turn or reach a safe durable handoff now.
-5. Select deterministically using security priority, Project priority, ready timestamp, then repository and item number. Never
+6. Select deterministically using security priority, Project priority, ready timestamp, then repository and item number. Never
    create a duplicate Project item, worker, branch, or pull request.
-6. Claim with one guarded delivery-control/v1 command. Set Execution=In progress plus the concrete tick/worker reference and
+7. Claim with one guarded delivery-control/v1 command. Set Execution=In progress plus the concrete tick/worker reference and
    lease, inspect the terminal reaction, then re-read and verify ownership before work. If execution or external dispatch cannot
    start, release to Ready. Set Blocked only when Dmitry must decide or act.
-7. Perform exactly one lifecycle turn:
+8. Perform exactly one lifecycle turn:
    - Planning: resolve outcome, decisions, non-goals, risk axes, Implementer, Verifier, and proof obligations.
    - Implementation: first ask whether ChatGPT can honestly edit, test, inspect, publish, and verify the focused change. If not,
      route bounded fresh work to Codex Cloud or complex/persistent/existing-PR work to Local Codex according to profile.yml.
@@ -84,15 +90,15 @@ Perform this protocol:
      before another implementation dispatch; do not mechanically issue another patch list.
    - Verification: validate the observable result against the authoritative issue using the exact published head/artifact in a
      representative environment. Do not rename unit tests or green CI as system verification.
-8. Publish human-useful evidence on the target issue/PR. Then use one guarded control command for the complete next Status,
+9. Publish human-useful evidence on the target issue/PR. Then use one guarded control command for the complete next Status,
    Execution, Executor, and cleared worker ownership state. Update GitHub Assignee separately when supported and verify it.
-9. Routine waiting for a concrete CI run or worker remains In progress only with a durable reference and next observation point.
-   Blocked always routes an exact action to Human/bedrin.
-10. Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged
+10. Routine waiting for a concrete CI run or worker remains In progress only with a durable reference and next observation point.
+    Blocked always routes an exact action to Human/bedrin.
+11. Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged
     repository/hosting operations without Dmitry's explicit instruction.
-11. If no eligible intake, due continuation, control-log rotation, claimable turn, or meaningful reconciliation exists, make no
-    GitHub/source mutation and reply only NO_CHANGE. Otherwise finish with a compact summary containing selected item, lifecycle
-    turn, durable evidence, and resulting Status / Execution / Executor / Assignee.
+12. If no eligible intake, stale-head reconciliation, due continuation, control-log rotation, claimable turn, or meaningful
+    reconciliation exists, make no GitHub/source mutation and reply only NO_CHANGE. Otherwise finish with a compact summary
+    containing selected item, lifecycle turn, durable evidence, and resulting Status / Execution / Executor / Assignee.
 ```
 
 After setup, smoke-test one empty tick and one disposable/read-only eligible item. Replacing a long defining task chat is manual

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -60,13 +60,14 @@ Treat each occurrence as logically stateless even though the transcript is persi
 1. ignore prior-run conclusions and mutable conversational context;
 2. read current GitHub state, repository policy, and [`profile.yml`](profile.yml) from scratch;
 3. reconcile eligible external PR intake;
-4. continue one due owned worker or select at most one eligible lifecycle turn;
-5. submit one guarded control command to claim it;
-6. verify the successful reaction and resulting Project state before doing work;
-7. perform the lifecycle turn directly or make one supported external dispatch;
-8. publish human-useful evidence on the target item;
-9. submit one guarded control command for the lifecycle handoff and verify the result;
-10. return `NO_CHANGE` when no intake, continuation, rotation, or eligible work exists.
+4. reconcile an open PR whose current head no longer matches the exact head supporting its downstream lifecycle state;
+5. continue one due owned worker or select at most one eligible lifecycle turn;
+6. submit one guarded control command to claim it;
+7. verify the successful reaction and resulting Project state before doing work;
+8. perform the lifecycle turn directly or make one supported external dispatch;
+9. publish human-useful evidence on the target item;
+10. submit one guarded control command for the lifecycle handoff and verify the result;
+11. return `NO_CHANGE` when no intake, head reconciliation, continuation, rotation, or eligible work exists.
 
 A tick must never claim work it cannot reasonably complete or hand off durably during that occurrence. Route long
 implementation, dependency-heavy builds, persistent services, and environment-specific verification to Codex Cloud, Local
@@ -115,6 +116,25 @@ arbitration comment is permitted.
 
 Control-log rotation is ordinary event-loop maintenance. A tick needing to post a command may rotate an old/full log first, then
 continue. Rotation does not require an additional Scheduled Task.
+
+### Exact-head reconciliation
+
+A lifecycle result is valid only for the exact pull-request head named by its evidence. Before continuing owned work or selecting
+ordinary queue work, a supervising tick inspects every open Project pull request whose current state depends on completed Review,
+Verification, Approval, or a human handoff derived from one of those statuses.
+
+If the current PR head differs from the exact head supporting that state, the tick must:
+
+1. stop relying on the stale review, verification packet, approval handoff, blocked decision, or worker reference;
+2. submit one guarded `delivery-control/v1` command that expects the current Status, Execution, Executor, and current PR head;
+3. set `Status = Review`, `Execution = Ready`, and `Executor = ChatGPT`, and clear stale worker ownership in the same command;
+4. inspect the terminal reaction and re-read Project state before treating the PR as re-queued;
+5. leave technical reconciliation details on the control issue rather than posting legacy field or claim comments on the PR.
+
+This reconciliation is supervisory work and may select an item even when its current Status is not otherwise eligible for the
+ChatGPT queue, including `Approval` or `Blocked / Human`. It consumes at most one item in a tick and precedes a new claim. A
+conflict means state changed concurrently; re-read and do not overwrite the newer route. A later Review must inspect the complete
+diff and matching-head CI again; an approval or verification result for an older head is never inherited automatically.
 
 ### Codex app automation adapter
 


### PR DESCRIPTION
## Problem

A pull request can reach `Approval / Ready / Human` and then receive a new head commit. The ordinary ChatGPT queue only selects Planning, Implementation, Review, and Verification, so stale exact-head approval or verification evidence could remain durable after the PR changed.

PR #690 exposed this gap after Dependabot rebased the branch following an approval.

## Design

- Merge current `develop` into the existing branch, preserving its newer universal PR intake, canonicalization, existing-PR continuation, routing, and verification rules.
- Run supervisory exact-head reconciliation after universal PR intake/canonicalization and before due-worker continuation or ordinary queue selection.
- Inspect open PRs whose canonical PR or owning issue has downstream lifecycle state based on an older exact head.
- Requeue through one guarded `delivery-control/v1` transition to `Review / Ready / ChatGPT`, clearing stale ownership while retaining the PR URL and new exact head as evidence.
- Identify a canonical PR through target plus `expected.head`; identify a PR owned by a canonical issue through structured `reviewPullRequest.number/head`.
- Verify the terminal reaction, PR draft/head, and canonical Project state; keep technical commands on the labeled control issue.

## Compatibility and policy impact

No product code, Project schema, workflow permissions, merge authority, Java compatibility, or public API changes. The generic event-loop rule is effective for dispatchers that re-read repository policy each tick; the checked-in ChatGPT setup prompt carries the same rule for future task replacement.

## Dependency changes

None.

## Validation

- `git diff --check origin/develop...HEAD`
- Exact changed-file assertion against `origin/develop...HEAD`; only `.chatgpt/scheduled-task-prompt.md` and `docs/ai-delivery/event-loop.md` differ.
- `rg` conflict-marker scan of both changed files.
- Verified the remote branch SHA matches the local exact head.

No executable source or workflow code changed, so no runtime test suite was applicable.

## Risks and limitations

Configured Scheduled Task prompt text is copied at task creation time, but current tasks re-read `docs/ai-delivery/event-loop.md` on every tick. The prompt-file change covers future task replacement and explicitly documents the same ordering and canonical-item rules.

Exact published head: `afaeac0c1f5a2c41c3d228771c51d3d0190bbf99`.

No merge or auto-merge is requested or enabled.
