### PR TITLE
Authenticate pull-request Codecov uploads with OIDC

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     env:
       HOME: /root
       PLAYWRIGHT_BROWSERS_PATH: /root/.cache/ms-playwright
@@ -60,10 +61,10 @@ jobs:
       - name: Upload frontend coverage
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./sniffy-ui/coverage/lcov.info
           flags: frontend
           disable_search: true
+          use_oidc: true
           fail_ci_if_error: true
           version: v11.3.1
           name: frontend
@@ -172,6 +173,9 @@ jobs:
           retention-days: 14
   smoke-test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -241,8 +245,9 @@ jobs:
             **/target/*jstack*.txt
       - uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend
+          use_oidc: true
+          fail_ci_if_error: true
   arch-matrix:
     runs-on: ubuntu-26.04
     timeout-minutes: 90
@@ -305,6 +310,9 @@ jobs:
       - smoke-test
     runs-on: ubuntu-26.04
     name: Test JDK IBM J9 1.8, ubuntu-26.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v7
       - name: Pull IBM JDK J9 1.8 Docker Image
@@ -342,12 +350,16 @@ jobs:
           MAVEN_OPTS: "-Dorg.slf4j.simpleLogger.showThreadName=true -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.showThreadName=true -Xmx1024m -Didea.home.path=${{ env.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
       - uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend
+          use_oidc: true
+          fail_ci_if_error: true
   test-matrix:
     needs:
       - smoke-test
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 30
     strategy:
       matrix:
@@ -420,8 +432,9 @@ jobs:
             **/target/*jstack*.txt
       - uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend
+          use_oidc: true
+          fail_ci_if_error: true
   analyze:
     needs:
       - smoke-test


### PR DESCRIPTION
Closes #755

## Problem

The `Check Pull Request` workflow passed `secrets.CODECOV_TOKEN` to Codecov, but Dependabot pull-request workflows do not receive ordinary Actions secrets. PR #690 exposed this as a blocking Frontend failure: Codecov rejected the upload with `Token required because branch is protected`.

The backend uploads in `smoke-test`, `test-ibm-j9`, and `test-matrix` were rejected for the same reason, but those failures were masked because Codecov upload errors were non-blocking there.

## Design

- Grant job-scoped `contents: read` and `id-token: write` only to the four coverage-producing jobs: `frontend`, `smoke-test`, `test-ibm-j9`, and `test-matrix`.
- Use Codecov's maintained OIDC support in all four existing upload steps.
- Make every frontend and backend upload fail closed with `fail_ci_if_error: true`.
- Remove all `CODECOV_TOKEN` inputs from the PR workflow.
- Preserve the existing `pull_request` trigger, job/check names, coverage flags, and Codecov's built-in external-fork handling. No `pull_request_target`, new workflow/job, repository secret, or workflow-level permission is introduced.

## Compatibility and dependency impact

No Java, runtime, public API, dependency, job-name, or trigger compatibility changes. The diff is limited to `.github/workflows/pr.yml`.

## Local validation

- `js-yaml@4.1.1` parsed `.github/workflows/pr.yml` successfully.
- Focused parsed-workflow assertions proved exactly four Codecov invocations, OIDC and fail-closed settings on all four, no `CODECOV_TOKEN`, `contents: read` on the four producing jobs, and `id-token: write` only on those four jobs.
- `prettier@3.9.6 --check .github/workflows/pr.yml` passed.
- `git diff --check` passed.
- `actionlint` 1.7.12 reported seven pre-existing findings (`ubuntu-26.04` runner recognition and one unrelated empty-matrix expression). A normalized comparison with the exact `origin/develop` workflow produced the identical seven findings and no new diagnostics.

## Exact-head runtime proof

`Check Pull Request` run [30566133530](https://github.com/sniffy/sniffy/actions/runs/30566133530) completed successfully at this exact head with 26/26 jobs green. All 20 expanded Codecov steps across Frontend, the four smoke jobs, IBM J9, and the multi-OS/JDK matrix succeeded with upload failures configured as blocking.

Representative frontend, smoke, IBM J9, and test-matrix logs each record `use_oidc: true`, `CC_FORK: false`, a successful `Get OIDC token` action, and `Upload queued for processing complete`. Codecov published successful backend/frontend project and patch checks for this head.

## Limitations and residual risk

This same-repository PR run directly proves the OIDC path. External-fork behavior remains delegated to Codecov's built-in fork detection as authorized by the issue; no fork-specific trigger, condition, token, or privileged workflow was added. Independent Verification can exercise a disposable external-fork PR if stronger runtime evidence is required.

Exact published head: `cde4df06d48adf6d70d9e64a8ab5f4c6a2a8cf64`.

No merge or auto-merge is requested or enabled.