### PR TITLE
Return agent PRs to implementation after Request Changes

### DIFF
--- a/.github/scripts/review-return.js
+++ b/.github/scripts/review-return.js
@@ -26,22 +26,66 @@ function projectItem(content, projectId) {
   return content?.projectItems?.nodes?.find(item => item.project?.id === projectId) || null;
 }
 
-function representedTargets(pullRequest, projectId) {
-  const targets = [];
+function pullRequestReference(pullRequest) {
+  return {
+    number: pullRequest.number,
+    branch: pullRequest.headRefName,
+    head: String(pullRequest.headRefOid || '').toLowerCase()
+  };
+}
+
+function selectCanonicalTarget(pullRequest, projectId) {
+  const closingIssues = pullRequest.closingIssuesReferences?.nodes || [];
+  const pullRequestRef = pullRequestReference(pullRequest);
+
+  if (closingIssues.length > 1) {
+    return {
+      target: null,
+      reason: `Pull request #${pullRequest.number} closes ${closingIssues.length} issues; current policy keeps a multi-issue pull request in Planning rather than returning one linked item automatically.`
+    };
+  }
+
+  if (closingIssues.length === 1) {
+    const issue = closingIssues[0];
+    const issueItem = projectItem(issue, projectId);
+    if (!issueItem) {
+      return {
+        target: null,
+        reason: `Closing issue #${issue.number} is canonical but is not represented in Project 2; wait for universal intake to materialize it.`
+      };
+    }
+    return {
+      target: {
+        type: 'Issue',
+        number: issue.number,
+        item: issueItem,
+        pullRequest: pullRequestRef
+      },
+      reason: null
+    };
+  }
+
   const pullRequestItem = projectItem(pullRequest, projectId);
-  if (pullRequestItem) {
-    targets.push({
+  if (!pullRequestItem) {
+    return {
+      target: null,
+      reason: `Standalone pull request #${pullRequest.number} is canonical but is not represented in Project 2.`
+    };
+  }
+  return {
+    target: {
       type: 'PullRequest',
       number: pullRequest.number,
-      head: String(pullRequest.headRefOid || '').toLowerCase(),
-      item: pullRequestItem
-    });
-  }
-  for (const issue of pullRequest.closingIssuesReferences?.nodes || []) {
-    const issueItem = projectItem(issue, projectId);
-    if (issueItem) targets.push({type: 'Issue', number: issue.number, head: null, item: issueItem});
-  }
-  return targets;
+      item: pullRequestItem,
+      pullRequest: pullRequestRef
+    },
+    reason: null
+  };
+}
+
+function continuationReference(target) {
+  const pullRequest = target.pullRequest;
+  return `Continuation PR https://github.com/${REPOSITORY}/pull/${pullRequest.number} (#${pullRequest.number}); branch ${pullRequest.branch}; exact head ${pullRequest.head}`;
 }
 
 function commandFor(target) {
@@ -50,13 +94,9 @@ function commandFor(target) {
   const execution = current.get('Execution') ?? null;
   const implementer = current.get('Implementer') ?? null;
   const executor = current.get('Executor') ?? null;
+  const workerReference = current.get('Worker reference') ?? null;
+  const desiredWorkerReference = target.type === 'Issue' ? continuationReference(target) : null;
 
-  if (status === 'Implementation' && execution === 'Ready' && executor === implementer && AGENT_EXECUTORS.has(implementer)) {
-    return {alreadyReturned: true, implementer, command: null};
-  }
-  if (!RETURNABLE_STATUSES.has(status)) {
-    throw new Error(`Project item is ${status || '(clear)'}, not Review or Approval.`);
-  }
   if (!AGENT_EXECUTORS.has(implementer)) {
     throw new Error(`Implementer "${implementer || '(clear)'}" is not an agent executor eligible for automatic continuation.`);
   }
@@ -64,27 +104,76 @@ function commandFor(target) {
     throw new Error('Blocked work requires a maintainer decision and cannot be returned automatically.');
   }
 
+  const alreadyRouted = status === 'Implementation' && execution === 'Ready' && executor === implementer;
+  const alreadyReturned = alreadyRouted && workerReference === desiredWorkerReference;
+  if (!alreadyRouted && !RETURNABLE_STATUSES.has(status)) {
+    throw new Error(`Project item is ${status || '(clear)'}, not Review or Approval.`);
+  }
+
   const expectedFields = {};
   for (const field of GUARDED_FIELDS) expectedFields[field] = current.get(field) ?? null;
   const expected = {type: target.type, fields: expectedFields};
-  if (target.type === 'PullRequest') expected.head = target.head;
+  if (target.type === 'PullRequest') expected.head = target.pullRequest.head;
+
+  const set = {
+    Status: 'Implementation',
+    Execution: 'Ready',
+    Executor: implementer
+  };
+  const clear = [];
+  if (desiredWorkerReference === null) {
+    clear.push('Worker reference');
+  } else {
+    set['Worker reference'] = desiredWorkerReference;
+  }
 
   return {
-    alreadyReturned: false,
+    alreadyReturned,
     implementer,
     command: {
       command: 'delivery-control/v1',
       target: {repository: REPOSITORY, number: target.number},
       expected,
-      set: {
-        Status: 'Implementation',
-        Execution: 'Ready',
-        Executor: implementer
-      },
-      clear: ['Worker reference'],
+      set,
+      clear,
       addIfMissing: false
     }
   };
+}
+
+async function verifyPullRequestHead({github, pullRequestNumber, expectedHead}) {
+  const [owner, repo] = REPOSITORY.split('/');
+  const response = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: Number(pullRequestNumber)
+  });
+  const actualHead = String(response.data?.head?.sha || '').toLowerCase();
+  const preparedHead = String(expectedHead || '').toLowerCase();
+  if (!preparedHead || actualHead !== preparedHead) {
+    throw new Error(`Pull request #${pullRequestNumber} head is ${actualHead || '(missing)'}, not prepared head ${preparedHead || '(missing)'}.`);
+  }
+  return actualHead;
+}
+
+async function clearAssigneesAndVerify({github, targetNumber}) {
+  const [owner, repo] = REPOSITORY.split('/');
+  const issueNumber = Number(targetNumber);
+  await github.rest.issues.update({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    assignees: []
+  });
+  const response = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: issueNumber
+  });
+  const remaining = (response.data?.assignees || []).map(assignee => assignee.login);
+  if (remaining.length > 0) {
+    throw new Error(`Failed to clear assignees from #${issueNumber}; still assigned: ${remaining.join(', ')}.`);
+  }
 }
 
 function skip(core, reason) {
@@ -116,6 +205,7 @@ async function prepareReviewReturn({github, context, core, authorizedActors}) {
       id
       number
       headRefOid
+      headRefName
       baseRefName
       isCrossRepository
       reviewDecision
@@ -157,32 +247,38 @@ async function prepareReviewReturn({github, context, core, authorizedActors}) {
     return skip(core, `The current aggregate review decision is ${pullRequest.reviewDecision || '(none)'}, not CHANGES_REQUESTED.`);
   }
 
-  const targets = representedTargets(pullRequest, project.id);
-  if (targets.length === 0) {
-    return skip(core, 'Neither the pull request nor a formally linked closing issue is represented in Project 2.');
-  }
-  if (targets.length > 1) {
-    throw new Error(`Found ${targets.length} represented work items. Keep exactly one Project work item for a pull request correction.`);
-  }
+  const selection = selectCanonicalTarget(pullRequest, project.id);
+  if (!selection.target) return skip(core, selection.reason);
 
-  const target = targets[0];
+  const target = selection.target;
   const prepared = commandFor(target);
   core.setOutput('target_repository', REPOSITORY.replace('/', '-'));
   core.setOutput('target_number', String(target.number));
   core.setOutput('target_type', target.type);
   core.setOutput('implementer', prepared.implementer);
-
-  if (prepared.alreadyReturned) {
-    return skip(core, `The ${target.type} #${target.number} is already Implementation / Ready for ${prepared.implementer}.`);
-  }
+  core.setOutput('pull_request_number', String(target.pullRequest.number));
+  core.setOutput('pull_request_branch', target.pullRequest.branch);
+  core.setOutput('pull_request_head', target.pullRequest.head);
 
   core.setOutput('should_transition', 'true');
   core.setOutput('payload_base64', Buffer.from(JSON.stringify(prepared.command)).toString('base64'));
   core.summary.addHeading('Review return prepared')
     .addRaw(`Reviewer: \`${reviewer}\`\n\nTarget: \`${target.type} ${REPOSITORY}#${target.number}\`\n\n`)
-    .addRaw(`Return route: \`Implementation / Ready / ${prepared.implementer}\`\n\n`)
+    .addRaw(`Return route: \`Implementation / Ready / ${prepared.implementer}\`\n\n`);
+  if (prepared.alreadyReturned) {
+    core.summary.addRaw('Project routing is already in the requested state; assignment release will still be re-run and verified.\n\n');
+  }
+  core.summary
     .addCodeBlock(JSON.stringify(prepared.command, null, 2), 'json');
   return {shouldTransition: true, target, ...prepared};
 }
 
-module.exports = {AGENT_EXECUTORS, commandFor, prepareReviewReturn, representedTargets, values};
+module.exports = {
+  AGENT_EXECUTORS,
+  clearAssigneesAndVerify,
+  commandFor,
+  prepareReviewReturn,
+  selectCanonicalTarget,
+  values,
+  verifyPullRequestHead
+};

--- a/.github/scripts/review-return.js
+++ b/.github/scripts/review-return.js
@@ -119,6 +119,7 @@ async function prepareReviewReturn({github, context, core, authorizedActors}) {
       baseRefName
       isCrossRepository
       reviewDecision
+      author { login }
       projectItems(first: 50) { nodes { ...ProjectItem } }
       closingIssuesReferences(first: 20) { nodes {
         id
@@ -148,6 +149,9 @@ async function prepareReviewReturn({github, context, core, authorizedActors}) {
   if (!project || !pullRequest) throw new Error('Project 2 or the reviewed pull request was not found.');
   if (pullRequest.baseRefName !== BASE_BRANCH || pullRequest.isCrossRepository) {
     return skip(core, 'The current pull request is no longer an eligible same-repository develop PR.');
+  }
+  if (pullRequest.author?.login === reviewer) {
+    return skip(core, 'The reviewer is also the pull request author; correction routing requires an independent review.');
   }
   if (pullRequest.reviewDecision !== 'CHANGES_REQUESTED') {
     return skip(core, `The current aggregate review decision is ${pullRequest.reviewDecision || '(none)'}, not CHANGES_REQUESTED.`);

--- a/.github/scripts/review-return.js
+++ b/.github/scripts/review-return.js
@@ -1,0 +1,184 @@
+'use strict';
+
+const REPOSITORY = 'sniffy/sniffy';
+const ORGANIZATION = 'sniffy';
+const PROJECT_NUMBER = 2;
+const BASE_BRANCH = 'develop';
+const AGENT_EXECUTORS = new Set(['ChatGPT', 'Codex Cloud', 'Local Codex']);
+const RETURNABLE_STATUSES = new Set(['Review', 'Approval']);
+const GUARDED_FIELDS = ['Status', 'Execution', 'Implementer', 'Executor', 'Worker reference'];
+
+function values(nodes) {
+  const result = new Map();
+  for (const value of nodes || []) {
+    if (!value.field?.name) continue;
+    if (value.__typename === 'ProjectV2ItemFieldSingleSelectValue') {
+      result.set(value.field.name, value.name ?? null);
+    }
+    if (value.__typename === 'ProjectV2ItemFieldTextValue') {
+      result.set(value.field.name, value.text ?? null);
+    }
+  }
+  return result;
+}
+
+function projectItem(content, projectId) {
+  return content?.projectItems?.nodes?.find(item => item.project?.id === projectId) || null;
+}
+
+function representedTargets(pullRequest, projectId) {
+  const targets = [];
+  const pullRequestItem = projectItem(pullRequest, projectId);
+  if (pullRequestItem) {
+    targets.push({
+      type: 'PullRequest',
+      number: pullRequest.number,
+      head: String(pullRequest.headRefOid || '').toLowerCase(),
+      item: pullRequestItem
+    });
+  }
+  for (const issue of pullRequest.closingIssuesReferences?.nodes || []) {
+    const issueItem = projectItem(issue, projectId);
+    if (issueItem) targets.push({type: 'Issue', number: issue.number, head: null, item: issueItem});
+  }
+  return targets;
+}
+
+function commandFor(target) {
+  const current = values(target.item.fieldValues?.nodes);
+  const status = current.get('Status') ?? null;
+  const execution = current.get('Execution') ?? null;
+  const implementer = current.get('Implementer') ?? null;
+  const executor = current.get('Executor') ?? null;
+
+  if (status === 'Implementation' && execution === 'Ready' && executor === implementer && AGENT_EXECUTORS.has(implementer)) {
+    return {alreadyReturned: true, implementer, command: null};
+  }
+  if (!RETURNABLE_STATUSES.has(status)) {
+    throw new Error(`Project item is ${status || '(clear)'}, not Review or Approval.`);
+  }
+  if (!AGENT_EXECUTORS.has(implementer)) {
+    throw new Error(`Implementer "${implementer || '(clear)'}" is not an agent executor eligible for automatic continuation.`);
+  }
+  if (execution === 'Blocked') {
+    throw new Error('Blocked work requires a maintainer decision and cannot be returned automatically.');
+  }
+
+  const expectedFields = {};
+  for (const field of GUARDED_FIELDS) expectedFields[field] = current.get(field) ?? null;
+  const expected = {type: target.type, fields: expectedFields};
+  if (target.type === 'PullRequest') expected.head = target.head;
+
+  return {
+    alreadyReturned: false,
+    implementer,
+    command: {
+      command: 'delivery-control/v1',
+      target: {repository: REPOSITORY, number: target.number},
+      expected,
+      set: {
+        Status: 'Implementation',
+        Execution: 'Ready',
+        Executor: implementer
+      },
+      clear: ['Worker reference'],
+      addIfMissing: false
+    }
+  };
+}
+
+function skip(core, reason) {
+  core.setOutput('should_transition', 'false');
+  core.setOutput('reason', reason);
+  core.summary.addHeading('Review return skipped').addRaw(`${reason}\n`);
+  return {shouldTransition: false, reason};
+}
+
+async function prepareReviewReturn({github, context, core, authorizedActors}) {
+  const payload = context.payload || {};
+  const reviewer = payload.review?.user?.login || context.actor;
+  if (!authorizedActors?.has(reviewer)) return skip(core, `Reviewer ${reviewer || '(unknown)'} is not authorized.`);
+  if (payload.action !== 'submitted' || payload.review?.state !== 'changes_requested') {
+    return skip(core, 'The event is not a submitted changes-requested review.');
+  }
+
+  const eventPullRequest = payload.pull_request;
+  if (!eventPullRequest?.number) throw new Error('The review event does not contain a pull request number.');
+  if (eventPullRequest.base?.ref !== BASE_BRANCH) return skip(core, `The pull request does not target ${BASE_BRANCH}.`);
+  if (eventPullRequest.head?.repo?.full_name !== REPOSITORY) {
+    return skip(core, 'Fork pull requests are excluded because correction dispatch must not use privileged secrets on untrusted heads.');
+  }
+
+  const [owner, name] = REPOSITORY.split('/');
+  const result = await github.graphql(`query($org: String!, $project: Int!, $owner: String!, $name: String!, $number: Int!) {
+    organization(login: $org) { projectV2(number: $project) { id } }
+    repository(owner: $owner, name: $name) { pullRequest(number: $number) {
+      id
+      number
+      headRefOid
+      baseRefName
+      isCrossRepository
+      reviewDecision
+      projectItems(first: 50) { nodes { ...ProjectItem } }
+      closingIssuesReferences(first: 20) { nodes {
+        id
+        number
+        projectItems(first: 50) { nodes { ...ProjectItem } }
+      } }
+    } }
+  }
+  fragment ProjectItem on ProjectV2Item {
+    id
+    project { id }
+    fieldValues(first: 100) { nodes {
+      __typename
+      ... on ProjectV2ItemFieldSingleSelectValue {
+        name
+        field { ... on ProjectV2SingleSelectField { name } }
+      }
+      ... on ProjectV2ItemFieldTextValue {
+        text
+        field { ... on ProjectV2Field { name } }
+      }
+    } }
+  }`, {org: ORGANIZATION, project: PROJECT_NUMBER, owner, name, number: eventPullRequest.number});
+
+  const project = result.organization?.projectV2;
+  const pullRequest = result.repository?.pullRequest;
+  if (!project || !pullRequest) throw new Error('Project 2 or the reviewed pull request was not found.');
+  if (pullRequest.baseRefName !== BASE_BRANCH || pullRequest.isCrossRepository) {
+    return skip(core, 'The current pull request is no longer an eligible same-repository develop PR.');
+  }
+  if (pullRequest.reviewDecision !== 'CHANGES_REQUESTED') {
+    return skip(core, `The current aggregate review decision is ${pullRequest.reviewDecision || '(none)'}, not CHANGES_REQUESTED.`);
+  }
+
+  const targets = representedTargets(pullRequest, project.id);
+  if (targets.length === 0) {
+    return skip(core, 'Neither the pull request nor a formally linked closing issue is represented in Project 2.');
+  }
+  if (targets.length > 1) {
+    throw new Error(`Found ${targets.length} represented work items. Keep exactly one Project work item for a pull request correction.`);
+  }
+
+  const target = targets[0];
+  const prepared = commandFor(target);
+  core.setOutput('target_repository', REPOSITORY.replace('/', '-'));
+  core.setOutput('target_number', String(target.number));
+  core.setOutput('target_type', target.type);
+  core.setOutput('implementer', prepared.implementer);
+
+  if (prepared.alreadyReturned) {
+    return skip(core, `The ${target.type} #${target.number} is already Implementation / Ready for ${prepared.implementer}.`);
+  }
+
+  core.setOutput('should_transition', 'true');
+  core.setOutput('payload_base64', Buffer.from(JSON.stringify(prepared.command)).toString('base64'));
+  core.summary.addHeading('Review return prepared')
+    .addRaw(`Reviewer: \`${reviewer}\`\n\nTarget: \`${target.type} ${REPOSITORY}#${target.number}\`\n\n`)
+    .addRaw(`Return route: \`Implementation / Ready / ${prepared.implementer}\`\n\n`)
+    .addCodeBlock(JSON.stringify(prepared.command, null, 2), 'json');
+  return {shouldTransition: true, target, ...prepared};
+}
+
+module.exports = {AGENT_EXECUTORS, commandFor, prepareReviewReturn, representedTargets, values};

--- a/.github/scripts/review-return.test.js
+++ b/.github/scripts/review-return.test.js
@@ -40,6 +40,7 @@ function pullRequest({prItem = null, issues = []} = {}) {
     baseRefName: 'develop',
     isCrossRepository: false,
     reviewDecision: 'CHANGES_REQUESTED',
+    author: {login: 'bedrin-codex-cloud'},
     projectItems: {nodes: prItem ? [prItem] : []},
     closingIssuesReferences: {nodes: issues}
   };
@@ -131,6 +132,23 @@ test('prepares exactly one linked issue transition from a current request-change
   assert.equal(core.outputs.target_type, 'Issue');
   const command = JSON.parse(Buffer.from(core.outputs.payload_base64, 'base64').toString('utf8'));
   assert.equal(command.set.Executor, 'Codex Cloud');
+});
+
+test('skips a self-review even when the aggregate decision requests changes', async () => {
+  const core = coreDouble();
+  await prepareReviewReturn({
+    github: {async graphql() {
+      return {
+        organization: {projectV2: {id: 'PROJECT'}},
+        repository: {pullRequest: {...pullRequest({issues: [issue(748)]}), author: {login: 'bedrin'}}}
+      };
+    }},
+    context: context(),
+    core,
+    authorizedActors: new Set(['bedrin'])
+  });
+  assert.equal(core.outputs.should_transition, 'false');
+  assert.match(core.outputs.reason, /also the pull request author/);
 });
 
 test('skips stale aggregate decisions and rejects duplicate represented work items', async () => {

--- a/.github/scripts/review-return.test.js
+++ b/.github/scripts/review-return.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {commandFor, prepareReviewReturn, representedTargets} = require('./review-return');
+
+const head = '46c47e02e8a5236cf1e7348fc6202da11ea1bbd3';
+
+function selectValue(field, name) {
+  return {__typename: 'ProjectV2ItemFieldSingleSelectValue', name, field: {name: field}};
+}
+
+function textValue(field, text) {
+  return {__typename: 'ProjectV2ItemFieldTextValue', text, field: {name: field}};
+}
+
+function item(project = 'PROJECT', overrides = {}) {
+  const fields = {
+    Status: 'Review',
+    Execution: 'In progress',
+    Implementer: 'Codex Cloud',
+    Executor: 'ChatGPT',
+    'Worker reference': 'review-claim',
+    ...overrides
+  };
+  return {
+    id: 'ITEM',
+    project: {id: project},
+    fieldValues: {nodes: Object.entries(fields).flatMap(([field, value]) => {
+      if (value === null) return [];
+      return field === 'Worker reference' ? [textValue(field, value)] : [selectValue(field, value)];
+    })}
+  };
+}
+
+function pullRequest({prItem = null, issues = []} = {}) {
+  return {
+    number: 751,
+    headRefOid: head,
+    baseRefName: 'develop',
+    isCrossRepository: false,
+    reviewDecision: 'CHANGES_REQUESTED',
+    projectItems: {nodes: prItem ? [prItem] : []},
+    closingIssuesReferences: {nodes: issues}
+  };
+}
+
+function issue(number, issueItem = item()) {
+  return {id: `ISSUE-${number}`, number, projectItems: {nodes: [issueItem]}};
+}
+
+function coreDouble() {
+  const outputs = {};
+  const summary = {
+    addHeading() { return this; },
+    addRaw() { return this; },
+    addCodeBlock() { return this; }
+  };
+  return {outputs, summary, setOutput(name, value) { outputs[name] = String(value); }};
+}
+
+function context(prNumber = 751) {
+  return {
+    actor: 'bedrin',
+    payload: {
+      action: 'submitted',
+      review: {state: 'changes_requested', user: {login: 'bedrin'}},
+      pull_request: {
+        number: prNumber,
+        base: {ref: 'develop'},
+        head: {repo: {full_name: 'sniffy/sniffy'}}
+      }
+    }
+  };
+}
+
+test('selects the PR when it is the only represented work item', () => {
+  const targets = representedTargets(pullRequest({prItem: item()}), 'PROJECT');
+  assert.deepEqual(targets.map(({type, number}) => ({type, number})), [{type: 'PullRequest', number: 751}]);
+});
+
+test('selects one formally linked issue when the PR is not represented', () => {
+  const targets = representedTargets(pullRequest({issues: [issue(748)]}), 'PROJECT');
+  assert.deepEqual(targets.map(({type, number}) => ({type, number})), [{type: 'Issue', number: 748}]);
+});
+
+test('builds a guarded return to the original agent implementer', () => {
+  const target = representedTargets(pullRequest({issues: [issue(748)]}), 'PROJECT')[0];
+  const prepared = commandFor(target);
+  assert.equal(prepared.implementer, 'Codex Cloud');
+  assert.deepEqual(prepared.command.set, {
+    Status: 'Implementation',
+    Execution: 'Ready',
+    Executor: 'Codex Cloud'
+  });
+  assert.deepEqual(prepared.command.clear, ['Worker reference']);
+  assert.equal(prepared.command.expected.type, 'Issue');
+  assert.equal(prepared.command.expected.fields.Status, 'Review');
+  assert.equal(prepared.command.expected.fields.Execution, 'In progress');
+  assert.equal(prepared.command.expected.fields.Executor, 'ChatGPT');
+  assert.equal(prepared.command.expected.fields['Worker reference'], 'review-claim');
+});
+
+test('guards the exact head when the PR itself is the work item', () => {
+  const target = representedTargets(pullRequest({prItem: item()}), 'PROJECT')[0];
+  assert.equal(commandFor(target).command.expected.head, head);
+});
+
+test('rejects non-agent implementers and blocked work', () => {
+  assert.throws(() => commandFor({type: 'Issue', number: 1, item: item('PROJECT', {Implementer: 'Human'})}), /not an agent executor/);
+  assert.throws(() => commandFor({type: 'Issue', number: 1, item: item('PROJECT', {Execution: 'Blocked'})}), /Blocked work/);
+});
+
+test('prepares exactly one linked issue transition from a current request-changes review', async () => {
+  const core = coreDouble();
+  const github = {async graphql() {
+    return {
+      organization: {projectV2: {id: 'PROJECT'}},
+      repository: {pullRequest: pullRequest({issues: [issue(748)]})}
+    };
+  }};
+  const result = await prepareReviewReturn({
+    github,
+    context: context(),
+    core,
+    authorizedActors: new Set(['bedrin'])
+  });
+  assert.equal(result.shouldTransition, true);
+  assert.equal(core.outputs.should_transition, 'true');
+  assert.equal(core.outputs.target_number, '748');
+  assert.equal(core.outputs.target_type, 'Issue');
+  const command = JSON.parse(Buffer.from(core.outputs.payload_base64, 'base64').toString('utf8'));
+  assert.equal(command.set.Executor, 'Codex Cloud');
+});
+
+test('skips stale aggregate decisions and rejects duplicate represented work items', async () => {
+  const staleCore = coreDouble();
+  await prepareReviewReturn({
+    github: {async graphql() {
+      return {
+        organization: {projectV2: {id: 'PROJECT'}},
+        repository: {pullRequest: {...pullRequest({issues: [issue(748)]}), reviewDecision: 'APPROVED'}}
+      };
+    }},
+    context: context(),
+    core: staleCore,
+    authorizedActors: new Set(['bedrin'])
+  });
+  assert.equal(staleCore.outputs.should_transition, 'false');
+
+  await assert.rejects(
+    prepareReviewReturn({
+      github: {async graphql() {
+        return {
+          organization: {projectV2: {id: 'PROJECT'}},
+          repository: {pullRequest: pullRequest({prItem: item(), issues: [issue(748)]})}
+        };
+      }},
+      context: context(),
+      core: coreDouble(),
+      authorizedActors: new Set(['bedrin'])
+    }),
+    /exactly one Project work item/
+  );
+});

--- a/.github/scripts/review-return.test.js
+++ b/.github/scripts/review-return.test.js
@@ -2,9 +2,16 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const {commandFor, prepareReviewReturn, representedTargets} = require('./review-return');
+const {
+  clearAssigneesAndVerify,
+  commandFor,
+  prepareReviewReturn,
+  selectCanonicalTarget,
+  verifyPullRequestHead
+} = require('./review-return');
 
 const head = '46c47e02e8a5236cf1e7348fc6202da11ea1bbd3';
+const branch = 'agent/example-correction';
 
 function selectValue(field, name) {
   return {__typename: 'ProjectV2ItemFieldSingleSelectValue', name, field: {name: field}};
@@ -37,6 +44,7 @@ function pullRequest({prItem = null, issues = []} = {}) {
   return {
     number: 751,
     headRefOid: head,
+    headRefName: branch,
     baseRefName: 'develop',
     isCrossRepository: false,
     reviewDecision: 'CHANGES_REQUESTED',
@@ -47,7 +55,14 @@ function pullRequest({prItem = null, issues = []} = {}) {
 }
 
 function issue(number, issueItem = item()) {
-  return {id: `ISSUE-${number}`, number, projectItems: {nodes: [issueItem]}};
+  return {id: `ISSUE-${number}`, number, projectItems: {nodes: issueItem ? [issueItem] : []}};
+}
+
+function issueTarget(overrides = {}) {
+  return selectCanonicalTarget(
+    pullRequest({issues: [issue(748, item('PROJECT', overrides))]}),
+    'PROJECT'
+  ).target;
 }
 
 function coreDouble() {
@@ -75,27 +90,56 @@ function context(prNumber = 751) {
   };
 }
 
-test('selects the PR when it is the only represented work item', () => {
-  const targets = representedTargets(pullRequest({prItem: item()}), 'PROJECT');
-  assert.deepEqual(targets.map(({type, number}) => ({type, number})), [{type: 'PullRequest', number: 751}]);
+test('selects the represented PR only when no issue is formally closed', () => {
+  const selection = selectCanonicalTarget(pullRequest({prItem: item()}), 'PROJECT');
+  assert.deepEqual(
+    {type: selection.target.type, number: selection.target.number},
+    {type: 'PullRequest', number: 751}
+  );
 });
 
-test('selects one formally linked issue when the PR is not represented', () => {
-  const targets = representedTargets(pullRequest({issues: [issue(748)]}), 'PROJECT');
-  assert.deepEqual(targets.map(({type, number}) => ({type, number})), [{type: 'Issue', number: 748}]);
+test('selects one formal closing issue even when the PR is also represented', () => {
+  const selection = selectCanonicalTarget(
+    pullRequest({prItem: item(), issues: [issue(748)]}),
+    'PROJECT'
+  );
+  assert.deepEqual(
+    {type: selection.target.type, number: selection.target.number},
+    {type: 'Issue', number: 748}
+  );
 });
 
-test('builds a guarded return to the original agent implementer', () => {
-  const target = representedTargets(pullRequest({issues: [issue(748)]}), 'PROJECT')[0];
+test('does not substitute a represented PR for a missing canonical issue', () => {
+  const selection = selectCanonicalTarget(
+    pullRequest({prItem: item(), issues: [issue(748, null)]}),
+    'PROJECT'
+  );
+  assert.equal(selection.target, null);
+  assert.match(selection.reason, /Closing issue #748 is canonical but is not represented/);
+});
+
+test('keeps a multi-issue pull request in Planning instead of routing one linked issue', () => {
+  const selection = selectCanonicalTarget(
+    pullRequest({prItem: item(), issues: [issue(748), issue(749)]}),
+    'PROJECT'
+  );
+  assert.equal(selection.target, null);
+  assert.match(selection.reason, /closes 2 issues.*multi-issue pull request in Planning/);
+});
+
+test('builds a guarded issue return with a durable continuation reference', () => {
+  const target = issueTarget();
   const prepared = commandFor(target);
   assert.equal(prepared.implementer, 'Codex Cloud');
   assert.deepEqual(prepared.command.set, {
     Status: 'Implementation',
     Execution: 'Ready',
-    Executor: 'Codex Cloud'
+    Executor: 'Codex Cloud',
+    'Worker reference': `Continuation PR https://github.com/sniffy/sniffy/pull/751 (#751); branch ${branch}; exact head ${head}`
   });
-  assert.deepEqual(prepared.command.clear, ['Worker reference']);
+  assert.deepEqual(prepared.command.clear, []);
   assert.equal(prepared.command.expected.type, 'Issue');
+  assert.equal(prepared.command.expected.head, undefined);
   assert.equal(prepared.command.expected.fields.Status, 'Review');
   assert.equal(prepared.command.expected.fields.Execution, 'In progress');
   assert.equal(prepared.command.expected.fields.Executor, 'ChatGPT');
@@ -103,13 +147,39 @@ test('builds a guarded return to the original agent implementer', () => {
 });
 
 test('guards the exact head when the PR itself is the work item', () => {
-  const target = representedTargets(pullRequest({prItem: item()}), 'PROJECT')[0];
+  const target = selectCanonicalTarget(pullRequest({prItem: item()}), 'PROJECT').target;
   assert.equal(commandFor(target).command.expected.head, head);
+  assert.deepEqual(commandFor(target).command.clear, ['Worker reference']);
+});
+
+test('repairs stale ownership on an already-routed issue before treating it as returned', () => {
+  const target = issueTarget({
+    Status: 'Implementation',
+    Execution: 'Ready',
+    Executor: 'Codex Cloud',
+    'Worker reference': 'stale review claim'
+  });
+  const prepared = commandFor(target);
+  assert.equal(prepared.alreadyReturned, false);
+  assert.match(prepared.command.set['Worker reference'], /PR https:\/\/github.com\/sniffy\/sniffy\/pull\/751/);
+});
+
+test('keeps an idempotent command so failed assignment release can be retried', () => {
+  const desiredReference = commandFor(issueTarget()).command.set['Worker reference'];
+  const prepared = commandFor(issueTarget({
+    Status: 'Implementation',
+    Execution: 'Ready',
+    Executor: 'Codex Cloud',
+    'Worker reference': desiredReference
+  }));
+  assert.equal(prepared.alreadyReturned, true);
+  assert.ok(prepared.command);
+  assert.equal(prepared.command.set['Worker reference'], desiredReference);
 });
 
 test('rejects non-agent implementers and blocked work', () => {
-  assert.throws(() => commandFor({type: 'Issue', number: 1, item: item('PROJECT', {Implementer: 'Human'})}), /not an agent executor/);
-  assert.throws(() => commandFor({type: 'Issue', number: 1, item: item('PROJECT', {Execution: 'Blocked'})}), /Blocked work/);
+  assert.throws(() => commandFor(issueTarget({Implementer: 'Human'})), /not an agent executor/);
+  assert.throws(() => commandFor(issueTarget({Execution: 'Blocked'})), /Blocked work/);
 });
 
 test('prepares exactly one linked issue transition from a current request-changes review', async () => {
@@ -117,7 +187,7 @@ test('prepares exactly one linked issue transition from a current request-change
   const github = {async graphql() {
     return {
       organization: {projectV2: {id: 'PROJECT'}},
-      repository: {pullRequest: pullRequest({issues: [issue(748)]})}
+      repository: {pullRequest: pullRequest({prItem: item(), issues: [issue(748)]})}
     };
   }};
   const result = await prepareReviewReturn({
@@ -130,8 +200,12 @@ test('prepares exactly one linked issue transition from a current request-change
   assert.equal(core.outputs.should_transition, 'true');
   assert.equal(core.outputs.target_number, '748');
   assert.equal(core.outputs.target_type, 'Issue');
+  assert.equal(core.outputs.pull_request_number, '751');
+  assert.equal(core.outputs.pull_request_branch, branch);
+  assert.equal(core.outputs.pull_request_head, head);
   const command = JSON.parse(Buffer.from(core.outputs.payload_base64, 'base64').toString('utf8'));
   assert.equal(command.set.Executor, 'Codex Cloud');
+  assert.match(command.set['Worker reference'], new RegExp(`branch ${branch}; exact head ${head}`));
 });
 
 test('skips a self-review even when the aggregate decision requests changes', async () => {
@@ -151,7 +225,7 @@ test('skips a self-review even when the aggregate decision requests changes', as
   assert.match(core.outputs.reason, /also the pull request author/);
 });
 
-test('skips stale aggregate decisions and rejects duplicate represented work items', async () => {
+test('skips stale aggregate decisions and non-materialized canonical targets', async () => {
   const staleCore = coreDouble();
   await prepareReviewReturn({
     github: {async graphql() {
@@ -166,18 +240,59 @@ test('skips stale aggregate decisions and rejects duplicate represented work ite
   });
   assert.equal(staleCore.outputs.should_transition, 'false');
 
+  const missingCore = coreDouble();
+  await prepareReviewReturn({
+    github: {async graphql() {
+      return {
+        organization: {projectV2: {id: 'PROJECT'}},
+        repository: {pullRequest: pullRequest({prItem: item(), issues: [issue(748, null)]})}
+      };
+    }},
+    context: context(),
+    core: missingCore,
+    authorizedActors: new Set(['bedrin'])
+  });
+  assert.equal(missingCore.outputs.should_transition, 'false');
+  assert.match(missingCore.outputs.reason, /Closing issue #748 is canonical but is not represented/);
+});
+
+test('verifies the prepared pull-request head immediately before transition', async () => {
+  const github = {
+    rest: {
+      pulls: {
+        async get() {
+          return {data: {head: {sha: head}}};
+        }
+      }
+    }
+  };
+  assert.equal(await verifyPullRequestHead({github, pullRequestNumber: 751, expectedHead: head}), head);
   await assert.rejects(
-    prepareReviewReturn({
-      github: {async graphql() {
-        return {
-          organization: {projectV2: {id: 'PROJECT'}},
-          repository: {pullRequest: pullRequest({prItem: item(), issues: [issue(748)]})}
-        };
-      }},
-      context: context(),
-      core: coreDouble(),
-      authorizedActors: new Set(['bedrin'])
-    }),
-    /exactly one Project work item/
+    verifyPullRequestHead({github, pullRequestNumber: 751, expectedHead: 'deadbeef'}),
+    /not prepared head deadbeef/
+  );
+});
+
+test('re-reads assignment state and fails when an assignee remains', async () => {
+  let updateArguments;
+  const github = {
+    rest: {
+      issues: {
+        async update(args) {
+          updateArguments = args;
+        },
+        async get() {
+          return {data: {assignees: []}};
+        }
+      }
+    }
+  };
+  await clearAssigneesAndVerify({github, targetNumber: 748});
+  assert.deepEqual(updateArguments.assignees, []);
+
+  github.rest.issues.get = async () => ({data: {assignees: [{login: 'bedrin-gpt'}]}});
+  await assert.rejects(
+    clearAssigneesAndVerify({github, targetNumber: 748}),
+    /still assigned: bedrin-gpt/
   );
 });

--- a/.github/workflows/review-return.yml
+++ b/.github/workflows/review-return.yml
@@ -3,6 +3,7 @@ name: Return requested changes to implementer
 on:
   pull_request:
     paths:
+      - .github/scripts/delivery-control.js
       - .github/scripts/review-return.js
       - .github/scripts/review-return.test.js
       - .github/workflows/review-return.yml
@@ -54,6 +55,9 @@ jobs:
       target_number: ${{ steps.prepare.outputs.target_number }}
       target_type: ${{ steps.prepare.outputs.target_type }}
       implementer: ${{ steps.prepare.outputs.implementer }}
+      pull_request_number: ${{ steps.prepare.outputs.pull_request_number }}
+      pull_request_branch: ${{ steps.prepare.outputs.pull_request_branch }}
+      pull_request_head: ${{ steps.prepare.outputs.pull_request_head }}
 
     steps:
       - uses: actions/checkout@v7
@@ -99,14 +103,27 @@ jobs:
         uses: actions/github-script@v9
         env:
           PAYLOAD_BASE64: ${{ needs.prepare.outputs.payload_base64 }}
+          PULL_REQUEST_NUMBER: ${{ needs.prepare.outputs.pull_request_number }}
+          PULL_REQUEST_HEAD: ${{ needs.prepare.outputs.pull_request_head }}
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const control = require('./.github/scripts/delivery-control.js');
+            const reviewReturn = require('./.github/scripts/review-return.js');
+            await reviewReturn.verifyPullRequestHead({
+              github,
+              pullRequestNumber: process.env.PULL_REQUEST_NUMBER,
+              expectedHead: process.env.PULL_REQUEST_HEAD
+            });
             await control.executeTransition({
               github,
               core,
               payloadBase64: process.env.PAYLOAD_BASE64
+            });
+            await reviewReturn.verifyPullRequestHead({
+              github,
+              pullRequestNumber: process.env.PULL_REQUEST_NUMBER,
+              expectedHead: process.env.PULL_REQUEST_HEAD
             });
       - name: Fail conflicting review return
         if: steps.transition.outputs.outcome == 'conflict'
@@ -121,11 +138,10 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: Number(process.env.TARGET_NUMBER),
-              assignees: []
+            const reviewReturn = require('./.github/scripts/review-return.js');
+            await reviewReturn.clearAssigneesAndVerify({
+              github,
+              targetNumber: process.env.TARGET_NUMBER
             });
-            core.summary.addRaw('Cleared GitHub assignees so the configured implementer pool can claim the correction.\n');
+            core.summary.addRaw('Cleared and verified GitHub assignees so the configured implementer pool can claim the correction.\n');
             await core.summary.write();

--- a/.github/workflows/review-return.yml
+++ b/.github/workflows/review-return.yml
@@ -1,0 +1,128 @@
+name: Return requested changes to implementer
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/review-return.js
+      - .github/scripts/review-return.test.js
+      - .github/workflows/review-return.yml
+      - docs/ai-delivery/review-return.md
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.18.0
+      - name: Check and test review return
+        run: |
+          node --check .github/scripts/review-return.js
+          node --check .github/scripts/review-return.test.js
+          node --test .github/scripts/review-return.test.js
+      - name: Parse workflow YAML
+        run: ruby -e 'require "yaml"; YAML.load_file(".github/workflows/review-return.yml")'
+
+  prepare:
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.action == 'submitted' &&
+      github.event.review.state == 'changes_requested' &&
+      github.event.pull_request.base.ref == 'develop' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      should_transition: ${{ steps.prepare.outputs.should_transition }}
+      payload_base64: ${{ steps.prepare.outputs.payload_base64 }}
+      target_repository: ${{ steps.prepare.outputs.target_repository }}
+      target_number: ${{ steps.prepare.outputs.target_number }}
+      target_type: ${{ steps.prepare.outputs.target_type }}
+      implementer: ${{ steps.prepare.outputs.implementer }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+      - name: Prepare guarded correction transition
+        id: prepare
+        uses: actions/github-script@v9
+        env:
+          AI_DELIVERY_COMMAND_ACTORS: ${{ vars.AI_DELIVERY_COMMAND_ACTORS }}
+          PRODUCT_MANAGER_LOGIN: ${{ vars.PRODUCT_MANAGER_LOGIN }}
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const control = require('./.github/scripts/delivery-control.js');
+            const reviewReturn = require('./.github/scripts/review-return.js');
+            await reviewReturn.prepareReviewReturn({
+              github,
+              context,
+              core,
+              authorizedActors: control.actorSet(process.env)
+            });
+            await core.summary.write();
+
+  transition:
+    needs: prepare
+    if: needs.prepare.outputs.should_transition == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: ai-delivery-${{ needs.prepare.outputs.target_repository }}-${{ needs.prepare.outputs.target_number }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+      - name: Apply guarded return to Implementation
+        id: transition
+        uses: actions/github-script@v9
+        env:
+          PAYLOAD_BASE64: ${{ needs.prepare.outputs.payload_base64 }}
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const control = require('./.github/scripts/delivery-control.js');
+            await control.executeTransition({
+              github,
+              core,
+              payloadBase64: process.env.PAYLOAD_BASE64
+            });
+      - name: Fail conflicting review return
+        if: steps.transition.outputs.outcome == 'conflict'
+        run: |
+          echo 'The guarded review-return transition conflicted with current Project state.' >&2
+          exit 1
+      - name: Release assignment to the implementer pool
+        if: steps.transition.outputs.outcome == 'success'
+        uses: actions/github-script@v9
+        env:
+          TARGET_NUMBER: ${{ needs.prepare.outputs.target_number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.TARGET_NUMBER),
+              assignees: []
+            });
+            core.summary.addRaw('Cleared GitHub assignees so the configured implementer pool can claim the correction.\n');
+            await core.summary.write();

--- a/.github/workflows/review-return.yml
+++ b/.github/workflows/review-return.yml
@@ -32,6 +32,8 @@ jobs:
           node --test .github/scripts/review-return.test.js
       - name: Parse workflow YAML
         run: ruby -e 'require "yaml"; YAML.load_file(".github/workflows/review-return.yml")'
+      - name: Lint GitHub Actions workflow
+        run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/review-return.yml
 
   prepare:
     if: >-
@@ -39,7 +41,8 @@ jobs:
       github.event.action == 'submitted' &&
       github.event.review.state == 'changes_requested' &&
       github.event.pull_request.base.ref == 'develop' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/docs/ai-delivery/review-return.md
+++ b/docs/ai-delivery/review-return.md
@@ -8,16 +8,17 @@ When an authorized independent reviewer submits a formal `REQUEST_CHANGES` revie
 
 The `Return requested changes to implementer` workflow listens to submitted `pull_request_review` events. It runs only for same-repository pull requests targeting `develop`; it never checks out or executes the reviewed head.
 
-The workflow queries the current aggregate `reviewDecision` and continues only while it is `CHANGES_REQUESTED`. It then requires exactly one represented Project 2 work item:
+The workflow queries the current aggregate `reviewDecision` and continues only while it is `CHANGES_REQUESTED`. It derives the canonical item from formal closing links before considering current Project representation:
 
-- the pull request itself, for PR-first intake such as an agent-owned standalone PR; or
-- one formally linked closing issue, for issue-first implementation work.
+- exactly one closing issue makes that issue canonical, even when the pull request was also auto-added;
+- no closing issue makes the pull request canonical;
+- several closing issues keep the pull request in Planning and are not returned automatically.
 
-Zero represented items are a no-op. More than one represented item is an error because dispatching duplicate correction work would violate single-work-item ownership. Plain issue mentions are intentionally insufficient; use GitHub's formal PR-to-issue link or a closing keyword.
+The canonical item must already be represented in Project 2. A missing canonical issue is a no-op until universal intake materializes it; a represented pull request is never substituted for that issue. Duplicate issue/PR representation does not redefine canonical identity or dispatch duplicate correction work. Plain issue mentions are intentionally insufficient; use GitHub's formal PR-to-issue link or a closing keyword.
 
 ## Transition
 
-The adapter uses the existing `delivery-control/v1` command shape and `executeTransition` implementation. It guards the current target type, exact head when the target is the PR, and the current `Status`, `Execution`, `Implementer`, `Executor`, and `Worker reference` values.
+The adapter uses the existing `delivery-control/v1` command shape and `executeTransition` implementation. It guards the current target type, exact head when the target is the PR, and the current `Status`, `Execution`, `Implementer`, `Executor`, and `Worker reference` values. For an issue-canonical continuation, the serialized transition re-reads the pull-request head immediately before and after Project mutation so a head change cannot silently publish a stale continuation reference.
 
 Eligible agent implementers are `ChatGPT`, `Codex Cloud`, and `Local Codex`. A successful formal Request Changes review applies:
 
@@ -25,23 +26,24 @@ Eligible agent implementers are `ChatGPT`, `Codex Cloud`, and `Local Codex`. A s
 Status: Implementation
 Execution: Ready
 Executor: <current Implementer>
-Worker reference: clear
-GitHub assignees: clear
+Worker reference for a canonical issue: existing PR URL/number + branch + exact head
+Worker reference for a canonical PR: clear
+GitHub assignees: cleared and re-read as empty
 ```
 
-Clearing assignees makes the item pool-ready for the selected executor. The normal 15-minute event loop claims it, continues the same branch and PR, and begins the standard 15-minute, 15-minute, then hourly supervision cycle after concrete dispatch.
+Replacing an issue's stale review claim with the durable PR/branch/head reference preserves adoption context while making the item pool-ready. A standalone PR carries its own identity and exact-head guard, so its stale Worker reference is cleared. Assignee release is complete only after a separate GitHub read confirms no assignee remains. An idempotent rerun still performs and verifies assignment release, including when Project mutation succeeded in an earlier attempt. The normal 15-minute event loop claims the item, continues the same branch and PR, and begins the standard 15-minute, 15-minute, then hourly supervision cycle after concrete dispatch.
 
 `Blocked` work, human or automation implementers, fork pull requests, stale/superseded review decisions, and ambiguous Project representation are not automatically dispatched.
 
 ## Permissions and security
 
-The workflow starts with `permissions: {}`. Validation receives `contents: read`. Runtime preparation checks out trusted `develop` and uses the existing `PROJECT_TOKEN` only to read Project and PR state. The serialized transition job receives `contents: read` and `issues: write`; Project mutation uses `PROJECT_TOKEN`, while the repository `GITHUB_TOKEN` only clears assignees on the selected issue or PR.
+The workflow starts with `permissions: {}`. Validation receives `contents: read` and runs when the adapter, workflow, documentation, or imported `delivery-control.js` implementation changes. Runtime preparation checks out trusted `develop` and uses the existing `PROJECT_TOKEN` only to read Project and PR state. The serialized transition job receives `contents: read` and `issues: write`; Project mutation and pull-request head verification use `PROJECT_TOKEN`, while the repository `GITHUB_TOKEN` only clears and verifies assignees on the selected issue or PR.
 
 The runtime path never checks out the reviewed head, never executes contributor code, does not merge, does not enable auto-merge, and does not run for forks. External contributors and Dependabot remain governed by pull-request intake policy rather than automatic correction dispatch.
 
 ## Blocking and failure semantics
 
-This is a non-required lifecycle automation, not a source-validation check. A skipped event writes a job summary and makes no mutation. An unexpected error, Project guard conflict, ambiguous target, failed Project verification, or failed assignee update fails the workflow for maintainer inspection. The shared per-item concurrency key serializes this transition with ordinary delivery-control commands.
+This is a non-required lifecycle automation, not a source-validation check. A skipped event writes a job summary and makes no mutation. An unexpected error, Project guard conflict, pull-request head change, failed Project verification, or failed assignment update/verification fails the workflow for maintainer inspection. The shared per-item concurrency key serializes this transition with ordinary delivery-control commands.
 
 The maintainer response is to inspect the Actions summary, current formal review decision, Project representation, and fields; correct the relationship or state; then re-run the failed job or perform one guarded manual transition. Do not create a duplicate work item or replacement PR merely to recover this automation.
 

--- a/docs/ai-delivery/review-return.md
+++ b/docs/ai-delivery/review-return.md
@@ -1,0 +1,50 @@
+# Automatic Request Changes return
+
+## Purpose
+
+When an authorized independent reviewer submits a formal `REQUEST_CHANGES` review on an agent-implemented pull request, the next action is implementation correction. This adapter returns the existing Project 2 work item to the original agent pool so the normal event loop can claim and continue the same branch and pull request.
+
+## Trigger and target selection
+
+The `Return requested changes to implementer` workflow listens to submitted `pull_request_review` events. It runs only for same-repository pull requests targeting `develop`; it never checks out or executes the reviewed head.
+
+The workflow queries the current aggregate `reviewDecision` and continues only while it is `CHANGES_REQUESTED`. It then requires exactly one represented Project 2 work item:
+
+- the pull request itself, for PR-first intake such as an agent-owned standalone PR; or
+- one formally linked closing issue, for issue-first implementation work.
+
+Zero represented items are a no-op. More than one represented item is an error because dispatching duplicate correction work would violate single-work-item ownership. Plain issue mentions are intentionally insufficient; use GitHub's formal PR-to-issue link or a closing keyword.
+
+## Transition
+
+The adapter uses the existing `delivery-control/v1` command shape and `executeTransition` implementation. It guards the current target type, exact head when the target is the PR, and the current `Status`, `Execution`, `Implementer`, `Executor`, and `Worker reference` values.
+
+Eligible agent implementers are `ChatGPT`, `Codex Cloud`, and `Local Codex`. A successful formal Request Changes review applies:
+
+```text
+Status: Implementation
+Execution: Ready
+Executor: <current Implementer>
+Worker reference: clear
+GitHub assignees: clear
+```
+
+Clearing assignees makes the item pool-ready for the selected executor. The normal 15-minute event loop claims it, continues the same branch and PR, and begins the standard 15-minute, 15-minute, then hourly supervision cycle after concrete dispatch.
+
+`Blocked` work, human or automation implementers, fork pull requests, stale/superseded review decisions, and ambiguous Project representation are not automatically dispatched.
+
+## Permissions and security
+
+The workflow starts with `permissions: {}`. Validation receives `contents: read`. Runtime preparation checks out trusted `develop` and uses the existing `PROJECT_TOKEN` only to read Project and PR state. The serialized transition job receives `contents: read` and `issues: write`; Project mutation uses `PROJECT_TOKEN`, while the repository `GITHUB_TOKEN` only clears assignees on the selected issue or PR.
+
+The runtime path never checks out the reviewed head, never executes contributor code, does not merge, does not enable auto-merge, and does not run for forks. External contributors and Dependabot remain governed by pull-request intake policy rather than automatic correction dispatch.
+
+## Blocking and failure semantics
+
+This is a non-required lifecycle automation, not a source-validation check. A skipped event writes a job summary and makes no mutation. An unexpected error, Project guard conflict, ambiguous target, failed Project verification, or failed assignee update fails the workflow for maintainer inspection. The shared per-item concurrency key serializes this transition with ordinary delivery-control commands.
+
+The maintainer response is to inspect the Actions summary, current formal review decision, Project representation, and fields; correct the relationship or state; then re-run the failed job or perform one guarded manual transition. Do not create a duplicate work item or replacement PR merely to recover this automation.
+
+## Ownership, noise, and lifecycle
+
+ChatGPT owns supervision of this adapter and the subsequent correction dispatch. Expected signal is one workflow run per formal Request Changes submission, with no target-conversation comment and no control-log noise. The workflow should be removed or folded into a future native Project automation only when GitHub can atomically route a formally reviewed PR or its canonical linked issue back to a dynamically selected implementer with equivalent guards, permissions, and audit evidence.


### PR DESCRIPTION
Closes #762

## Problem

A formal Request Changes review records feedback but does not currently return the canonical Project 2 work item to a deliberately selected agent implementer. The item can remain in Review/Approval, preventing the normal event loop from claiming an implementation correction.

## Design

Add a dedicated `pull_request_review` adapter for same-repository PRs targeting `develop`.

On a submitted formal Request Changes review, it:

- verifies the reviewer is authorized and independent from the PR author;
- re-queries the aggregate `reviewDecision` and requires `CHANGES_REQUESTED`;
- derives canonical identity from formal closing links before inspecting Project representation: one closing issue is canonical, no closing issue makes the PR canonical, and multi-issue PRs remain in Planning;
- never substitutes an auto-added PR for a missing canonical issue and tolerates duplicate PR/issue representation without duplicate dispatch;
- requires `Implementer` to be `ChatGPT`, `Codex Cloud`, or `Local Codex`;
- reuses the existing `delivery-control/v1` command and serialized transition implementation;
- applies `Status = Implementation`, `Execution = Ready`, and `Executor = Implementer`;
- replaces stale issue-owned worker claims with a durable existing PR URL/number, branch, and exact head; standalone PR targets clear stale worker ownership and use their own exact-head guard;
- re-reads the PR head immediately before and after an issue-owned Project transition;
- clears assignees and re-reads the target to verify the assignment set is empty;
- keeps idempotent reruns capable of retrying assignment release.

The normal event loop performs the actual continuation dispatch and supervision on the same branch and PR.

## Security and permissions

- top-level `permissions: {}` with least-privilege job permissions;
- runtime checks out trusted `develop`, never the reviewed head;
- runtime is limited to same-repository, non-Dependabot PRs targeting `develop`;
- forks, external contributors, Dependabot, human/automation implementers, blocked work, stale reviews, and non-materialized or multi-issue canonical targets are excluded;
- `PROJECT_TOKEN` is used for Project mutation and trusted PR-state reads;
- repository `GITHUB_TOKEN` receives only `issues: write` to clear and verify assignees;
- no branch writes, merge, auto-merge, deployment, environment, or hosting permissions.

## Compatibility and dependencies

No Java/runtime/public API behavior changes and no repository dependency changes. The correction branch merges current `develop` at `da0e8e26878882a6c6787450ee3b895051cd520d`. Validation uses Node 24.18.0 and the official actionlint image at pinned version `1.7.12`.

## Tests and checks

Locally executed after the base merge:

- `node --check .github/scripts/review-return.js`
- `node --check .github/scripts/review-return.test.js`
- `node --test .github/scripts/review-return.test.js` — 14/14 passing
- `node --test .github/scripts/delivery-control.test.js .github/scripts/delivery-policy.test.js .github/scripts/review-return.test.js` — 37/37 passing
- Ruby YAML parse of `.github/workflows/review-return.yml`
- actionlint 1.7.12 on `.github/workflows/review-return.yml`
- `git diff --check`

The focused validation workflow also runs when imported `.github/scripts/delivery-control.js` changes. Exact-head GitHub Actions are terminal for the published correction head: 32 checks succeeded, five event-only jobs were intentionally skipped, and zero checks failed, were cancelled, or remained pending. The full matrix is recorded in [Check Pull Request run 30588430178](https://github.com/sniffy/sniffy/actions/runs/30588430178); the focused validators also succeeded.

## Limitations and risks

- A plain issue mention is insufficient; the issue must be formally linked/closing.
- A missing canonical Project item is skipped until universal intake materializes it.
- Multi-issue PRs stay in Planning rather than being automatically returned to one linked issue.
- A PR head change or failed Project/assignment verification fails visibly for maintainer inspection.
- The runtime review-event path cannot execute until this workflow is merged into `develop`; after merge it needs a disposable exact-head smoke test covering successful routing and verified Project/assignment state.
- Fork and Dependabot correction flows remain governed by pull-request intake policy.

## Published head

`fb78887a37b539eb3225bfd3e5de48b9111cc109`
