### PR TITLE
Codify coordinated Playwright and legacy Spring updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,61 @@ updates:
       day: "sunday"
       time: "05:00"
     open-pull-requests-limit: 5
+    groups:
+      playwright-toolchain:
+        applies-to: "version-updates"
+        patterns:
+          - "@playwright/test"
+          - "playwright"
+      playwright-toolchain-security:
+        applies-to: "security-updates"
+        patterns:
+          - "@playwright/test"
+          - "playwright"
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # The core module intentionally remains on Spring Framework 5.3 for Java 8.
+  # Keep security alerts visible, allow patched 5.3 releases, and suppress only
+  # incompatible Spring 6+ proposals. Version-update PRs remain disabled here.
+  - package-ecosystem: "maven"
+    directory: "/sniffy"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "06:00"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "org.springframework:spring-web"
+        versions:
+          - "[6,)"
+    labels:
+      - "dependencies"
+      - "java"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # sniffy-web-javax is the Java 8 / javax.servlet compatibility lane.
+  # Spring 6+ requires Java 17 and Jakarta APIs; the separate modern module owns
+  # that coverage. Continue accepting patched Spring 5.3 security releases only.
+  - package-ecosystem: "maven"
+    directory: "/sniffy-web-javax"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "07:00"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "org.springframework:spring-webmvc"
+        versions:
+          - "[6,)"
+    labels:
+      - "dependencies"
+      - "java"
     commit-message:
       prefix: "deps"
       include: "scope"


### PR DESCRIPTION
## Problem

Dependabot can update `@playwright/test` without the directly pinned `playwright`, producing two incompatible browser-tooling trees as seen in PR #719. It can also propose Spring Framework 6/7 for modules that intentionally preserve Java 8 and `javax.servlet` compatibility, as seen in PRs #706 and #707.

## Design

- Group `@playwright/test` and `playwright` for both npm version updates and grouped security updates in `/sniffy-ui`.
- Add directory-scoped Maven configuration for `/sniffy` and `/sniffy-web-javax`.
- Disable routine Maven version-update PRs for those two entries while retaining security-update configuration.
- Ignore only Spring Framework versions `[6,)` for the exact legacy artifact in each directory, allowing future patched 5.3 releases while preventing incompatible Java 17/Jakarta proposals.
- Keep the modern Spring 7/Jakarta lane unchanged.

## Compatibility impact

This records existing repository compatibility policy; it does not downgrade or change any dependency in source. `sniffy` remains Java 8-compatible on Spring 5.3, `sniffy-web-javax` remains the Java 8/`javax.servlet` lane, and modern Spring support remains isolated in the existing Java 17 module.

## Dependency changes

No dependency version is changed by this PR. It changes only future Dependabot proposal generation.

## Validation

- Parsed the complete YAML successfully with Ruby's YAML parser.
- Compared the exact one-file diff against current `develop`.
- Verified Maven dependency names use `groupId:artifactId` format and Maven range syntax.
- Verified the Maven entries point to the exact manifest directories and do not set `target-branch`, so their ignore rules can apply to security updates.

## Risks and limitations

The Playwright grouping prevents future partial routine proposals after this configuration reaches `develop`; it does not repair the already-open PR #719. A linked replacement implementation must still synchronize both direct dependencies, regenerate the lockfile, and pass Frontend and Website browser jobs.

Exact published head: `e591d9d3aa6953e8c67129231ab9bd5ac50d4062`.

No merge or auto-merge is requested or enabled.