### PR TITLE
Make Codex Cloud Git publication recoverable

### DIFF
--- a/.codex/cloud/maintenance.sh
+++ b/.codex/cloud/maintenance.sh
@@ -10,6 +10,19 @@ fi
 # shellcheck disable=SC1090
 source "${HOME}/.sniffy-codex-env"
 
+GITHUB_REPOSITORY_URL="https://github.com/sniffy/sniffy.git"
+
+if git remote get-url origin >/dev/null 2>&1; then
+  git remote set-url --push origin "${GITHUB_REPOSITORY_URL}"
+else
+  git remote add origin "${GITHUB_REPOSITORY_URL}"
+fi
+
+if [[ "$(git remote get-url --push origin)" != "${GITHUB_REPOSITORY_URL}" ]]; then
+  echo "Could not configure the canonical origin push URL." >&2
+  exit 1
+fi
+
 # Resolve dependencies again after checkout. With a warm ~/.m2 cache this is
 # cheap, while still downloading dependencies introduced by the selected branch.
 bash .codex/cloud/warm-maven-cache.sh

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -14,6 +14,7 @@ GH_VERSION="2.96.0"
 NODE_VERSION="24.15.0"
 GH_BIN_DIR="${HOME}/.local/bin"
 GH_INSTALL_DIR="${HOME}/.local/share/gh/${GH_VERSION}"
+GITHUB_REPOSITORY_URL="https://github.com/sniffy/sniffy.git"
 
 case "$(uname -m)" in
   x86_64)
@@ -74,7 +75,30 @@ install_github_cli() {
   gh --version
 }
 
+configure_github_remote() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Codex Cloud setup must run inside the Sniffy Git worktree." >&2
+    exit 1
+  fi
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    git remote set-url --push origin "${GITHUB_REPOSITORY_URL}"
+  else
+    git remote add origin "${GITHUB_REPOSITORY_URL}"
+  fi
+
+  local push_url
+  push_url="$(git remote get-url --push origin)"
+  if [[ "${push_url}" != "${GITHUB_REPOSITORY_URL}" ]]; then
+    echo "Could not configure the canonical origin push URL: ${push_url}" >&2
+    exit 1
+  fi
+
+  echo "Configured origin push URL: ${push_url}"
+}
+
 install_github_cli
+configure_github_remote
 
 configure_github_auth() {
   if [[ -z "${GH_TOKEN:-}" ]]; then
@@ -101,7 +125,7 @@ configure_github_auth() {
   auth_login="$(gh api user --jq '.login')"
   probe_branch="agent/codex-auth-check-$(git rev-parse --short=12 HEAD)"
 
-  if ! push_error="$(git push --dry-run --porcelain https://github.com/sniffy/sniffy.git "HEAD:refs/heads/${probe_branch}" 2>&1)"; then
+  if ! push_error="$(git push --dry-run --porcelain origin "HEAD:refs/heads/${probe_branch}" 2>&1)"; then
     echo "GH_TOKEN authenticates as ${auth_login}, but setup could not negotiate a dry-run push to sniffy/sniffy:" >&2
     printf '%s\n' "${push_error}" >&2
     echo "The repository .permissions.push flag only describes the account role; token permissions can be narrower." >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ constraints for their subtrees.
   credentials, external infrastructure, destructive ambiguity, or contradictory requirements.
 - The roles, executors, routing rules, delivery state machine, and verification ownership model live under
   [`docs/ai-delivery/`](docs/ai-delivery/README.md). They are operational guidance, not a replacement for repository policy.
+- Before executor-specific work, read the applicable runbook under `docs/ai-delivery/executors/`. Codex Cloud work must read
+  [`docs/ai-delivery/executors/codex-cloud.md`](docs/ai-delivery/executors/codex-cloud.md) before editing or publication.
 
 ## Delivery and Git safety
 
@@ -21,6 +23,9 @@ constraints for their subtrees.
   incomplete.
 - GitHub remote state is the publication source of truth. Before reporting delivery, verify the remote branch, full SHA,
   pull-request URL, base/head refs, draft state, and matching pull-request head.
+- An absent `origin` in an isolated Sniffy checkout is recoverable configuration, not by itself a publication blocker.
+  Configure its push URL as `https://github.com/sniffy/sniffy.git` without embedded credentials, verify authentication, and
+  attempt the authorized push before reporting an access blocker.
 - Preserve unrelated work. Do not reset, clean, rebase shared branches, force-push, rewrite history, create a replacement PR
   for a continuation, merge, or enable auto-merge unless Dmitry explicitly authorizes that exact action.
 - Prefer a fresh `agent/<short-description>` branch from current `develop` for new work. Continue review fixes on the exact

--- a/docs/ai-delivery/executors/codex-cloud.md
+++ b/docs/ai-delivery/executors/codex-cloud.md
@@ -29,8 +29,9 @@ Planning, or block for Dmitry.
 
 The supported environment uses:
 
-- `.codex/cloud/setup.sh` for initial setup and GitHub CLI authentication;
-- `.codex/cloud/maintenance.sh` when a cached environment resumes on another branch;
+- `.codex/cloud/setup.sh` for initial setup, GitHub CLI authentication, and canonical `origin` push configuration;
+- `.codex/cloud/maintenance.sh` to restore the toolchain and canonical `origin` push URL when a cached environment resumes on
+  another branch;
 - `.codex/cloud/use-jdk.sh <8|11|17|21|25>` for toolchain selection;
 - platform-provided Maven and JDK 11/17/21/25;
 - repository-installed Temurin JDK 8;
@@ -61,6 +62,7 @@ Before relying on a new or changed environment, run a small reversible validatio
 - reads `AGENTS.md`, [`../profile.yml`](../profile.yml), and this runbook;
 - reports Java, Maven, Node when relevant, and `gh` versions;
 - checks `gh auth status`;
+- confirms `origin` has `https://github.com/sniffy/sniffy.git` as its push URL;
 - performs and removes a reversible remote-ref write;
 - switches between JDK 8 and JDK 25;
 - runs one focused test and `git diff --check`;
@@ -95,8 +97,22 @@ A Cloud implementation task reads the authoritative issue/thread, lifecycle/rout
     worker ownership; update the ChatGPT Assignee separately and verify both operations;
 11. never review/approve its own implementation, merge, or enable auto-merge.
 
-If `origin` is absent, configure an explicit repository URL. If publication access fails, preserve/recover the existing workspace
-or commit instead of recreating implementation.
+A missing `origin` is recoverable checkout configuration, not evidence that setup authentication failed. Setup persists `gh`
+authentication for the agent phase, while the repository URL contains no credential. Before reporting a publication blocker,
+restore the canonical remote, verify auth, and attempt the authorized push:
+
+```bash
+if git remote get-url origin >/dev/null 2>&1; then
+  git remote set-url --push origin https://github.com/sniffy/sniffy.git
+else
+  git remote add origin https://github.com/sniffy/sniffy.git
+fi
+gh auth status --hostname github.com
+git push --set-upstream origin HEAD
+```
+
+Only an actual authentication, network-policy, permission, or branch-protection failure after that attempt is a publication
+blocker. Preserve/recover the existing workspace or commit instead of recreating implementation.
 
 ## Verification lifecycle contract
 


### PR DESCRIPTION
## Problem

While supervising #755, Codex Cloud completed and committed the workflow change but reported the checkout's missing Git remote as a publication blocker. The Cloud setup already persisted GitHub CLI credentials and verified push negotiation, and the executor runbook already treated an absent `origin` as recoverable, but that rule was not present in the mandatory root instructions and setup did not create the remote itself.

## Change

- configure `origin` with the canonical `https://github.com/sniffy/sniffy.git` push URL during fresh Cloud setup;
- restore that push URL during cached-environment maintenance without replacing an existing platform fetch URL;
- make the Codex Cloud runbook mandatory from root `AGENTS.md`;
- state explicitly that a missing remote is recoverable configuration, not a blocker until auth and an actual push have been attempted;
- document the exact credential-free recovery commands and validate the remote in the environment proof task.

## Validation

- `bash -n` passed for `.codex/cloud/setup.sh` and `.codex/cloud/maintenance.sh`;
- focused temporary-repository assertions passed for both absent-`origin` and existing-mirror-fetch cases;
- checked all four changed files for trailing whitespace;
- focused assertions confirmed setup dry-runs through `origin`, both scripts configure the canonical push URL, the mandatory instructions contain the non-blocker rule, and no credential is embedded in a repository URL;
- inspected the complete branch diff against current `develop`.

## Compatibility and risk

The change affects only Codex Cloud environment setup, maintenance, and executor documentation. Existing fetch URLs are preserved; only `origin`'s push URL is made canonical. No token is placed in Git configuration or command text.

Published head: `648d9af589c8289aa89c43f7171cca415cd93e0a`

Related: #755