### PR TITLE
Generalize delivery intake to arbitrary pull requests

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -57,21 +57,34 @@ ProjectV2 control protocol:
 - workflow_dispatch is an administrative/debug fallback to the same implementation, not the autonomous ChatGPT path.
 
 Perform this protocol:
-1. Reconcile external pull-request intake before ordinary queue work. Find eligible open sniffy/sniffy dependency PRs missing
-   from Project 2, verify actual author, labels, target, draft state, and exact head, and materialize them idempotently through one
-   guarded command with addIfMissing=true. Set Review, Execution, Verifier, Executor, and Worker reference as applicable, but do
-   not infer or set Implementer from the PR author or automation. Preserve an existing Implementer value without requiring it.
-   Intake is not approval.
-2. Before claiming new work, inspect ChatGPT-owned Execution=In progress items whose worker, CI, external dispatch, or monitoring
-   observation is due. Worker observation belongs to this same event loop: first after 15 minutes, again 15 minutes later, then
-   hourly while incomplete. Continue or recover existing ownership before starting unrelated work.
+1. Reconcile pull-request intake before ordinary queue work. Scan every open pull request in sniffy/sniffy targeting develop,
+   regardless of author, label, bot/provider, branch creator, or whether it originated from a Project issue. Verify author,
+   same-repository versus fork, labels, draft state, exact head, formal closing issues, existing Project representation, review
+   state, and current CI.
+   - Draft PR: do not start Review. Continue monitoring only when an existing canonical Project item already owns that draft PR.
+   - Exactly one formal closing issue: that issue is the canonical lifecycle item. Add or locate the issue idempotently and, when
+     the PR is non-draft and implementation publication is complete, initialize or hand it off to Review / Ready / ChatGPT with
+     the PR URL and exact head in Worker reference. Do not add the PR as a second active lifecycle item.
+   - No formal closing issue: the non-draft PR itself is the canonical lifecycle item. Add or locate it idempotently through one
+     guarded command with addIfMissing=true and initialize Review / Ready / ChatGPT.
+   - Multiple formal closing issues: the non-draft PR is the canonical coordination item and enters Planning / Ready / ChatGPT.
+     Record every linked issue and resolve scope, proof, completion propagation, and duplicate eligibility before Review.
+   - If an issue and its PR were both accidentally materialized, do not perform duplicate Review. Prefer the canonical item above,
+     make the duplicate non-claimable through a guarded reconciliation, and record the canonical link.
+   Intake leaves Implementer unchanged/empty, chooses a Verifier from actual risk, assigns bedrin-gpt separately, and records PR
+   URL, author, fork/same-repo status, branch, exact head, labels, linked issues, and security/dependency metadata. Intake is not
+   approval. Dependabot is one specialization of this universal intake, not the only PR source.
+2. Before claiming new work, inspect ChatGPT-owned Execution=In progress items whose worker, CI, external dispatch, rebase, draft
+   publication, or monitoring observation is due. Worker observation belongs to this same event loop: first after 15 minutes,
+   again 15 minutes later, then hourly while incomplete. Continue or recover existing ownership before starting unrelated work.
 3. If a needed control command would exceed the rotation threshold, rotate the active control issue using control-plane.md, then
    continue this tick. Do not create a separate cleanup scheduler.
-4. Otherwise select at most one Project 2 item where:
+4. Otherwise select at most one canonical Project 2 item where:
    - Execution = Ready;
    - Executor = ChatGPT;
    - Assignee is empty or bedrin-gpt;
    - Status is Planning, Implementation, Review, or Verification;
+   - the item is not a duplicate representation or a linked issue suppressed by an open canonical multi-issue PR;
    - current ChatGPT tools and identity can truthfully complete the lifecycle turn or reach a safe durable handoff now.
    Eligibility must not require Implementer to be populated.
 5. Select deterministically using security priority, Project priority, ready timestamp, then repository and item number. Never
@@ -80,28 +93,32 @@ Perform this protocol:
    lease, inspect the terminal reaction, then re-read and verify ownership before work. If execution or external dispatch cannot
    start, release to Ready. Set Blocked only when Dmitry must decide or act.
 7. Perform exactly one lifecycle turn:
-   - Planning: resolve outcome, decisions, non-goals, risk axes, Implementer when a future Implementation turn is actually needed,
-     Verifier, and proof obligations. Do not use an external PR author as a substitute for a deliberate implementation route.
-   - Implementation: first ask whether ChatGPT can honestly edit, test, inspect, publish, and verify the focused change. If not,
-     route bounded fresh work to Codex Cloud or complex/persistent/existing-PR work to Local Codex according to profile.yml.
-     Implementation may start only after a concrete Implementer/Executor route has been selected.
-   - Review: inspect the complete exact-head diff, issue decisions, tests, prior review threads, and matching-head CI. Submit
-     APPROVE only with independent identity. Otherwise submit one comprehensive REQUEST_CHANGES or record the identity limit.
-     When corrected work requires another Implementation turn and Implementer is empty, deliberately choose an internal route or
-     create a linked replacement task before transitioning; never copy the external PR author into Implementer. When a corrected
-     head returns to Review and still has substantive blockers, perform the routing.md convergence checkpoint before another
-     implementation dispatch; do not mechanically issue another patch list.
-   - Verification: validate the observable result against the authoritative issue using the exact published head/artifact in a
-     representative environment. Do not rename unit tests or green CI as system verification.
-8. Publish human-useful evidence on the target issue/PR. Then use one guarded control command for the complete next Status,
-   Execution, Executor, and cleared worker ownership state. Update GitHub Assignee separately when supported and verify it.
-9. Routine waiting for a concrete CI run or worker remains In progress only with a durable reference and next observation point.
-   Blocked always routes an exact action to Human/bedrin.
+   - Planning: resolve outcome, canonical item, linked issues, decisions, non-goals, risk axes, Implementer when a future
+     Implementation turn is actually needed, Verifier, and proof obligations. Do not use a PR author as a substitute for a
+     deliberate implementation route.
+   - Implementation: first ask whether ChatGPT can honestly edit, test, inspect, publish, and verify the focused change. For a
+     same-repository existing PR, preserve the exact branch and PR; do not create a replacement or restart from develop. Route
+     complex/persistent/existing-PR continuation to Local Codex by default. Route bounded fresh work to Codex Cloud. Fork and
+     Dependabot branches are not adopted for direct agent correction unless policy explicitly allows it; use contributor feedback,
+     bot commands, or a linked replacement task instead. Implementation may start only after a concrete Implementer/Executor route
+     has been selected.
+   - Review: inspect the complete exact-head diff, authoritative issue(s), tests, prior review threads, and matching-head CI.
+     Submit APPROVE only with independent identity. Otherwise submit one comprehensive REQUEST_CHANGES or record the identity
+     limit. A same-repository PR may be returned to a deliberately selected ChatGPT or Local Codex continuation on the same branch.
+     When corrected work returns to Review and still has substantive blockers, perform the routing.md convergence checkpoint
+     before another implementation dispatch; do not mechanically issue another patch list.
+   - Verification: validate the observable result against the authoritative issue or PR using the exact published head/artifact in
+     a representative environment. Do not rename unit tests or green CI as system verification.
+8. Publish human-useful evidence on the canonical target issue/PR. Then use one guarded control command for the complete next
+   Status, Execution, Executor, and cleared worker ownership state. Update GitHub Assignee separately when supported and verify it.
+   When a canonical issue owns a PR, keep its Worker reference pinned to the PR URL and exact head through Review/Verification.
+9. Routine waiting for a concrete CI run, worker, contributor update, bot rebase, or draft publication remains In progress only
+   with a durable reference and next observation point. Blocked always routes an exact action to Human/bedrin.
 10. Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged
     repository/hosting operations without Dmitry's explicit instruction.
 11. If no eligible intake, due continuation, control-log rotation, claimable turn, or meaningful reconciliation exists, make no
-    GitHub/source mutation and reply only NO_CHANGE. Otherwise finish with a compact summary containing selected item, lifecycle
-    turn, durable evidence, and resulting Status / Execution / Executor / Assignee.
+    GitHub/source mutation and reply only NO_CHANGE. Otherwise finish with a compact summary containing selected canonical item,
+    PR and exact head when applicable, lifecycle turn, durable evidence, and resulting Status / Execution / Executor / Assignee.
 ```
 
 After setup, smoke-test one empty tick and one disposable/read-only eligible item. Replacing a long defining task chat is manual

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -21,30 +21,37 @@ Model/profile: Sol / extra-high reasoning
 This conversation coordinates only. Never edit source, create a work branch, run implementation/verification commands, review
 the worker's PR, merge, or enable auto-merge.
 
-1. Read AGENTS.md, docs/ai-delivery/{README,profile,lifecycle,control-plane,event-loop,routing,supervision,verification}.md,
+1. Read AGENTS.md, docs/ai-delivery/{README,profile,lifecycle,control-plane,event-loop,pull-request-intake,routing,supervision,verification}.md,
    this prompt, and the worker template.
 2. Before new work, inspect Local-Codex-owned Execution=In progress items whose worker or monitoring observation is due. The
    normal event loop performs the 15-minute, second-15-minute, and hourly observations; do not create another monitor.
-3. Otherwise choose at most one item where:
+3. Otherwise choose at most one canonical Project item where:
    - Execution = Ready;
    - Executor = Local Codex;
    - Status = Implementation or Verification;
-   - Assignee is empty or already matches the dedicated local-worker identity.
-4. Re-read the issue, routing, proof matrix, Project fields, branch/PR, existing worker reference, review state, and CI. Prefer a
-   valid re-queued continuation over fresh work. Never create a duplicate worker.
-5. If no eligible item or due continuation exists, create no task, worktree, branch, target comment, or Project mutation. Reply
+   - Assignee is empty or already matches the dedicated local-worker identity;
+   - the item is not a duplicate PR/issue representation or a linked issue suppressed by an open canonical multi-issue PR.
+4. Re-read the canonical issue or PR, all formally linked issues, routing, proof matrix, Project fields, exact branch/PR/head,
+   existing worker reference, review state, and CI. Prefer a valid re-queued continuation over fresh work. Never create a duplicate
+   worker, branch, or pull request.
+5. An existing same-repository PR may be an adopted continuation even when Dmitry, ChatGPT, an IDE agent, or another configured
+   worker created it. Adoption is valid only when the verified Project route explicitly sets Implementer/Executor=Local Codex for
+   that canonical item. Reuse the exact branch and PR. Do not adopt fork or Dependabot branches for direct correction.
+6. If no eligible item or due continuation exists, create no task, worktree, branch, target comment, or Project mutation. Reply
    only NO_CHANGE.
-6. Select deterministically by Project priority, ready timestamp, then issue number. The Local Codex profile remains Sol /
-   extra-high; executor routing has already decided that this work merits the strong local environment.
-7. Claim through the one active technical control issue using one guarded delivery-control/v1 command. Guard current Status,
-   Execution=Ready, Executor=Local Codex, and exact PR head when applicable; set Execution=In progress plus claim token/lease inside the provisional Worker reference. Inspect the reaction and re-read Project state before spawning.
-8. Render every placeholder in .codex/local/worker-task-prompt.md.
-9. Create exactly one NEW one-time standalone app-owned task named "Sniffy #<issue-number> <status>: <issue-title>" using the
-   current local project, a new isolated worktree, Sol, extra-high reasoning, and the rendered prompt. Never create it in this
-   dispatcher conversation.
-10. Do not use shell UI automation, Python observers, codex app-server, codex exec, or .codex/local/run-issue.sh for this
+7. Select deterministically by Project priority, ready timestamp, repository, item type, then item number. The Local Codex profile
+   remains Sol / extra-high; executor routing has already decided that this work merits the strong local environment.
+8. Claim through the one active technical control issue using one guarded delivery-control/v1 command. Guard current Status,
+   Execution=Ready, Executor=Local Codex, and exact PR head when the canonical item is a PR; set Execution=In progress plus claim
+   token/lease inside the provisional Worker reference. Inspect the reaction and re-read Project state before spawning.
+9. Render every placeholder in .codex/local/worker-task-prompt.md, including canonical work-item type/URL, authoritative linked
+   issue, exact existing PR branch/head, repository ownership, author, and fresh/continuation/adopted-continuation mode.
+10. Create exactly one NEW one-time standalone app-owned task named "Sniffy <work-item-type> #<number> <status>: <title>" using
+    the current local project, a new isolated worktree, Sol, extra-high reasoning, and the rendered prompt. Never create it in this
+    dispatcher conversation.
+11. Do not use shell UI automation, Python observers, codex app-server, codex exec, or .codex/local/run-issue.sh for this
     app-native adapter.
-11. After confirming the child task exists, publish one guarded control command updating the final worker reference, then verify
+12. After confirming the child task exists, publish one guarded control command updating the final worker reference, then verify
     it. If child creation fails, release to Ready through the same protocol. Set Blocked only when Dmitry must decide or act.
 
 Never dispatch the same lifecycle generation twice. Never merge or enable auto-merge.
@@ -55,11 +62,13 @@ Never dispatch the same lifecycle generation twice. Never merge or enable auto-m
 Before enabling the recurring dispatcher, prove with disposable/read-only items that:
 
 - an empty tick stays in this conversation and creates no worktree;
-- one eligible item creates exactly one standalone worker conversation and isolated WSL worktree;
-- the worker uses Sol / extra-high and receives intended Status/routing fields;
+- one eligible issue item creates exactly one standalone worker conversation and isolated WSL worktree;
+- one explicitly routed same-repository PR continuation reuses its exact branch and PR without creating a duplicate;
+- fork and Dependabot PRs are rejected for adopted direct correction;
+- the worker uses Sol / extra-high and receives intended canonical item, Status, routing, and exact-head fields;
 - concurrent guarded claims produce one success and one conflict without target-item claim comments;
 - failed child creation releases the claim;
-- a completed worker hands off to the next lifecycle status rather than creating its own reviewer conversation.
+- a completed worker hands off the canonical item to the next lifecycle status rather than creating its own reviewer conversation.
 
 Repeat after material Codex automation changes. If nested one-time task creation is unavailable, pause this adapter and use a
 manual app worker or the headless Linux adapter; do not substitute external UI automation.

--- a/.codex/local/worker-task-prompt.md
+++ b/.codex/local/worker-task-prompt.md
@@ -5,75 +5,98 @@ one lifecycle turn only. Shared policy lives in `AGENTS.md` and `docs/ai-deliver
 extra-high reasoning.
 
 ```text
-Work autonomously on one lifecycle status of Sniffy issue #<ISSUE_NUMBER> in this dedicated worker conversation and isolated
-worktree.
+Work autonomously on one lifecycle status of canonical Sniffy <WORK_ITEM_TYPE> #<WORK_ITEM_NUMBER> in this dedicated worker
+conversation and isolated worktree.
 
-Issue title: <ISSUE_TITLE>
-Issue URL: <ISSUE_URL>
+Work item title: <WORK_ITEM_TITLE>
+Work item URL: <WORK_ITEM_URL>
+Authoritative issue: <AUTHORITATIVE_ISSUE_URL_OR_NONE>
 Status: <STATUS>
 Execution: In progress
 Mode: <WORK_MODE>
 Base branch: develop
 Branch: <BRANCH_NAME>
 Existing pull request: <PR_URL_OR_NONE>
+Exact pull-request head: <PR_HEAD_SHA_OR_NONE>
+Pull-request repository ownership: <SAME_REPOSITORY_OR_FORK_OR_NONE>
+Pull-request author: <PR_AUTHOR_OR_NONE>
 Implementer: <IMPLEMENTER>
 Verifier: <VERIFIER>
 Claim token: <CLAIM_TOKEN>
 Dispatch generation: <DISPATCH_GENERATION>
 Local Codex profile: Sol / extra-high reasoning
 
-Before any mutation, read the complete issue/comments, Project fields, worker record, linked PR, review submissions and unresolved
-threads, current CI, remote develop, nearest AGENTS.md, and
-`docs/ai-delivery/{profile,lifecycle,control-plane,routing,supervision,verification}.md`. Verify this task still owns the exact
-claim token/generation and worker reference.
+Before any mutation, read the complete canonical work item/comments, every formally linked issue, linked PR, review submissions
+and unresolved threads, current CI, Project fields, worker record, remote develop, nearest AGENTS.md, and
+`docs/ai-delivery/{profile,lifecycle,control-plane,pull-request-intake,routing,supervision,verification}.md`. Verify this task still
+owns the exact claim token/generation and worker reference.
 
 Use the common rotating technical control issue for every ProjectV2 transition. Never post /project-status, /project-field,
 claim arbitration, lease, or polling comments on the target item. A handoff is complete only after the guarded
-`delivery-control/v1` command has a terminal reaction and the Project state has been re-read.
+`delivery-control/v1` command has a terminal reaction and the canonical Project state has been re-read.
 
 Stop autonomous work when a required product, API, architecture, compatibility, permission, credential, privileged operation,
 external service, or bespoke-infrastructure decision is missing. Keep current Status, set Execution=Blocked and Executor=Human
 through one guarded command, assign bedrin separately, and record the smallest target-item decision/action Dmitry must take.
 Routine waiting for CI or another observable operation remains In progress with a worker reference and next observation point.
 
+Canonical-item rules:
+- an issue is canonical when the PR formally closes exactly that one issue;
+- a standalone PR is canonical when it has no formal closing issue;
+- a PR with several formal closing issues is canonical only after Planning has routed the combined work;
+- mutate lifecycle fields only on <WORK_ITEM_URL>; linked issues/PRs are requirements and implementation evidence unless the
+  dispatcher explicitly says otherwise;
+- never create a shadow issue or second PR merely because this worker did not author the existing branch.
+
 Branch rules:
-- fresh Implementation: verify no branch/PR/worker already owns the issue and create <BRANCH_NAME> from current origin/develop;
-- continuation Implementation: reuse the exact open PR branch and verify local HEAD, remote branch, and PR head agree;
+- fresh Implementation: verify no branch/PR/worker already owns the canonical item and create <BRANCH_NAME> from current
+  origin/develop;
+- continuation or adopted-continuation Implementation: reuse the exact same-repository open PR branch even when it was originally
+  created by Dmitry, ChatGPT, an IDE agent, or another configured worker; verify local HEAD, remote branch, and PR head agree;
+- adopted continuation requires the explicit verified Project route to Local Codex; branch authorship alone is not permission;
+- never adopt a fork or Dependabot branch for direct correction. Return a precise blocker/route for contributor feedback, bot
+  commands, or a linked replacement task;
 - Verification: use the exact published implementation head/artifact named by Review;
 - never reset, rebase, force-push, replace an existing PR, discard unrelated work, or merge.
 
 If <STATUS> is Implementation:
-1. Convert every acceptance criterion into implementer-owned proof and implement the smallest coherent solution.
-2. Run focused tests first, broader applicable checks separately, and available runtime/browser checks. Confirm named tests ran;
+1. Convert every acceptance criterion from the canonical item and linked issues into implementer-owned proof and implement the
+   smallest coherent solution.
+2. For continuation, first inspect the entire existing PR and all Review findings; preserve useful commits and user changes. Do
+   not create a fresh branch or duplicate PR.
+3. Run focused tests first, broader applicable checks separately, and available runtime/browser checks. Confirm named tests ran;
    record unsupported proof honestly.
-3. Inspect complete final diff, generated/unrelated files, dependencies, documentation, and proof. Run git diff --check.
-4. Commit and push with the dedicated worker identity. Create/update the intended PR and keep it draft only while implementation
-   or locally available proof is incomplete.
-5. Verify remote branch, full SHA, PR URL, base/head refs, draft state, and matching PR head.
-6. Publish exact human-useful commands/results/limitations on the target issue/PR.
-7. Hand off with one guarded command setting Status=Review, Execution=Ready, Executor=ChatGPT, clearing worker ownership, then assign
-   bedrin-gpt separately and verify both state and assignment.
-8. Do not review or approve your own implementation and do not create a reviewer task. The shared event loop owns Review.
+4. Inspect complete final diff, generated/unrelated files, dependencies, documentation, and proof. Run git diff --check.
+5. Commit and push with the dedicated worker identity. Create the intended PR only for fresh work; continuation must update the
+   existing PR. Keep it draft only while implementation or locally available proof is incomplete.
+6. Verify remote branch, full SHA, PR URL, base/head refs, draft state, and matching PR head. Mark the PR ready for review when
+   implementation and locally available proof are complete.
+7. Publish exact human-useful commands/results/limitations on the canonical issue/PR and keep the PR description synchronized.
+8. Hand off the canonical item with one guarded command setting Status=Review, Execution=Ready, Executor=ChatGPT, clearing worker
+   ownership, and recording the PR URL plus exact new head in Worker reference; assign bedrin-gpt separately and verify both state
+   and assignment.
+9. Do not review or approve your own implementation and do not create a reviewer task. The shared event loop owns Review.
 
 If <STATUS> is Verification:
-1. Re-read the authoritative issue and later discussion. Identify observable journey, negative cases, exact implementation
-   head/artifact, and representative environment.
+1. Re-read the canonical item and later discussion. Identify observable journey, negative cases, exact implementation head/artifact,
+   and representative environment.
 2. Perform outcome-centric system/integration/browser/compatibility proof. Do not merely repeat unit tests or trust implementer
    summary. Record runtime actions, logs, browser errors/requests, screenshots, cleanup, and artifact identity as applicable.
-3. Classify the result and use one guarded handoff command:
+3. Classify the result and use one guarded handoff command on the canonical item:
    - pass -> Status=Approval, Execution=Ready, Executor=Human; assign bedrin separately;
-   - implementation defect -> Status=Implementation, Execution=Ready, Executor=<IMPLEMENTER>;
+   - implementation defect -> Status=Implementation, Execution=Ready, Executor=<IMPLEMENTER>, but only when Implementer is a
+     deliberately selected supported executor;
    - verification harness/evidence defect -> Status=Verification, Execution=Ready, Executor=<VERIFIER>;
-   - requirement/architecture defect -> Status=Planning, Execution=Ready, Executor=ChatGPT; assign bedrin-gpt separately;
-   - Dmitry decision/action required -> keep Status=Verification, Execution=Blocked, Executor=Human; assign bedrin and record
-     the exact request on the target issue.
+   - requirement/architecture/canonicalization defect -> Status=Planning, Execution=Ready, Executor=ChatGPT; assign bedrin-gpt;
+   - Dmitry decision/action required -> keep Status=Verification, Execution=Blocked, Executor=Human; assign bedrin and record the
+     exact request on the target item.
 4. Publish exact environment, source/artifact identity, commands/actions, results, and failure classification before handoff.
-5. Do not modify production code as an unrecorded shortcut. A required correction returns to Implementation.
+5. Do not modify production code as an unrecorded shortcut. A required correction returns to a deliberately routed Implementation.
 
 For either lifecycle status:
 - leave no In progress item with a finished or missing worker;
-- never close the issue, merge, enable auto-merge, bypass protection, or perform privileged operations without Dmitry's explicit
-  instruction;
+- never close the canonical item, merge, enable auto-merge, bypass protection, or perform privileged operations without Dmitry's
+  explicit instruction;
 - finish by reporting final lifecycle handoff and exact remote/evidence state in this worker conversation.
 ```
 
@@ -81,16 +104,22 @@ For either lifecycle status:
 
 | Placeholder | Meaning |
 | --- | --- |
-| `<ISSUE_NUMBER>` | Numeric Sniffy issue number |
-| `<ISSUE_TITLE>` | Current issue title |
-| `<ISSUE_URL>` | Resolvable issue URL |
+| `<WORK_ITEM_TYPE>` | `Issue` or `PullRequest` for the canonical Project item |
+| `<WORK_ITEM_NUMBER>` | Numeric canonical item number |
+| `<WORK_ITEM_TITLE>` | Current canonical item title |
+| `<WORK_ITEM_URL>` | Canonical issue or PR URL and delivery-control target |
+| `<AUTHORITATIVE_ISSUE_URL_OR_NONE>` | Requirement issue URL when one exists, otherwise `none` |
 | `<STATUS>` | `Implementation` or `Verification` |
-| `<WORK_MODE>` | `fresh` or `continuation` for Implementation; `published-head` for Verification |
-| `<BRANCH_NAME>` | Fresh branch or exact existing PR head |
+| `<WORK_MODE>` | `fresh`, `continuation`, or `adopted-continuation`; `published-head` for Verification |
+| `<BRANCH_NAME>` | Fresh branch or exact existing PR head branch |
 | `<PR_URL_OR_NONE>` | Existing/published PR or `none` for fresh Implementation |
-| `<IMPLEMENTER>` | Planned Implementer field value |
+| `<PR_HEAD_SHA_OR_NONE>` | Exact existing/published PR head or `none` |
+| `<SAME_REPOSITORY_OR_FORK_OR_NONE>` | `same-repository`, `fork`, or `none` |
+| `<PR_AUTHOR_OR_NONE>` | Current PR author login or `none` |
+| `<IMPLEMENTER>` | Deliberately selected Implementer field value for Implementation |
 | `<VERIFIER>` | Planned Verifier field value |
 | `<CLAIM_TOKEN>` | Verified guarded claim token |
 | `<DISPATCH_GENERATION>` | Current lifecycle dispatch generation |
 
-Do not launch a worker with unresolved placeholders or an unverified claim.
+Do not launch a worker with unresolved placeholders or an unverified claim. An existing PR created outside the delivery system is
+not a duplicate when the canonical Project route explicitly selects continuation of that exact PR.

--- a/.github/scripts/.universal-pr-intake-marker
+++ b/.github/scripts/.universal-pr-intake-marker
@@ -1,0 +1,1 @@
+universal-pr-intake/v1

--- a/.github/scripts/.universal-pr-intake-marker
+++ b/.github/scripts/.universal-pr-intake-marker
@@ -1,1 +1,0 @@
-universal-pr-intake/v1

--- a/.github/scripts/delivery-policy.test.js
+++ b/.github/scripts/delivery-policy.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.join(__dirname, '../..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+test('ChatGPT dispatcher scans and canonicalizes every develop pull request', () => {
+  const prompt = read('.chatgpt/scheduled-task-prompt.md');
+  assert.match(prompt, /Scan every open pull request in sniffy\/sniffy targeting develop/i);
+  assert.match(prompt, /Exactly one formal closing issue: that issue is the canonical lifecycle item/i);
+  assert.match(prompt, /No formal closing issue: the non-draft PR itself is the canonical lifecycle item/i);
+  assert.match(prompt, /Multiple formal closing issues: the non-draft PR is the canonical coordination item/i);
+  assert.match(prompt, /Draft PR: do not start Review/i);
+  assert.match(prompt, /regardless of author, label, bot\/provider, branch creator/i);
+  assert.doesNotMatch(prompt, /Find eligible open sniffy\/sniffy dependency PRs missing/i);
+});
+
+test('profile makes universal intake and existing-PR routing explicit', () => {
+  const profile = read('docs/ai-delivery/profile.yml');
+  assert.match(profile, /pullRequests:\s*\n\s+enabled:\s*true/);
+  assert.match(profile, /baseBranch:\s*develop/);
+  assert.match(profile, /includeDraftsInReview:\s*false/);
+  assert.match(profile, /setImplementerFromAuthor:\s*false/);
+  assert.match(profile, /exactlyOneClosingIssue:\s*issue/);
+  assert.match(profile, /noClosingIssue:\s*pullRequest/);
+  assert.match(profile, /multipleClosingIssues:\s*pullRequestPlanning/);
+  assert.match(profile, /existingPullRequestContinuationExecutor:\s*Local Codex/);
+});
+
+test('Local Codex can adopt an explicitly routed same-repository PR without duplication', () => {
+  const worker = read('.codex/local/worker-task-prompt.md');
+  const dispatcher = read('.codex/local/scheduled-task-prompt.md');
+  assert.match(worker, /<WORK_ITEM_TYPE>/);
+  assert.match(worker, /adopted-continuation/);
+  assert.match(worker, /reuse the exact same-repository open PR branch/i);
+  assert.match(worker, /never adopt a fork or Dependabot branch/i);
+  assert.match(worker, /do not create a fresh branch or duplicate PR/i);
+  assert.match(dispatcher, /existing same-repository PR may be an adopted continuation/i);
+  assert.match(dispatcher, /Reuse the exact branch and PR/i);
+  assert.match(dispatcher, /Do not adopt fork or Dependabot branches/i);
+});
+
+test('canonical intake policy treats issues and PRs as distinct linked artifacts', () => {
+  const intake = read('docs/ai-delivery/pull-request-intake.md');
+  const lifecycle = read('docs/ai-delivery/lifecycle.md');
+  assert.match(intake, /Every open PR targeting `develop` is therefore a discovery source/);
+  assert.match(intake, /exactly one Project item is canonical for lifecycle routing/i);
+  assert.match(intake, /one formal closing issue -> that issue is canonical/i);
+  assert.match(intake, /no closing issue -> the PR itself is canonical/i);
+  assert.match(intake, /several closing issues -> the PR is canonical in Planning/i);
+  assert.match(lifecycle, /The canonical item owns Status, Execution, Executor, Assignee, and Worker reference/);
+});
+
+test('Cloud does not turn arbitrary existing PRs into duplicate fresh work', () => {
+  const cloud = read('docs/ai-delivery/executors/codex-cloud.md');
+  assert.match(cloud, /Do not route an arbitrary existing PR/i);
+  assert.match(cloud, /Cloud must not open a duplicate branch\/PR/i);
+  assert.match(cloud, /existing-PR continuation normally goes to Local Codex/i);
+});

--- a/.github/scripts/delivery-policy.test.js
+++ b/.github/scripts/delivery-policy.test.js
@@ -52,9 +52,10 @@ test('canonical intake policy treats issues and PRs as distinct linked artifacts
   const lifecycle = read('docs/ai-delivery/lifecycle.md');
   assert.match(intake, /Every open PR targeting `develop` is therefore a discovery source/);
   assert.match(intake, /exactly one Project item is canonical for lifecycle routing/i);
-  assert.match(intake, /one formal closing issue -> that issue is canonical/i);
-  assert.match(intake, /no closing issue -> the PR itself is canonical/i);
-  assert.match(intake, /several closing issues -> the PR is canonical in Planning/i);
+  assert.match(intake, /## Canonical work-item selection/);
+  assert.match(intake, /### Exactly one formal closing issue[\s\S]*The issue is the canonical lifecycle item/i);
+  assert.match(intake, /### No formal closing issue[\s\S]*The PR itself is the canonical lifecycle item/i);
+  assert.match(intake, /### Multiple formal closing issues[\s\S]*The PR is the canonical coordination item/i);
   assert.match(lifecycle, /The canonical item owns Status, Execution, Executor, Assignee, and Worker reference/);
 });
 

--- a/.github/scripts/delivery-policy.test.js
+++ b/.github/scripts/delivery-policy.test.js
@@ -41,7 +41,7 @@ test('Local Codex can adopt an explicitly routed same-repository PR without dupl
   assert.match(worker, /adopted-continuation/);
   assert.match(worker, /reuse the exact same-repository open PR branch/i);
   assert.match(worker, /never adopt a fork or Dependabot branch/i);
-  assert.match(worker, /do not create a fresh branch or duplicate PR/i);
+  assert.match(worker, /Do\s+not create a fresh branch or duplicate PR/i);
   assert.match(dispatcher, /existing same-repository PR may be an adopted continuation/i);
   assert.match(dispatcher, /Reuse the exact branch and PR/i);
   assert.match(dispatcher, /Do not adopt fork or Dependabot branches/i);
@@ -50,7 +50,7 @@ test('Local Codex can adopt an explicitly routed same-repository PR without dupl
 test('canonical intake policy treats issues and PRs as distinct linked artifacts', () => {
   const intake = read('docs/ai-delivery/pull-request-intake.md');
   const lifecycle = read('docs/ai-delivery/lifecycle.md');
-  assert.match(intake, /Every open PR targeting `develop` is therefore a discovery source/);
+  assert.match(intake, /Every open PR targeting\s+`develop` is therefore a discovery source/);
   assert.match(intake, /exactly one Project item is canonical for lifecycle routing/i);
   assert.match(intake, /## Canonical work-item selection/);
   assert.match(intake, /### Exactly one formal closing issue[\s\S]*The issue is the canonical lifecycle item/i);

--- a/.github/workflows/delivery-control.yml
+++ b/.github/workflows/delivery-control.yml
@@ -3,10 +3,14 @@ name: AI delivery control
 on:
   pull_request:
     paths:
+      - .chatgpt/scheduled-task-prompt.md
+      - .codex/local/scheduled-task-prompt.md
+      - .codex/local/worker-task-prompt.md
       - .github/scripts/delivery-control.js
       - .github/scripts/delivery-control.test.js
+      - .github/scripts/delivery-policy.test.js
       - .github/workflows/delivery-control.yml
-      - docs/ai-delivery/profile.yml
+      - docs/ai-delivery/**
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -35,7 +39,8 @@ jobs:
         run: |
           node --check .github/scripts/delivery-control.js
           node --check .github/scripts/delivery-control.test.js
-          node --test .github/scripts/delivery-control.test.js
+          node --check .github/scripts/delivery-policy.test.js
+          node --test .github/scripts/delivery-control.test.js .github/scripts/delivery-policy.test.js
       - name: Parse workflow and profile YAML
         run: >-
           ruby -e 'require "yaml";

--- a/docs/ai-delivery/README.md
+++ b/docs/ai-delivery/README.md
@@ -1,36 +1,52 @@
 # AI-assisted delivery in Sniffy
 
-This directory describes how Dmitry and ChatGPT plan, route, supervise, review, and verify work performed by ChatGPT, Codex
-Cloud, Local Codex, an IDE-hosted coding agent, automation such as Dependabot, an external contributor, or a human. It is the
+This directory describes how Dmitry and ChatGPT plan, canonicalize, route, supervise, review, and verify work performed by ChatGPT,
+Codex Cloud, Local Codex, an IDE-hosted coding agent, automation such as Dependabot, an external contributor, or a human. It is the
 control-plane documentation for delivery. Repository engineering rules remain in the nearest applicable `AGENTS.md`.
 
 The current Sniffy routing knobs live in [`profile.yml`](profile.yml). Shared semantics belong in Markdown; the profile selects
-current executors, identities, Local Codex model/effort, control-log rotation thresholds, default routes, and external-PR intake
+current executors, identities, Local Codex model/effort, control-log rotation thresholds, default routes, and universal PR intake
 behavior without redefining the lifecycle.
 
 ## Terminology
 
 | Term | Meaning | Sniffy example |
 | --- | --- | --- |
-| Work item | An issue or pull request represented in the delivery Project | feature issue, Dependabot PR |
+| Work item | An issue or pull request represented in the delivery Project | feature issue, standalone PR |
+| Canonical item | The one Project item that owns lifecycle state for one published change | linked issue or standalone PR |
+| Implementation evidence | Exact PR branch/head, diff, CI, and review conversation linked to the canonical item | PR #763 at `6d45aff...` |
 | Role | A responsibility in the delivery process | supervisor, implementer, reviewer, verifier, operator |
 | Executor | The product and environment performing a current action | ChatGPT, Codex Cloud, Local Codex, human |
-| Implementer | Optional planned executor for a future Implementation turn | Local Codex; empty for an already-published external PR |
+| Implementer | Optional planned executor for a future Implementation turn | Local Codex; empty for an already-published PR |
 | Verifier | Planned executor coordinating Verification | ChatGPT |
 | Assignee | Concrete GitHub identity or human responsible now | `bedrin-gpt`, `bedrin-codex-local`, `bedrin` |
 | Agent instance | One concrete running chat, task, process, or worker | one Codex task and worktree |
 | Repository instructions | Engineering policy applied by path | root or nested `AGENTS.md` |
 | Runbook | Environment- or procedure-specific operating instructions | Codex Cloud setup, local worker |
-| Task prompt | One launch or continuation request | a rendered worker prompt for an issue |
+| Task prompt | One launch or continuation request | a rendered worker prompt for an issue or PR |
 | Control command | Guarded provider-neutral ProjectV2 transition | one `delivery-control/v1` JSON comment |
 
-Roles and executors are independent. ChatGPT is the default supervisor, but it may also implement, review, or verify a task.
-Codex Cloud and Local Codex may perform the same implementer role in different environments. Model selection is a separate
-configuration axis: Cloud is provider-managed, while the current Local Codex profile uses Sol with extra-high reasoning.
+Roles, executors, identities, and PR provenance are independent. ChatGPT is the default supervisor, but it may also implement,
+review, or verify a task. Codex Cloud and Local Codex may perform the same implementer role in different environments. Model
+selection is a separate configuration axis: Cloud is provider-managed, while the current Local Codex profile uses Sol with
+extra-high reasoning.
 
-PR authorship is separate provenance. An external author, Dependabot, or a future bot is not automatically a Sniffy routing
-executor, so external intake leaves `Implementer` empty unless a later Planning decision deliberately selects an implementation
-route.
+PR authorship is provenance, not a routing decision. A PR created by Dmitry, ChatGPT, an IDE agent, Dependabot, an external
+contributor, or a future bot is eligible for intake. Its author controls formal-review independence and branch-correction policy,
+but intake does not copy that identity into `Implementer`.
+
+## Issue and PR relationship
+
+Issues and pull requests are both first-class Project items, but one item owns lifecycle state for one published change:
+
+```text
+one formal closing issue -> issue is canonical; PR is implementation evidence
+no formal closing issue  -> PR is canonical
+several closing issues   -> PR is canonical in Planning
+```
+
+This lets Dmitry push a ready PR from IntelliJ without first creating an issue, while preserving an existing issue as the durable
+requirements item when one already exists. The event loop must not review both an issue and its PR as duplicate work.
 
 ## Lifecycle summary
 
@@ -41,39 +57,39 @@ Status:    Draft -> Planning -> Implementation -> Review -> Verification (when r
 Execution: Ready | In progress | Blocked
 ```
 
-Planning records `Implementer` when a future Implementation turn is needed and records `Verifier` when Verification may be
-needed. `Executor` materializes who performs the next current action, while `Assignee` names the concrete identity or human. An
-external pull request may enter directly at `Review / Ready` with an empty Implementer when its implementation already exists and
-its scope is clear.
+Planning records `Implementer` when a future Implementation turn is needed and records `Verifier` when Verification may be needed.
+`Executor` materializes who performs the next current action, while `Assignee` names the concrete identity or human. A non-draft
+PR may enter directly at `Review / Ready` with an empty Implementer when its implementation already exists and its scope is clear.
+A multi-issue PR enters Planning first.
 
-A worker owns one lifecycle turn. A corrected implementation that returns to Review with substantive blockers does not
-immediately receive another narrow patch request: ChatGPT first performs the convergence checkpoint in [`routing.md`](routing.md)
-and [`supervision.md`](supervision.md).
+A worker owns one lifecycle turn. A corrected implementation that returns to Review with substantive blockers does not immediately
+receive another narrow patch request: ChatGPT first performs the convergence checkpoint in [`routing.md`](routing.md) and
+[`supervision.md`](supervision.md).
 
 ## Control plane and execution plane
 
 ```text
-Dmitry + ChatGPT decide outcome, risk, routing, and proof
-                  |
-                  v
-   guarded control command + exact worker dispatch
-                  |
-                  v
- ChatGPT | Codex Cloud | Local Codex | automation | human
-                  |
-                  v
-      exact-head evidence and independent verification
-                  |
-                  v
-       Dmitry authorizes privileged actions or merge
+Dmitry + ChatGPT decide canonical item, outcome, risk, routing, and proof
+                              |
+                              v
+             guarded control command + exact worker dispatch
+                              |
+                              v
+        ChatGPT | Codex Cloud | Local Codex | automation | human
+                              |
+                              v
+          exact PR-head evidence and independent verification
+                              |
+                              v
+               Dmitry authorizes privileged actions or merge
 ```
 
-All configured executors use the same central control-issue protocol for ProjectV2 transitions. The target issue/PR conversation
-is reserved for human-useful plans, reviews, evidence, blockers, and handoffs. Omitted Project fields remain unchanged, and an
-empty optional field is valid state rather than a reason to invent a new select option. See [`control-plane.md`](control-plane.md).
+All configured executors use the same central control-issue protocol for ProjectV2 transitions. The canonical issue/PR conversation
+is reserved for human-useful plans, reviews, evidence, blockers, and handoffs. Omitted Project fields remain unchanged, and an empty
+optional field is valid state rather than a reason to invent a new select option. See [`control-plane.md`](control-plane.md).
 
-Dmitry owns product decisions, accepted risk, privileged repository/hosting operations, final acceptance, and merge
-authorization. ChatGPT owns issue refinement, external-PR intake, routing proposals, supervision, code review, verification
+Dmitry owns product decisions, accepted risk, privileged repository/hosting operations, final acceptance, and merge authorization.
+ChatGPT owns issue refinement, universal PR intake/canonicalization, routing proposals, supervision, code review, verification
 coordination, control-log rotation, and clear handoff. An executor owns only the lifecycle turn and proof explicitly routed to it.
 
 ## Sources of truth
@@ -81,12 +97,13 @@ coordination, control-log rotation, and clear handoff. An executor owns only the
 Use this precedence when instructions differ:
 
 1. Dmitry's explicit current decision, especially for product, risk, privileged operations, and merge.
-2. The authoritative GitHub issue or pull request, including later comments that explicitly supersede older guidance.
-3. The nearest applicable `AGENTS.md` for files being changed.
-4. Root `AGENTS.md`.
-5. This directory and [`profile.yml`](profile.yml).
-6. The selected executor runbook or skill.
-7. The concrete task prompt.
+2. The authoritative canonical GitHub issue or pull request, including later comments that explicitly supersede older guidance.
+3. The linked implementation PR exact branch/head, reviews, CI, and artifacts.
+4. The nearest applicable `AGENTS.md` for files being changed.
+5. Root `AGENTS.md`.
+6. This directory and [`profile.yml`](profile.yml).
+7. The selected executor runbook or skill.
+8. The concrete task prompt.
 
 Historical tick chats, Codex conversations, and Actions logs are telemetry and evidence, not the only copy of durable delivery
 state.
@@ -94,20 +111,20 @@ state.
 ## Documentation map
 
 - [`profile.yml`](profile.yml) — current Sniffy Project, field, identity, routing, Local Codex, intake, and rotation configuration.
-- [`lifecycle.md`](lifecycle.md) — lifecycle statuses, execution states, optional planned routing fields, and corrections.
+- [`lifecycle.md`](lifecycle.md) — statuses, execution states, canonical issue/PR rules, optional planned routing, and corrections.
 - [`control-plane.md`](control-plane.md) — one guarded mutation protocol, optional/omitted fields, control issue, concurrency,
   reactions, and rotation.
-- [`event-loop.md`](event-loop.md) — reusable clock/dispatcher/intake/claim design and provider adapters.
+- [`event-loop.md`](event-loop.md) — reusable clock, universal PR intake/canonicalization, dispatcher, claims, and provider adapters.
 - [`.chatgpt/scheduled-task-prompt.md`](../../.chatgpt/scheduled-task-prompt.md) — exact prompt for four ChatGPT Scheduled Tasks.
-- [`pull-request-intake.md`](pull-request-intake.md) — external PRs, provenance, optional Implementer, Dependabot review, rebase,
-  verification, and replacement flow.
+- [`pull-request-intake.md`](pull-request-intake.md) — arbitrary PR discovery, canonical issue/PR selection, drafts, forks,
+  Dependabot, review, correction, and completion.
 - [`chat-retention.md`](chat-retention.md) — persistent Scheduled Task chats, compact outputs, and bounded manual rotation.
-- [`routing.md`](routing.md) — role/executor/model separation, routing heuristics, and convergence checkpoint.
-- [`supervision.md`](supervision.md) — dispatch proof, worker monitoring, review convergence, and merge boundaries.
+- [`routing.md`](routing.md) — role/executor/model/provenance separation, fresh versus existing-PR routing, and convergence.
+- [`supervision.md`](supervision.md) — canonical handoff, dispatch proof, worker/PR monitoring, review convergence, and merge boundaries.
 - [`verification.md`](verification.md) — implementer, reviewer, verifier, CI, browser/system proof, and capability routing.
 - [`executors/chatgpt.md`](executors/chatgpt.md) — ChatGPT direct execution, scheduling, and limitations.
-- [`executors/codex-cloud.md`](executors/codex-cloud.md) — Cloud routing, setup, credentials, publication, and troubleshooting.
-- [`executors/codex-local.md`](executors/codex-local.md) — app-native and headless Local Codex worker topologies.
+- [`executors/codex-cloud.md`](executors/codex-cloud.md) — Cloud fresh-work routing, setup, credentials, publication, and troubleshooting.
+- [`executors/codex-local.md`](executors/codex-local.md) — app-native/headless workers and adopted existing-PR continuation.
 - [`executors/ide-agent.md`](executors/ide-agent.md) — generic VS Code/IntelliJ agent-host guidance.
 - [`../chatgpt-site-preview.md`](../chatgpt-site-preview.md) — exact-head website artifact and Chromium verification.
 - [`../retrospectives/`](../retrospectives/README.md) — historical incidents and durable lessons incorporated here.
@@ -115,24 +132,27 @@ state.
 ## Current adapters
 
 The ChatGPT clock uses four hourly Scheduled Tasks offset by 15 minutes. Product testing on 2026-07-30 showed that recurrences
-append to each task's defining chat rather than reliably creating a new chat. Every occurrence must therefore behave statelessly
-by instruction and re-read GitHub/repository state, while the four defining chats are retained and periodically replaced as a
+append to each task's defining chat rather than reliably creating a new chat. Every occurrence must therefore behave statelessly by
+instruction and re-read GitHub/repository state, while the four defining chats are retained and periodically replaced as a
 maintenance action. No Scheduled Task may rely on previous chat turns as state.
 
-A no-op tick creates no GitHub mutation. A productive tick performs at most one lifecycle turn directly or makes one supported
-external dispatch. Scheduled ChatGPT ticks cannot create child Scheduled Tasks.
+A no-op tick creates no GitHub mutation. A productive tick performs at most one canonicalization/reconciliation or lifecycle turn
+directly, or makes one supported external dispatch. Scheduled ChatGPT ticks cannot create child Scheduled Tasks.
 
-Dependabot PRs are first-class Project items rather than shadow issues. GitHub's built-in auto-add workflow discovers newly
-created or updated dependency PRs; the event loop backfills existing untracked PRs, initializes Review fields through the central
-control protocol, verifies the author, leaves Implementer empty, and routes any required compatibility implementation to a linked
-agent-owned issue/PR with a deliberately selected Implementer. Project 2 currently retains a `Dependabot` Implementer option for
-manual/historical classification, but normal intake does not select it.
+Every open PR targeting `develop` is scanned. A single linked issue remains canonical; a standalone PR becomes the Project item;
+a multi-issue PR enters Planning. Same-repository corrections can be adopted by ChatGPT or Local Codex on the exact existing
+branch/PR. Forks and managed-bot branches use contributor/bot operations or a linked replacement task.
+
+GitHub Project auto-add remains useful for issues created by agents and dependency PR discovery, but it does not replace
+canonicalization. Project 2 currently retains a `Dependabot` Implementer option for manual/historical classification; normal
+intake does not select it.
 
 ## Provider-specific files
 
 - `.chatgpt/` contains copy-paste Scheduled Task prompts, not durable delivery state.
 - `.codex/` contains Codex environment scripts and launch prompts, not general repository policy.
 - `.github/workflows/delivery-control.yml` and `.github/scripts/delivery-control.js` implement the provider-neutral mutation bridge.
+- `.github/scripts/delivery-policy.test.js` protects the canonical universal-intake and adopted-continuation prompt contract.
 - `.github/copilot-instructions.md` is a small Copilot adapter pointing to `AGENTS.md` and this directory.
 - `.agents/skills/` contains optional reusable procedures that an executor invokes only when applicable.
 - IDE-specific rule directories should not duplicate `AGENTS.md`; add them only for a proven client-specific gap.

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -8,14 +8,16 @@ Sniffy is the first profile, not the framework itself. Current Sniffy configurat
 ```text
 Clock
   -> Dispatcher tick
-      -> Intake adapters
+      -> Intake and canonicalization adapters
           -> Guarded claim/transition protocol
               -> Lifecycle worker
 ```
 
 - **Clock** starts one dispatcher tick. It knows only cadence and slot identity.
-- **Dispatcher tick** loads one or more project profiles, queries eligible work, and selects a deterministic candidate.
-- **Intake adapters** materialize external work such as Dependabot pull requests into the same lifecycle.
+- **Dispatcher tick** loads one or more project profiles, reconciles source systems, queries eligible work, and selects a
+  deterministic candidate.
+- **Intake adapters** materialize arbitrary pull requests and other external work into the same lifecycle.
+- **Canonicalization** chooses one active Project item when an issue and PR describe the same delivery.
 - **Control protocol** serializes guarded ProjectV2 claims and transitions through one technical control issue.
 - **Lifecycle worker** performs one lifecycle turn, publishes evidence, and hands the task to the next status as `Ready`.
 
@@ -29,8 +31,8 @@ compact execution transcript to its own scheduler conversation.
 ## Desired cadence
 
 The logical queue should be checked every 15 minutes. Worker follow-up is part of the same event-loop responsibility; it is not a
-second independent scheduler. When an existing worker is due for observation, a tick continues or recovers that ownership before
-claiming unrelated work.
+second independent scheduler. When an existing worker or observable PR operation is due for observation, a tick continues or
+recovers that ownership before claiming unrelated work.
 
 ### ChatGPT Scheduled Tasks adapter
 
@@ -59,21 +61,21 @@ Treat each occurrence as logically stateless even though the transcript is persi
 
 1. ignore prior-run conclusions and mutable conversational context;
 2. read current GitHub state, repository policy, and [`profile.yml`](profile.yml) from scratch;
-3. reconcile eligible external PR intake without inferring a Project Implementer from PR authorship;
-4. continue one due owned worker or select at most one eligible lifecycle turn;
+3. reconcile every open PR targeting the configured base branch and choose one canonical issue/PR item;
+4. continue one due owned worker/PR operation or select at most one eligible lifecycle turn;
 5. submit one guarded control command to claim it;
 6. verify the successful reaction and resulting Project state before doing work;
 7. perform the lifecycle turn directly or make one supported external dispatch;
-8. publish human-useful evidence on the target item;
+8. publish human-useful evidence on the canonical target item;
 9. submit one guarded control command for the lifecycle handoff and verify the result;
-10. return `NO_CHANGE` when no intake, continuation, rotation, or eligible work exists.
+10. return `NO_CHANGE` when no intake, continuation, rotation, reconciliation, or eligible work exists.
 
 A tick must never claim work it cannot reasonably complete or hand off durably during that occurrence. Route long
-implementation, dependency-heavy builds, persistent services, and environment-specific verification to Codex Cloud, Local
-Codex, CI, or a human.
+implementation, dependency-heavy builds, persistent services, existing-PR continuation, and environment-specific verification to
+Codex Cloud, Local Codex, CI, or a human as documented in [`routing.md`](routing.md).
 
 Scheduled Task executions cannot create child Scheduled Tasks. They may dispatch a supported external worker, but `In progress`
-is valid only after a concrete worker/task/branch/process reference exists.
+is valid only after a concrete worker/task/branch/process/reference exists.
 
 The four chats are operational telemetry, not durable state. Keep output compact and follow [`chat-retention.md`](chat-retention.md)
 for bounded replacement of long task chats. Chat rotation must never alter GitHub lifecycle state.
@@ -90,27 +92,57 @@ create another Scheduled Task. All durable context therefore lives in GitHub and
 The four tasks may scan several repositories because queue state is external. Repository-specific filters and executor settings
 belong in explicit profiles, not in prior chat history.
 
-### Pull-request intake adapters
+## Universal pull-request intake adapter
 
-A repository profile may define PR-first sources. Prefer GitHub Projects' built-in auto-add workflow for newly created or updated
-PRs. For Sniffy, select repository `sniffy/sniffy` and filter `is:pr is:open label:dependencies`. The auto-add filter cannot
-identify the author and does not backfill existing matching PRs, so ticks still reconcile the source queue.
+Every open PR targeting the configured base branch is a discovery source, regardless of author, label, bot/provider, branch
+creator, or whether an issue was created first. The adapter scans drafts as telemetry but only starts Review for non-draft PRs.
 
-Before claiming ordinary work, a tick:
+Before ordinary work, a tick re-reads for each PR:
 
-1. scans for open matching PRs not already represented in the Project;
-2. verifies the actual author, labels, target, draft state, and exact head;
-3. submits a guarded control command with `addIfMissing: true`;
-4. initializes `Review / Ready / Executor = ChatGPT`, the chosen Verifier, and a concrete Worker reference;
-5. omits `Implementer` from the command, preserving any existing value but treating an absent value as valid;
-6. re-reads the Project item before treating intake as complete.
+- repository, base branch, draft/open state, exact head, mergeability, and same-repository/fork ownership;
+- author, labels, dependency/security metadata, and provider-specific controls;
+- formal closing issues and whether each issue/PR is already represented in Project 2;
+- current lifecycle fields, assignees, Worker reference, review decision, unresolved threads, and exact-head CI;
+- whether another canonical item or worker already owns the implementation.
 
-PR authorship is provenance used for trust, review identity, and provider-specific commands. It is not automatically a planned
-implementation route. For Dependabot, use the bot author plus dependency label to classify the update, but do not set
-`Implementer = Dependabot`. The Project currently offers that option for manual/historical use; normal intake leaves it empty.
-Do not create a shadow issue unless review discovers independently owned implementation work. Intake is not approval.
+Canonicalization is deterministic:
 
-### Control-issue adapter
+```text
+exactly one formal closing issue -> issue is canonical
+no formal closing issue          -> PR is canonical
+multiple formal closing issues   -> PR is canonical in Planning
+```
+
+For exactly one closing issue, add or locate that issue idempotently and attach the PR URL/exact head as implementation evidence.
+Do not add the PR as a second active lifecycle item. For a standalone PR, add or locate the PR itself. For a multi-issue PR, add or
+locate the PR as `Planning / Ready / ChatGPT` and suppress duplicate work on linked issues until Planning resolves combined scope
+and proof.
+
+A draft PR does not enter Review. It may remain linked to an existing canonical issue in `Implementation / In progress` and be
+monitored. Once it becomes ready for review, the next tick performs the canonical handoff; no separate event workflow is required.
+
+If both an issue and its PR were accidentally materialized, the tick does not review both. It prefers the canonical item above,
+makes the duplicate non-claimable through a guarded reconciliation when possible, and records the canonical link. The backfill key
+is repository plus item number; existing representation or ownership prevents duplication.
+
+A guarded intake/handoff:
+
+1. targets the canonical issue or PR;
+2. sets `Review / Ready / Executor = ChatGPT` for a reviewable implementation, or `Planning / Ready / ChatGPT` for a multi-issue or
+   ambiguous PR;
+3. chooses a Verifier from actual compatibility and observable-risk obligations;
+4. omits `Implementer`, preserving any deliberate existing value while treating absence as valid;
+5. records PR URL, branch, exact head, author, fork/same-repo status, linked issues, labels, and relevant security/dependency data;
+6. assigns `bedrin-gpt` separately and re-reads both Project state and GitHub assignment.
+
+PR authorship is provenance used for trust, formal-review independence, and provider-specific commands. It is not automatically a
+planned implementation route. Dependabot is one specialization of universal intake; trusted automation is not approval.
+See [`pull-request-intake.md`](pull-request-intake.md).
+
+GitHub Projects auto-add may assist discovery, especially for issues created by agents and dependency PRs, but it cannot perform
+canonicalization. Do not rely on blind PR auto-add as the only intake path.
+
+## Control-issue adapter
 
 All executors use [`control-plane.md`](control-plane.md). They find the one active control issue, post one guarded
 `delivery-control/v1` command, inspect its terminal reaction, and re-read Project state. No target-item field command or claim
@@ -119,7 +151,7 @@ arbitration comment is permitted.
 Control-log rotation is ordinary event-loop maintenance. A tick needing to post a command may rotate an old/full log first, then
 continue. Rotation does not require an additional Scheduled Task.
 
-### Codex app automation adapter
+## Codex app automation adapter
 
 Codex automations can run on schedules, and some can return to the same conversation. Local automations require the computer to
 be awake and the Codex app running.
@@ -127,6 +159,10 @@ be awake and the Codex app running.
 Use one persistent dispatcher conversation when app-owned one-time worker creation is proven. The current Sniffy Local Codex
 profile is fixed to Sol with extra-high reasoning. The dispatcher selects work and routing; it does not pretend Cloud or Local
 model choice is the same axis as executor choice.
+
+The dispatcher may receive an issue or PR canonical item. An explicitly routed same-repository existing PR is a valid adopted
+continuation: reuse the exact branch and PR even when it was created by Dmitry, ChatGPT, an IDE agent, or another worker. Fork and
+Dependabot branches are not adopted for direct correction.
 
 ### Headless Local Codex adapter
 
@@ -138,8 +174,8 @@ systemd timer or cron
   -> dispatcher loads project profiles
   -> central guarded claim
   -> isolated git worktree
-  -> codex exec with rendered worker prompt
-  -> commit, push, PR, evidence, and guarded handoff
+  -> codex exec with rendered lifecycle prompt
+  -> commit/update exact PR, evidence, and guarded handoff
 ```
 
 A five- or fifteen-minute timer is straightforward locally. Host-local `flock` complements the GitHub target-item concurrency
@@ -155,27 +191,30 @@ Executor = <dispatcher executor type>
 Assignee is empty OR Assignee belongs to this dispatcher pool
 ```
 
-The work item may be an issue or pull request. The dispatcher also checks lifecycle compatibility, required access, worker-pool
-capacity, existing branch/PR ownership, and absence of a valid current worker. Eligibility must not require `Implementer` or
-`Verifier` to be populated when the current status does not use them. A blank `Implementer` means unknown/not deliberately
-selected, while `Executor` remains the authoritative current route.
+The canonical work item may be an issue or pull request. The dispatcher also checks lifecycle compatibility, required access,
+worker-pool capacity, existing branch/PR ownership, and absence of a valid current worker. It excludes duplicate representations
+and linked issues suppressed by an open canonical multi-issue PR.
 
-Lifecycle transitions copy a planned field into `Executor` only when that route has been deliberately selected. Entering
-Implementation requires a non-empty Implementer; external PR Review, rebase monitoring, Verification, Approval, and closure do
-not.
+Eligibility must not require `Implementer` or `Verifier` to be populated when the current status does not use them. A blank
+`Implementer` means unknown/not deliberately selected, while `Executor` remains the authoritative current route. Entering
+Implementation requires a non-empty deliberately selected Implementer; Review, PR monitoring, Verification, Approval, and closure
+do not.
 
-Use deterministic selection such as security priority, Project priority, ready timestamp, then repository/item number. Claim at
-most available capacity and never create duplicate workers or Project items.
+Use deterministic selection such as security priority, Project priority, ready timestamp, then repository, item type, and item
+number. Claim at most available capacity and never create duplicate workers or Project items.
 
 ## Guarded claim
 
 A claim is one ordinary `delivery-control/v1` transition, not a public comment-election protocol:
 
-1. query an eligible `Ready` item;
-2. re-read its Status, Execution, Executor, Assignee, exact PR head, branch/PR, worker reference, and lease;
+1. query an eligible canonical `Ready` item;
+2. re-read its Status, Execution, Executor, Assignee, exact PR head when the item is a PR, linked branch/PR, worker reference, and
+   lease;
 3. construct a unique token and worker/tick reference;
-4. post one command guarding at least the current Status, `Execution = Ready`, current Executor, and exact PR head when applicable;
-5. set `Execution = In progress`, one Worker reference containing claim token, lease time, concrete owner, and any configured routing fields in that same command;
+4. post one command guarding at least current Status, `Execution = Ready`, current Executor, canonical target type, and exact PR
+   head when applicable;
+5. set `Execution = In progress`, one Worker reference containing claim token, lease time, concrete owner, and relevant linked
+   PR/head in that same command;
 6. inspect the command reaction and re-read Project state;
 7. only the verified winner performs work or confirms an external dispatch.
 
@@ -198,9 +237,10 @@ workerReference
 lastObservableEvidence
 ```
 
-Before expiring a lease, inspect the worker record, issue, branch, PR, commits, review state, and CI. Lack of a recent target
-comment does not prove inactivity. Recover the existing branch/worker where possible. Release to `Ready` only when ownership is
-genuinely stale. Routine waiting remains `In progress`; use `Blocked` only when Dmitry must intervene.
+Before expiring a lease, inspect the worker record, canonical item, linked issues/PR, branch, commits, review state, and CI. Lack
+of a recent target comment does not prove inactivity. Recover the exact existing branch/worker where possible. Release to `Ready`
+only when ownership is genuinely stale. Routine waiting for CI, contributor update, bot rebase, or draft publication remains
+`In progress`; use `Blocked` only when Dmitry must intervene.
 
 Worker monitoring follows [`supervision.md`](supervision.md): first observation after 15 minutes, a second 15 minutes later, then
 hourly while incomplete. Those due observations are selected by the same dispatcher ticks; no extra monitoring scheduler is
@@ -210,19 +250,21 @@ required.
 
 One worker or direct ChatGPT tick owns one lifecycle turn. It must:
 
-- re-read the authoritative issue/PR, current lifecycle fields, nearest `AGENTS.md`, branch/PR, and exact head;
+- re-read the canonical issue/PR, all linked requirements, current lifecycle fields, nearest `AGENTS.md`, exact branch/PR/head,
+  review threads, and CI;
 - verify its Project ownership before mutating source or GitHub;
 - perform only the routed lifecycle responsibility;
-- publish exact human-useful evidence;
+- preserve and continue an explicitly adopted same-repository existing PR rather than creating a duplicate;
+- publish exact human-useful evidence on the canonical target;
 - use the common guarded control protocol for the next lifecycle state;
 - stop without spawning a replacement worker when blocked and route the exact next action to Dmitry;
 - never merge or enable auto-merge without explicit authorization.
 
 ## Generic core versus project profile
 
-Generic documents define lifecycle, intake, guarded claims, leases, correction limits, publication, verification, and merge
-authority. [`profile.yml`](profile.yml) supplies current Sniffy configuration, including Project fields, identities, default
-routes, Local Codex Sol/extra-high settings, external-intake implementer policy, and control-log thresholds.
+Generic documents define lifecycle, canonicalization, intake, guarded claims, leases, correction limits, publication,
+verification, and merge authority. [`profile.yml`](profile.yml) supplies current Sniffy configuration, including Project fields,
+identities, default routes, Local Codex Sol/extra-high settings, universal PR intake, and control-log thresholds.
 
 Profiles may add filters, capacity, evidence requirements, or future executor settings, but must not redefine the shared meaning
 of Status, Execution, publication, verification, or merge authority. Update the profile when a routing preference changes; edit

--- a/docs/ai-delivery/executors/chatgpt.md
+++ b/docs/ai-delivery/executors/chatgpt.md
@@ -9,8 +9,12 @@ As supervisor, ChatGPT:
 
 - turns discussions into an authoritative issue with decisions, non-goals, Implementer when Implementation is needed, Verifier,
   and proof obligations;
-- ingests eligible external pull requests such as Dependabot updates into Review without inferring Implementer from authorship;
+- scans every open PR targeting `develop`, regardless of author/label/provider, and canonicalizes issue versus PR before work;
+- treats exactly one closing issue as canonical, standalone PRs as canonical, and multi-issue PRs as Planning items;
+- ingests ready implementations into Review without inferring Implementer from authorship;
+- suppresses duplicate issue/PR lifecycle representations and never reviews the same implementation twice;
 - tracks lifecycle fields, guarded claims, workers, branches, PRs, exact SHAs, reviews, Verification, CI, artifacts, and blockers;
+- routes same-repository existing-PR corrections to ChatGPT or Local Codex continuation without opening a duplicate;
 - rotates the technical control issue during normal event-loop work;
 - performs the convergence checkpoint when corrected work returns to Review with substantive blockers;
 - never merges or performs privileged operations without explicit instruction.
@@ -19,6 +23,7 @@ As executor, reviewer, or verifier, ChatGPT may:
 
 - inspect and modify repository files through the GitHub connector;
 - create issues, branches, commits, and pull requests when authorized;
+- continue an explicitly routed same-repository existing PR when connector-backed edits and validation are sufficient;
 - analyze exact-head diffs, comments, review threads, CI jobs, logs, and artifacts;
 - download supported CI artifacts and inspect their contents;
 - run focused commands when source and dependencies are present;
@@ -26,7 +31,7 @@ As executor, reviewer, or verifier, ChatGPT may:
 - prepare precise Request Changes, verification evidence, and operator checklists.
 
 It delegates obligations it cannot truthfully perform, such as unavailable dependency installation, private/local services,
-hardware, privileged settings, or formal review of its own GitHub-authored PR.
+hardware, privileged settings, complex existing-branch work, or formal review of its own GitHub-authored PR.
 
 ## Capability separation
 
@@ -39,24 +44,44 @@ Do not treat “ChatGPT has internet” as one capability. In the current Sniffy
 - Chromium may load a localhost artifact, which does not prove a source build;
 - direct workflow dispatch may be unavailable even though issue comments and repository writes are available.
 
-Run a capability preflight for source, dependencies, network, runtimes, browser, credentials, publication, and review identity.
-Use the strongest truthful evidence available and route missing obligations elsewhere.
+Run a capability preflight for canonical item, source, exact branch/head, dependencies, network, runtimes, browser, credentials,
+publication, branch ownership, and review identity. Use the strongest truthful evidence available and route missing obligations
+elsewhere.
 
 ## Common ProjectV2 control path
 
 ChatGPT uses the same [`../control-plane.md`](../control-plane.md) protocol as Codex and human/CLI operators:
 
 1. locate the one active technical control issue;
-2. post one guarded `delivery-control/v1` JSON command;
-3. inspect the reaction and Actions result;
-4. re-read the resulting Project fields;
-5. only then claim ownership or report a handoff.
+2. choose and re-read the canonical issue or PR;
+3. post one guarded `delivery-control/v1` JSON command;
+4. inspect the reaction and Actions result;
+5. re-read the resulting Project fields;
+6. only then claim ownership or report a handoff.
 
-Omit optional fields that are not part of the transition. In particular, external PR intake leaves `Implementer` untouched and
-accepts an empty value; it does not synthesize an author, bot, provider, or `Unknown` single-select value.
+When the canonical item is a PR, guard its exact head. When an issue is canonical, keep its Worker reference pinned to the linked
+PR URL and exact head. Omit optional fields that are not part of the transition. Universal PR intake leaves `Implementer`
+untouched and accepts an empty value; it does not synthesize an author, bot, provider, IDE, or `Unknown` option.
 
 Do not post `/project-status`, `/project-field`, claim-intent, lease arbitration, or polling comments on target issues/PRs.
 `workflow_dispatch` is the administrative fallback to the same implementation and is not required for normal ChatGPT operation.
+
+## Universal PR intake
+
+Before ordinary queue work, each stateless tick scans all open PRs targeting `develop`:
+
+- draft PRs are telemetry and may be monitored by an existing Implementation owner, but do not enter Review;
+- one formal closing issue means that issue owns lifecycle state and the PR is exact-head implementation evidence;
+- no formal closing issue means the non-draft PR itself becomes the Project item;
+- several formal closing issues mean the PR enters Planning before Review;
+- same-repository, fork, Dependabot, maintainer, IDE, and configured-agent PRs all enter discovery;
+- author/repository ownership affects formal-review and correction policy, not eligibility.
+
+If both an issue and its PR are materialized, ChatGPT reconciles one canonical active item and makes the duplicate non-claimable.
+It does not invent a shadow issue for a standalone PR and does not create a replacement PR solely because an agent did not author
+the existing branch.
+
+See [`../pull-request-intake.md`](../pull-request-intake.md).
 
 ## ChatGPT Scheduled Tasks
 
@@ -73,20 +98,21 @@ Use four hourly tasks at `:00`, `:15`, `:30`, and `:45`. Create each task from a
 `AI Delivery Event Loop` Project. The exact setup and shared prompt live in
 [`.chatgpt/scheduled-task-prompt.md`](../../../.chatgpt/scheduled-task-prompt.md).
 
-Product testing on 2026-07-30 showed that recurrences append to the defining chat rather than reliably starting a fresh chat.
-Each occurrence must therefore be stateless by procedure:
+Product testing on 2026-07-30 showed that recurrences append to the defining chat rather than reliably starting a fresh chat. Each
+occurrence must therefore be stateless by procedure:
 
 - ignore previous-run conclusions;
 - read current GitHub and repository-owned policy from scratch;
-- perform at most one lifecycle turn or supported dispatch;
+- canonicalize arbitrary PRs before queue selection;
+- perform at most one reconciliation, lifecycle turn, or supported dispatch;
 - make no GitHub mutation for `NO_CHANGE`;
 - keep durable state outside the chat.
 
 The four persistent transcripts are telemetry. Replace a long defining chat deliberately using
 [`../chat-retention.md`](../chat-retention.md); do not delete an active task chat before its replacement is smoke-tested.
 
-Worker monitoring is not another Scheduled Task. Due 15-minute, second-15-minute, and hourly observations are selected by these
-same event-loop ticks before new work.
+Worker and PR-operation monitoring is not another Scheduled Task. Due 15-minute, second-15-minute, and hourly observations are
+selected by these same event-loop ticks before new work.
 
 ## ChatGPT Project bootstrap
 
@@ -97,9 +123,10 @@ For every sniffy/sniffy task, first read the current repository policy at
 https://github.com/sniffy/sniffy/blob/develop/AGENTS.md and the AI delivery map at
 https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/README.md .
 
-Treat the current GitHub issue, Project fields, pull request, exact head SHA, reviews, CI, artifacts, and central control protocol
-as the source of truth. Never claim that a checkout, command, build, browser session, publication, deployment, or settings change
-occurred unless it completed and its output was inspected. Never merge or enable auto-merge without Dmitry's explicit command.
+Treat the canonical GitHub issue or pull request, linked PR exact head, Project fields, reviews, CI, artifacts, and central control
+protocol as the source of truth. Never claim that a checkout, command, build, browser session, publication, deployment, or settings
+change occurred unless it completed and its output was inspected. Never merge or enable auto-merge without Dmitry's explicit
+command.
 ```
 
 Re-read current-`develop` policy at the start of each repository task. Review evidence remains pinned to the immutable PR head.
@@ -110,8 +137,9 @@ credentials and generated artifacts.
 
 Prefer direct ChatGPT implementation when:
 
-- repository state can be read accurately through available tools;
+- canonical repository state can be read accurately through available tools;
 - edits and publication are focused and supported;
+- a same-repository existing PR can be safely continued without complex checkout/service state;
 - required checks can run with present source/dependencies, or exact-head CI/artifacts provide the intended proof;
 - browser/system verification can be performed truthfully;
 - formal review remains honest about PR-author identity.
@@ -120,25 +148,27 @@ Otherwise follow [`../routing.md`](../routing.md): bounded well-specified fresh 
 persistent, cross-version, service/browser, existing-PR, or non-converging work goes to Local Codex Sol/extra-high; privileged or
 unresolved decisions go to Dmitry.
 
-An external PR with empty Implementer may still be reviewed, monitored, verified, approved, superseded, or closed. If new code is
-required, choose a supported Implementer through Planning or a linked replacement task before entering Implementation.
+For same-repository correction, preserve the exact branch and PR. For a fork, leave contributor-facing findings and wait for a new
+head or create a deliberately routed internal replacement. For Dependabot, use documented bot commands or linked replacement work.
+
+A PR with empty Implementer may still be reviewed, monitored, verified, approved, superseded, or closed. If new code is required,
+choose a supported Implementer before entering Implementation.
 
 ## Review convergence
 
 When Review returns work to Implementation and the corrected head comes back with substantive blockers again, ChatGPT pauses
-serial patching and performs the convergence checkpoint. It may continue the same executor with superseding guidance, preserve
-the branch/PR and escalate to Local Codex, return to Planning, or block for Dmitry. This is a Review decision inside the ordinary
-event loop, not a new timer.
+serial patching and performs the convergence checkpoint. It may continue the same executor, adopt/escalate the exact existing PR
+to Local Codex, return to Planning, or block for Dmitry. This is a Review decision inside the ordinary event loop, not a new timer.
 
 ## Review identity limitation
 
 A PR authored by `bedrin-gpt` cannot be formally approved by the same identity. ChatGPT still performs full Review and routed
-Verification, then leaves exact ready-for-Dmitry-review or blocking feedback. A Dependabot-authored or external-contributor PR is
-independent from `bedrin-gpt` and may receive an honest formal ChatGPT review. This decision uses the actual PR author, not the
+Verification, then leaves exact ready-for-Dmitry-review or blocking feedback. A Dmitry-, Dependabot-, external-contributor-, IDE-,
+or independently-agent-authored PR may receive an honest formal ChatGPT review. This decision uses the actual PR author, not the
 optional Project Implementer field.
 
 ## Website verification
 
 The command sandbox may lack outbound DNS while GitHub connector access and managed Chromium remain available. Prefer exact-head
-CI artifacts rather than inventing a checkout. Follow [`../../chatgpt-site-preview.md`](../../chatgpt-site-preview.md) for
-artifact identity, localhost serving, reversible browser policy, Playwright evidence, screenshots, and truthful reporting.
+CI artifacts rather than inventing a checkout. Follow [`../../chatgpt-site-preview.md`](../../chatgpt-site-preview.md) for artifact
+identity, localhost serving, reversible browser policy, Playwright evidence, screenshots, and truthful reporting.

--- a/docs/ai-delivery/executors/codex-cloud.md
+++ b/docs/ai-delivery/executors/codex-cloud.md
@@ -10,15 +10,19 @@ explicitly selects a verified value; do not assume Cloud means Terra or Sol.
 
 ## Route to Cloud when
 
-- work starts from current `develop` on a fresh branch, or an explicitly re-queued existing Cloud branch can be recovered;
-- product, architecture, compatibility, module placement, and negative scope are resolved;
+- work starts from current `develop` on a fresh branch, or an explicitly re-queued existing **Cloud-owned** branch can be recovered;
+- product, architecture, compatibility, module placement, canonical item, and negative scope are resolved;
 - dependencies are public or prepared by setup/cache;
 - required tests fit available JDKs, tools, network policy, and task window;
 - no local service, device, private network, unusual history surgery, or persistent interactive artifact inspection is required;
 - parallel asynchronous implementation or verification is useful.
 
-Cloud is the preferred first external implementation executor for suitable bounded work after ChatGPT's direct-capability check.
-That is an environment/routing decision, not a model claim.
+Cloud is the preferred first external implementation executor for suitable bounded **fresh work** after ChatGPT's
+direct-capability check. That is an environment/routing decision, not a model claim.
+
+Do not route an arbitrary existing PR from Dmitry, ChatGPT, an IDE agent, external contributor, Dependabot, or another worker to
+Cloud as if it were a fresh task. Cloud must not open a duplicate branch/PR. Unless the branch is an explicitly recoverable
+Cloud-owned continuation, return routing to the supervisor; same-repository existing-PR continuation normally goes to Local Codex.
 
 Several interacting risk axes require the preflight and proof matrix in [`../routing.md`](../routing.md). When corrected Cloud work
 returns to Review and still has substantive blockers, ChatGPT performs the convergence checkpoint before another dispatch. The
@@ -77,25 +81,31 @@ control issue, posts one guarded `delivery-control/v1` command for a claim or ha
 state. It must not update Project fields through a private Cloud-only GraphQL path or post field/claim comments on the target
 item.
 
+The canonical target may be an issue or PR. For fresh work it is normally an issue; for an explicitly recoverable Cloud-owned PR
+continuation the worker reference must name the exact branch/head and no duplicate PR may be created.
+
 GitHub assignment, source publication, PR creation, reviews, and CI remain separately verified operations.
 
 ## Implementation lifecycle contract
 
-A Cloud implementation task reads the authoritative issue/thread, lifecycle/routing fields, current `develop`, applicable
-`AGENTS.md`, and delivery docs before editing. It must:
+A Cloud implementation task reads the canonical issue/PR, every linked requirement, lifecycle/routing fields, current `develop`,
+applicable `AGENTS.md`, and delivery docs before editing. It must:
 
-1. verify intended claim/branch/PR and convert each acceptance criterion to implementer-owned proof;
-2. implement only approved scope;
-3. run focused checks first, broader applicable checks separately, and available runtime/browser checks;
-4. inspect final diff, generated output, dependencies, documentation, and test discovery;
-5. run `git diff --check`, commit, and push the intended branch;
-6. create/update the intended PR, using draft only while implementation or Cloud-available proof is incomplete;
-7. verify remote branch, full SHA, PR URL, base/head refs, draft state, and matching PR head;
-8. reconcile the PR description with current head, commands, limitations, artifacts, and CI;
-9. publish human-useful implementation evidence on the target item;
-10. hand off with one guarded command to `Status = Review`, `Execution = Ready`, `Executor = ChatGPT`, clearing Cloud
-    worker ownership; update the ChatGPT Assignee separately and verify both operations;
-11. never review/approve its own implementation, merge, or enable auto-merge.
+1. verify intended canonical target, fresh/continuation mode, claim, branch, and PR;
+2. reject arbitrary existing-PR adoption and return to supervisor instead of creating a duplicate;
+3. convert each acceptance criterion to implementer-owned proof and implement only approved scope;
+4. run focused checks first, broader applicable checks separately, and available runtime/browser checks;
+5. inspect final diff, generated output, dependencies, documentation, and test discovery;
+6. run `git diff --check`, commit, and push the intended branch;
+7. create the intended PR for fresh work or update the explicitly recoverable Cloud-owned PR; use draft only while implementation
+   or Cloud-available proof is incomplete;
+8. verify remote branch, full SHA, PR URL, base/head refs, draft state, and matching PR head;
+9. mark the PR ready for review when implementation and locally available proof are complete;
+10. reconcile the PR description with current head, commands, limitations, artifacts, and CI;
+11. publish human-useful implementation evidence on the canonical target;
+12. hand off the canonical item with one guarded command to `Status = Review`, `Execution = Ready`, `Executor = ChatGPT`, recording
+    PR URL/exact head and clearing Cloud worker ownership; update the ChatGPT Assignee separately and verify both operations;
+13. never review/approve its own implementation, merge, or enable auto-merge.
 
 A missing `origin` is recoverable checkout configuration, not evidence that setup authentication failed. Setup persists `gh`
 authentication for the agent phase, while the repository URL contains no credential. Before reporting a publication blocker,
@@ -120,12 +130,12 @@ When selected as Verifier, Cloud uses the exact published implementation head or
 outcome-centric proof the Cloud environment genuinely supports, such as same-artifact compatibility, service/browser journey,
 packaging behavior, or failure/rollback path, and records exact environment/actions/results.
 
-It then publishes evidence and uses one guarded handoff command:
+It then publishes evidence and uses one guarded handoff command on the canonical item:
 
 - pass -> `Approval / Ready / Human`;
-- implementation defect -> `Implementation / Ready / Executor := Implementer`;
+- implementation defect -> `Implementation / Ready / Executor := Implementer` only when a deliberate Implementer is selected;
 - verification harness/evidence defect -> `Verification / Ready / Executor := Verifier`;
-- requirement/architecture defect -> `Planning / Ready / ChatGPT`;
+- requirement/architecture/canonicalization defect -> `Planning / Ready / ChatGPT`;
 - capability unavailable in Cloud but available elsewhere -> keep `Ready` and reroute Executor/Verifier;
 - Dmitry action required -> `Verification / Blocked / Human` with exact request.
 
@@ -138,7 +148,8 @@ A formal review or PR mention may not dispatch Cloud implementation. Use the pro
 performed by the normal event loop; do not create a separate monitoring scheduler.
 
 Verify a connector acknowledgement or new commit before saying work resumed. If the corrected head returns to Review with
-substantive blockers, stop automatic serial correction and wait for the convergence checkpoint route.
+substantive blockers, stop automatic serial correction and wait for the convergence checkpoint route. Arbitrary existing-PR
+continuation should be preserved and routed to Local Codex rather than recreated in Cloud.
 
-The exact GitHub branch, PR, SHA, reviews, checks, control-command result, and Project state are authoritative. Codex UI
-associations are useful metadata but do not prove publication or completion.
+The exact canonical item, GitHub branch, PR, SHA, reviews, checks, control-command result, and Project state are authoritative.
+Codex UI associations are useful metadata but do not prove publication or completion.

--- a/docs/ai-delivery/executors/codex-local.md
+++ b/docs/ai-delivery/executors/codex-local.md
@@ -5,8 +5,9 @@ Local Codex has two supported shapes:
 1. **app-native Local Codex** for app-owned conversations, worktrees, automations, and optional mobile Remote visibility;
 2. **headless Local Codex CLI** for unattended Linux scheduling, persistent caches/services, and scalable worker processes.
 
-Both follow `AGENTS.md`, the shared lifecycle, guarded control protocol, verification contract, and no-merge boundary. Current
-Sniffy configuration in [`../profile.yml`](../profile.yml) uses **Sol** with **extra-high** reasoning for Local Codex.
+Both follow `AGENTS.md`, universal issue/PR canonicalization, the shared lifecycle, guarded control protocol, verification contract,
+and no-merge boundary. Current Sniffy configuration in [`../profile.yml`](../profile.yml) uses **Sol** with **extra-high** reasoning
+for Local Codex.
 
 ## Route to Local Codex when
 
@@ -15,28 +16,32 @@ Prefer Local Codex for:
 - complex architecture, concurrency, lifecycle, cleanup, or failure composition;
 - cross-version Java and same-artifact compatibility;
 - persistent dependencies, Docker, services, browsers, or representative local environments;
-- existing branch/PR continuation and recovery;
+- existing same-repository branch/PR continuation, adoption, and recovery;
 - verification requiring local state or long-lived artifacts;
 - a convergence checkpoint that identifies Cloud context/environment/capability limits.
 
-Do not route an unresolved product or architecture decision merely because the local model/profile is strong. Planning and
-maintainer authority still precede implementation.
+Do not route an unresolved product, canonicalization, or architecture decision merely because the local model/profile is strong.
+Planning and maintainer authority still precede implementation.
+
+Do not adopt a fork or Dependabot branch for direct autonomous correction. Those remain contributor/bot-owned or are superseded by
+a deliberately routed internal task.
 
 ## Fixed model/profile
 
 The local scheduled automation selects its model and reasoning for the automation as a whole. The current Sniffy dispatcher and
 workers therefore use Sol / extra-high consistently. Do not label Codex Cloud as Terra and do not pretend the local dispatcher can
-switch models per issue unless a future product capability is explicitly smoke-tested and the profile is changed.
+switch models per item unless a future product capability is explicitly smoke-tested and the profile is changed.
 
 ## App-native topology
 
 ```text
 persistent dispatcher conversation (Sol / extra-high)
   -> empty queue: NO_CHANGE, no task/chat/worktree
-  -> eligible issue: guarded claim through central control issue
+  -> eligible canonical issue or PR: guarded claim through central control issue
        -> one one-time standalone worker task
-       -> one dedicated issue conversation
+       -> one dedicated canonical-item conversation
        -> one isolated app-managed worktree
+       -> fresh branch or exact adopted existing PR branch
        -> worker publishes evidence and guarded lifecycle handoff
 ```
 
@@ -46,7 +51,9 @@ The Windows app runs on the disposable VM; code, terminal, GitHub CLI, Java, Mav
 Before enabling app dispatch, smoke-test:
 
 - an empty tick creates no worker conversation or worktree;
-- a claimed item creates exactly one standalone worker;
+- a claimed issue item creates exactly one standalone worker;
+- an explicitly routed same-repository PR continuation reuses the exact branch/PR without a duplicate;
+- fork and Dependabot PRs cannot be adopted for direct correction;
 - the worker uses the expected project/worktree and Sol / extra-high profile;
 - failed child creation releases the guarded claim;
 - repeated automation returns to the intended persistent dispatcher;
@@ -61,11 +68,11 @@ one-time task creation survives a product update without retesting.
 systemd timer or cron
   -> flock / host-local dispatcher lock
   -> load docs/ai-delivery/profile.yml
-  -> query Status + Execution + Executor
+  -> query canonical Status + Execution + Executor
   -> central guarded claim
   -> isolated git worktree
   -> codex exec with rendered lifecycle prompt
-  -> tests, publication, evidence, guarded handoff
+  -> update exact branch/PR, tests, evidence, guarded handoff
 ```
 
 Use headless CLI when unattended reliability, Docker/services, persistent caches, several isolated workers, and machine-readable
@@ -74,26 +81,29 @@ Host-local `flock` prevents same-host overlap; the GitHub transition workflow se
 
 Each worker owns:
 
+- one canonical issue or PR and every linked requirement/evidence object;
 - one verified claim token and lifecycle generation;
 - one isolated worktree;
-- one branch and intended PR;
+- one fresh branch/intended PR or exact adopted existing branch/PR;
 - one rendered prompt for the current lifecycle status;
 - one structured log/evidence directory;
 - a bounded process timeout and cleanup path.
 
 A host may run several workers only when capacity, memory, disk, Maven/npm/Docker contention, and repository ownership are
-explicitly configured. Never let two workers own the same task/branch.
+explicitly configured. Never let two workers own the same canonical item or branch.
 
 ## Dispatcher contract
 
 Both adapters:
 
-- read `Execution = Ready` items routed to Local Codex;
+- read canonical `Execution = Ready` items routed to Local Codex;
+- accept issue and PR Project items;
 - respect directed Assignee or empty pool ownership;
-- inspect lifecycle, profile, access, capacity, branch/PR, current worker, and due monitoring;
+- inspect canonicalization, lifecycle, profile, access, capacity, exact branch/PR/head, current worker, and due monitoring;
+- exclude duplicate representations and linked issues suppressed by an open canonical multi-issue PR;
 - use the one active technical control issue and one guarded `delivery-control/v1` command per claim/transition;
 - inspect the reaction and re-read Project state before spawning;
-- record concrete conversation/task or process/worktree references;
+- record concrete conversation/task or process/worktree and exact PR references;
 - release to `Ready` when spawn fails;
 - set `Blocked` only when Dmitry must decide or act;
 - create no source or GitHub mutation for an empty queue.
@@ -101,20 +111,39 @@ Both adapters:
 Worker observation after 15 minutes, another 15 minutes, then hourly is part of this same dispatcher loop. Do not add a separate
 monitoring scheduler.
 
+## Fresh versus adopted continuation
+
+Fresh Implementation starts from current `origin/develop` only when no existing branch/PR owns the canonical item.
+
+An adopted continuation is valid when all are true:
+
+- an open same-repository PR already contains the intended implementation;
+- the canonical Project item explicitly routes `Implementer = Local Codex`, `Executor = Local Codex`;
+- the worker reference names the exact PR, branch, and head;
+- effective push permission and absence of competing ownership are verified;
+- the correction request is complete enough for one implementation turn.
+
+The worker then fetches and updates the exact existing branch. It does not reset, rebase, force-push, discard useful commits,
+open a replacement PR, or silently narrow the PR to only its latest review comments. Branch authorship by Dmitry, ChatGPT, or an
+IDE agent is neither a blocker nor sufficient authorization; the guarded Project route is authoritative.
+
 ## Worker contract
 
 A Local Codex worker performs only the routed lifecycle status:
 
 - Planning is unusual and normally remains ChatGPT/human-owned;
-- Implementation changes code, runs implementer-owned checks, inspects the diff, commits, pushes, and verifies publication;
+- Implementation changes code, runs implementer-owned checks, inspects the full diff, commits, pushes, and verifies publication;
 - Verification runs outcome-centric system/integration/browser proof when selected;
 - Review is performed only with an independent configured identity and explicit route.
 
-For fresh work, branch from current `origin/develop`. For continuation, use the exact existing PR branch and never reset, rebase,
-force-push, replace the PR, or discard useful work. Keep PRs draft only while implementation or locally available proof is
-incomplete.
+For fresh work, create one branch and intended PR. For continuation, use the exact existing same-repository PR branch. Mark the PR
+ready for review when implementation and locally available proof are complete. Publish human-useful evidence on the canonical
+item and synchronize the PR description.
 
-Publish human-useful evidence on the target item. Use the central technical issue for Project transitions and claim/lease state.
+Implementation completion is not just a push: the worker must verify the exact remote head and use one guarded command to hand the
+canonical item to `Review / Ready / ChatGPT`, recording the PR URL/head and clearing worker ownership. It then assigns
+`bedrin-gpt` separately and verifies both state and assignment.
+
 Never merge or enable auto-merge without Dmitry's explicit instruction.
 
 ## Security

--- a/docs/ai-delivery/lifecycle.md
+++ b/docs/ai-delivery/lifecycle.md
@@ -1,14 +1,15 @@
 # Task lifecycle
 
 The lifecycle separates **what kind of work is next** from **whether that work can run now**. It is provider-neutral: the
-same model applies to ChatGPT, Codex Cloud, Local Codex, IDE-hosted agents, automation-authored pull requests, and humans.
+same model applies to ChatGPT, Codex Cloud, Local Codex, IDE-hosted agents, automation-authored pull requests, external
+contributors, and humans.
 
 ## Fields
 
 ### Status
 
-- `Draft` — captured but not activated.
-- `Planning` — refine outcome, decisions, non-goals, proof, implementation route, and verification route.
+- `Draft` — captured but not activated, or a duplicate/non-canonical Project representation suppressed from ordinary claims.
+- `Planning` — refine outcome, canonical item, decisions, non-goals, proof, implementation route, and verification route.
 - `Implementation` — change the repository and produce implementer-owned proof.
 - `Review` — inspect the code, scope, tests, review threads, and exact-head CI evidence.
 - `Verification` — validate the observable result in a representative environment.
@@ -18,18 +19,35 @@ same model applies to ChatGPT, Codex Cloud, Local Codex, IDE-hosted agents, auto
 ### Execution
 
 - `Ready` — the next action in the current status can start now.
-- `In progress` — a concrete actor owns and is performing the next action, including waiting for checks that actor started.
+- `In progress` — a concrete actor owns and is performing the next action, including waiting for checks or an external operation
+  that actor started.
 - `Blocked` — the autonomous workflow cannot safely continue and requires Dmitry's decision or action.
 
 `Review` is a lifecycle status, not an execution state: it is substantive work with its own actor, inputs, outcomes, and
 correction transitions. `Blocked` is an execution state, not a lifecycle status: preserving the current status records where
 work should resume after Dmitry clears the blocker.
 
-`Draft` and `Done` do not need an execution value. They are lifecycle endpoints outside the claim loop.
+`Draft` and `Done` do not need an execution value. They are lifecycle endpoints outside the ordinary claim loop.
 
-Routine waiting is not `Blocked`. A worker waiting for CI, an already-dispatched agent, or another observable operation it owns
+Routine waiting is not `Blocked`. A worker waiting for CI, contributor changes, a Dependabot rebase, or draft publication it owns
 remains `In progress` and is monitored. Set `Blocked` only when the automation must stop, assign `Executor = Human` and
 `Assignee = bedrin`, record the exact decision or action required, and notify Dmitry.
+
+## Canonical work item
+
+Issues and pull requests may both be Project items, but one item is canonical for lifecycle routing of one published change:
+
+- exactly one formal closing issue -> that issue is canonical and the PR is implementation evidence;
+- no formal closing issue -> the PR itself is canonical;
+- multiple formal closing issues -> the PR is canonical in Planning until combined scope and completion propagation are resolved.
+
+The canonical item owns Status, Execution, Executor, Assignee, and Worker reference. Linked issues and PRs remain authoritative
+requirements or implementation evidence. The event loop must not perform duplicate Review merely because both an issue and its PR
+are represented in Project 2.
+
+When an issue is canonical, Worker reference stays pinned to the implementation PR URL, branch, and exact head through Review and
+Verification. When a PR is canonical, its exact head is also included in every guarded claim. A duplicate representation may be
+moved to Draft/cleared routing with a canonical-link explanation so it is not selected independently.
 
 ## Planned routing and current ownership
 
@@ -39,14 +57,14 @@ Planning chooses future roles before those lifecycle statuses begin:
   not applicable to the already-published change, or not yet deliberately routed.
 - `Verifier` — executor responsible for coordinating `Verification` and its evidence.
 
-PR authorship and automation identity are provenance in the pull request itself, not implicit routing values. External-PR intake
-must not copy an author, bot name, or previously unseen provider into `Implementer` merely to populate the field.
+PR authorship and automation identity are provenance in the pull request itself, not implicit routing values. Universal PR intake
+must not copy an author, bot name, IDE product, or previously unseen provider into `Implementer` merely to populate the field.
 
 Current routing is materialized separately:
 
 - `Executor` — product/runtime expected to perform the **next current action**.
 - `Assignee` — concrete GitHub identity or human responsible for that action.
-- `Worker reference` — concrete chat, task, process, worktree, branch, PR, or tick ownership record after claim.
+- `Worker reference` — concrete chat, task, process, worktree, branch, PR, exact head, or tick ownership record after claim.
 
 Keeping planned and current routing separate is intentional. Planning records `Implementer` only when an Implementation route is
 needed, and records `Verifier` when Verification may be needed. `Executor` lets every dispatcher use the same query for the
@@ -56,15 +74,16 @@ Transition invariants include:
 
 ```text
 Planning -> Implementation: require non-empty Implementer; Executor := Implementer
-Implementation -> Review: Executor := ChatGPT (default reviewer)
-External PR intake -> Review: leave Implementer unchanged/empty; Executor := ChatGPT
+Implementation -> Review: Executor := ChatGPT; Worker reference := PR URL + exact head
+Universal PR intake -> Review: leave Implementer unchanged/empty; Executor := ChatGPT
+Multi-issue PR intake -> Planning: canonical item := PR; Executor := ChatGPT
 Review -> Implementation: deliberately choose/set Implementer first when it is empty
-Review -> Verification: Executor := Verifier
+Review -> Verification: require selected Verifier; Executor := Verifier
 Review/Verification -> Approval: Executor := Human
 ```
 
-A repository may override the default reviewer explicitly, but formal GitHub review still requires an identity independent
-from the PR author.
+A repository may override the default reviewer explicitly, but formal GitHub review still requires an identity independent from
+the PR author.
 
 ## Ready semantics
 
@@ -82,6 +101,7 @@ Implementer: Local Codex
 Verifier: ChatGPT
 Executor: Local Codex
 Assignee: empty
+Worker reference: PR #123; exact branch/head when continuation
 ```
 
 After claim:
@@ -91,7 +111,7 @@ Status: Implementation
 Execution: In progress
 Executor: Local Codex
 Assignee: bedrin-codex-local
-Worker reference: <task/process/worktree>
+Worker reference: <task/process/worktree; existing PR/head when continuation>
 ```
 
 ### Directed Ready
@@ -131,54 +151,87 @@ Assignee: bedrin
 ```
 
 Dmitry may transition directly from that state to Done by actually merging/closing, or route the task back to Planning,
-Implementation, or Verification. `Approval / In progress` is optional when he wants to signal that human review has started;
-it is not required for a direct decision.
+Implementation, or Verification. `Approval / In progress` is optional when he wants to signal that human review has started; it
+is not required for a direct decision.
 
 ## Pull-request-first entry
 
-A work item may be an issue or a pull request. When Dependabot or another external actor already opened a reviewable PR, add the
-PR itself to the Project and normally initialize it as:
+Any non-draft open PR targeting `develop` is eligible for canonicalization, regardless of author or label.
+
+### Canonical issue with published PR
 
 ```text
+Issue item:
+Status: Review
+Execution: Ready
+Implementer: preserve planned implementation route or empty
+Verifier: <selected verifier>
+Executor: ChatGPT
+Assignee: bedrin-gpt
+Worker reference: PR URL; exact head; author; branch; CI/evidence
+```
+
+The issue owns lifecycle state. The PR owns diff, exact head, CI, and review conversation.
+
+### Standalone PR
+
+```text
+PR item:
 Status: Review
 Execution: Ready
 Implementer: empty
 Verifier: <selected verifier>
 Executor: ChatGPT
 Assignee: bedrin-gpt
-Worker reference: <PR URL and exact head>
+Worker reference: author; fork/same-repo; exact branch/head; linked context
 ```
 
-The pull request records its actual author. Leaving `Implementer` empty means the delivery system has not selected an executor to
-perform new implementation work; it does not lose provenance and does not prevent Review, Verification, Approval, rebase
-monitoring, or closure.
+The PR body supplies the current outcome/intent unless Planning creates a durable issue for independently owned work or unresolved
+decisions.
 
-This skips Draft, Planning, and Implementation only when the scope is understandable and no product, compatibility, security,
-or policy decision is missing. Otherwise route the PR item to `Planning / Ready`.
+### Multi-issue PR
+
+```text
+PR item:
+Status: Planning
+Execution: Ready
+Implementer: empty
+Verifier: <not required until planned>
+Executor: ChatGPT
+Assignee: bedrin-gpt
+Worker reference: all closing issues; exact branch/head; canonicalization decision pending
+```
+
+Planning resolves combined scope, proof, completion propagation, and whether any linked issue must continue independently before
+the PR enters Review.
+
+A draft PR does not enter Review. It may remain implementation evidence for an already-owned issue in `Implementation / In
+progress`; the implementation worker marks it ready and performs the guarded handoff when publication is complete.
 
 An acceptable PR advances to Verification or Approval. A stale Dependabot head stays in Review while ChatGPT owns monitoring of
-the bot rebase through `Executor` and `Worker reference`. A PR requiring repository-specific compatibility code becomes
-`Review / Blocked`, assigns the next action to Dmitry, and links to a new issue routed through Planning and Implementation; that
-linked work deliberately selects its own Implementer. The source PR remains the work item for the original proposal until
-superseded or closed. See [`pull-request-intake.md`](pull-request-intake.md).
+the bot rebase through `Executor` and Worker reference. A same-repository PR requiring corrections may be deliberately routed to
+ChatGPT or Local Codex continuation on the exact existing branch. A fork or bot PR normally receives contributor/bot commands or a
+linked internal replacement task rather than autonomous branch adoption. See [`pull-request-intake.md`](pull-request-intake.md).
 
 ## Lifecycle
 
 ```mermaid
 stateDiagram-v2
     [*] --> Draft
-    ExternalPR --> ReviewReady : implementation already published
+    PullRequest --> PlanningReady : multi-issue or ambiguous implementation
+    PullRequest --> ReviewReady : reviewable implementation published
 
-    Draft --> PlanningReady : Dmitry activates task
+    Draft --> PlanningReady : Dmitry or intake activates task
     Draft --> ImplementationReady : implementation explicitly preapproved
 
     PlanningReady --> PlanningProgress : current executor claims next planning action
     PlanningProgress --> PlanningReady : handoff to Dmitry or planning correction
-    PlanningReady --> ImplementationReady : Dmitry approves implementation
+    PlanningReady --> ImplementationReady : Dmitry approves implementation route
+    PlanningReady --> ReviewReady : published PR scope/proof resolved without new code
     PlanningReady --> ApprovalReady : planning-only task complete
 
     ImplementationReady --> ImplementationProgress : implementer claims task
-    ImplementationProgress --> ReviewReady : PR head and implementer proof published
+    ImplementationProgress --> ReviewReady : exact PR head and implementer proof published
 
     ReviewReady --> ReviewProgress : reviewer claims exact-head review
     ReviewProgress --> ImplementationReady : implementation changes requested after route selected
@@ -188,10 +241,10 @@ stateDiagram-v2
     VerificationReady --> VerificationProgress : verifier claims task
     VerificationProgress --> ImplementationReady : implementation defect after route selected
     VerificationProgress --> VerificationReady : verification harness or evidence defect
-    VerificationProgress --> PlanningReady : requirement or architecture defect
+    VerificationProgress --> PlanningReady : requirement, architecture, or canonicalization defect
     VerificationProgress --> ApprovalReady : verification passed
 
-    ApprovalReady --> PlanningReady : plan or scope issue
+    ApprovalReady --> PlanningReady : plan, scope, or canonicalization issue
     ApprovalReady --> ImplementationReady : implementation issue after route selected
     ApprovalReady --> VerificationReady : more evidence required
     ApprovalReady --> Done : PR actually merged or task deliberately closed
@@ -209,12 +262,12 @@ Track substantive correction rounds separately from scheduler retries and infras
 
 - Increment the implementation correction count when Review returns a real code/design defect to Implementation.
 - Increment the verification correction count when outcome verification finds a real implementation defect.
-- Do not increment for runner outages, transient network failures, or a retry of unchanged evidence.
+- Do not increment for runner outages, transient network failures, contributor wait, bot rebase, or retry of unchanged evidence.
 - After two substantive unattended correction rounds, or immediately after a product/architecture reversal, re-baseline the
-authoritative issue and deliberately choose the next executor. Do not allow ten blind autonomous loops.
+  authoritative issue/PR and deliberately choose the next executor. Do not allow ten blind autonomous loops.
 
 ## Completion
 
-There is no separate `Ready to merge` lifecycle status. A task remains `Approval / Ready` until Dmitry accepts it and the PR is
-actually merged (or the task is deliberately closed). Add a separate queue later only if approved-but-unmerged work becomes a
-real operational backlog, such as a release train.
+There is no separate `Ready to merge` lifecycle status. A canonical item remains `Approval / Ready` until Dmitry accepts it and
+the PR is actually merged (or the task is deliberately closed). For a canonical PR with several linked issues, Planning defines
+how the observed merge/closure propagates to each issue; a mention alone does not mark an issue Done.

--- a/docs/ai-delivery/profile.yml
+++ b/docs/ai-delivery/profile.yml
@@ -45,6 +45,7 @@ routing:
     directChatGPTWhenCapable: true
     firstExternalExecutorForBoundedFreshWork: Codex Cloud
     complexOrPersistentExecutor: Local Codex
+    existingPullRequestContinuationExecutor: Local Codex
   convergence:
     checkpointTrigger: corrected-work-returns-to-review-with-substantive-blockers
     doNotAutoDispatchAnotherPatchRound: true
@@ -52,14 +53,24 @@ routing:
   mergeExecutor: Human
 
 intake:
-  externalPullRequests:
+  pullRequests:
+    enabled: true
+    repository: sniffy/sniffy
+    baseBranch: develop
+    includeDraftsInReview: false
     # PR authorship is provenance, not a routing decision. Leave Implementer empty during intake.
     setImplementerFromAuthor: false
+    initialReviewer: ChatGPT
+    defaultVerifier: ChatGPT
+    canonicalization:
+      exactlyOneClosingIssue: issue
+      noClosingIssue: pullRequest
+      multipleClosingIssues: pullRequestPlanning
   dependabot:
     enabled: true
     projectAutoAddFilter: "is:pr is:open label:dependencies"
     backfillExisting: true
-    initialStatus: Review
+    # Dependabot is a specialization of universal PR intake, not a separate lifecycle entry.
     reviewer: ChatGPT
     # Project 2 currently contains a Dependabot Implementer option for manual/backward-compatible classification,
     # but automated intake deliberately does not select it.

--- a/docs/ai-delivery/pull-request-intake.md
+++ b/docs/ai-delivery/pull-request-intake.md
@@ -1,137 +1,211 @@
 # Pull-request-first intake
 
-Not every delivery item starts as an issue. Dependabot, an external contributor, or other automation may open a pull request that
-already contains an implementation. Add that pull request itself to the GitHub Project; do not create a shadow issue unless
-follow-up work needs a new independently owned implementation.
+A Sniffy implementation may arrive before the delivery system knows about it. Dmitry may push from IntelliJ, ChatGPT or Codex may
+publish a branch, Dependabot may open an update, or an external contributor may submit a fork PR. Every open PR targeting
+`develop` is therefore a discovery source. Author, label, provider, and branch origin affect trust, review independence, and
+correction strategy; they do not decide whether the PR belongs in the delivery process.
 
-## Lifecycle entry
+Issues and pull requests are both first-class Project items:
 
-A newly discovered external pull request normally enters as:
+- an **issue** is normally the authoritative outcome, decisions, acceptance criteria, and proof contract;
+- a **pull request** is the authoritative published implementation, exact head, CI, and review conversation;
+- exactly one Project item is canonical for lifecycle routing at a time; the other object remains linked requirements or evidence.
+
+Do not create a shadow issue merely because a PR exists without one. Do not create a second PR merely because the selected worker
+did not author the existing branch.
+
+## Canonical work-item selection
+
+For every open PR targeting `develop`, inspect formal closing links and current Project representation before adding anything:
+
+### Exactly one formal closing issue
+
+The issue is the canonical lifecycle item, whether or not it is already in Project 2.
+
+```text
+Canonical Project item: Issue #123
+Implementation evidence: PR #456 at exact head <sha>
+```
+
+Add or locate the issue idempotently. When the PR becomes non-draft and implementation publication is complete, initialize or
+transition the issue to:
 
 ```text
 Status: Review
 Execution: Ready
-Implementer: empty
-Verifier: <chosen during intake>
+Implementer: preserve existing value; empty is valid
+Verifier: <chosen from actual risk>
 Executor: ChatGPT
 Assignee: bedrin-gpt
-Worker reference: <PR URL and exact head>
+Worker reference: PR #456; branch; exact head; author; CI/evidence summary
 ```
 
-The PR is the authoritative source for its author and implementation provenance. Intake must not copy the author login, bot name,
-or a newly observed provider into `Implementer`. Empty means that Sniffy has not deliberately selected an executor for a future
-Implementation turn; Review and later lifecycle statuses do not require one.
+Do not add the PR as a second active lifecycle item. If both objects were already materialized, prefer the issue, suppress the PR
+item from ordinary claims through one guarded reconciliation, and record the canonical issue link. Never perform the same Review
+twice merely because both GitHub objects appear in the Project.
 
-This skips Draft, Planning, and Implementation only when the proposed scope is understandable and no product, compatibility,
-security, or policy decision is missing. Ambiguous, breaking, or policy-sensitive changes move to `Planning / Ready` before
-review continues.
+### No formal closing issue
 
-The exact head, body, commits, CI, labels, and linked alerts replace the branch/PR publication proof normally produced by a
-Sniffy-routed Implementer.
+The PR itself is the canonical lifecycle item. A non-draft PR normally enters:
 
-## GitHub Project intake for Sniffy
+```text
+Status: Review
+Execution: Ready
+Implementer: empty or preserved existing deliberate value
+Verifier: <chosen from actual risk>
+Executor: ChatGPT
+Assignee: bedrin-gpt
+Worker reference: exact branch/head, author, fork/same-repo, labels, linked context
+```
 
-Use GitHub Projects' built-in **Auto-add to project** workflow rather than a new repository workflow:
+The PR body is the requirement source unless Planning determines that a durable issue is needed for independently owned follow-up
+work or unresolved product decisions.
 
-1. Open organization Project 2 and choose **Workflows -> Auto-add to project**.
-2. Select repository `sniffy/sniffy`.
-3. Use filter `is:pr is:open label:dependencies`.
-4. Save and enable the workflow.
+### Multiple formal closing issues
 
-GitHub's auto-add workflow supports `is` and `label` filters but not an author filter. The `dependencies` label is therefore the
-discovery signal; intake must still verify the actual PR author for trust, review independence, Dependabot commands, and policy
-classification. Authorship is not a Project routing decision and must not be mirrored automatically into `Implementer`.
+The PR is the canonical coordination item and enters `Planning / Ready / ChatGPT`, not Review. Record every closing issue and
+resolve:
 
-Project 2 currently contains a `Dependabot` option in the `Implementer` single-select. It is retained for manual or historical
-classification, but automated external-PR intake deliberately leaves `Implementer` empty. The same rule applies to human external
-contributors, bots, and future automation providers that are not part of Sniffy's configured implementation executor pool.
+- whether the combined scope is intentional;
+- which issue decisions and acceptance criteria govern the PR;
+- one combined review and verification proof matrix;
+- how merge/closure evidence propagates to each linked issue;
+- whether any issue should be removed from the combined PR and continue independently.
 
-Auto-add is not retroactive. Existing matching PRs must be added manually or backfilled by an idempotent event-loop scan. The
-backfill key is repository plus PR number, and an existing Project item or intake marker prevents duplication.
+While the canonical multi-issue PR is open, the event loop must not independently claim a linked issue for duplicate Review or
+Implementation of the same published change. Planning may split the work, but it must do so explicitly and preserve existing
+branches/PRs where possible.
 
-The current `.github/dependabot.yml` schedules weekly GitHub Actions and npm updates and applies `dependencies` to both. Open
-Dependabot PRs may include browser tooling, GitHub Actions, framework major versions, cryptography, and other update classes, so
-the queue must not apply one blanket approval policy.
+## Draft and publication semantics
 
-Enabling the Project workflow is a manual repository-management action outside documentation/code changes. Until it is enabled,
-the stateless event loop provides discovery and backfill; after it is enabled, the loop remains responsible for field
-initialization, author verification, missed-item reconciliation, and review.
+A draft PR is visible implementation telemetry, not automatically `Review / Ready`:
 
-## Event-loop intake adapter
+- a new standalone draft PR is ignored by Review intake until it becomes ready for review;
+- a draft linked to an already-owned canonical issue may remain `Implementation / In progress` and be monitored through its exact
+  worker reference;
+- `ready_for_review` does not need a separate event workflow because the next stateless tick re-scans all open PRs;
+- an implementation worker must mark its PR ready when implementation and all locally available proof are complete, then perform
+  the guarded canonical-item handoff to Review.
 
-Before selecting ordinary `Execution = Ready` work, a tick may scan for eligible open pull requests that are not yet represented
-in the Project. Intake should:
+A green CI run on a draft PR does not substitute for the missing publication handoff.
 
-1. verify repository, open state, bot/external author, labels, target branch, draft state, and exact head;
-2. add or locate the PR Project item idempotently;
-3. classify security versus routine update and assign priority;
-4. choose a Verifier from the actual compatibility and environment risk;
-5. initialize `Review / Ready / Executor = ChatGPT / Assignee = bedrin-gpt` without setting `Implementer`;
-6. preserve an existing `Implementer` value if one was deliberately set, but never require it for intake or Review;
-7. record the PR URL, exact head, dependency ecosystem, old/new version, author, and linked security alert when available.
+## Authorship, provenance, and optional Implementer
 
-A guarded command should omit `Implementer` from both `set` and `clear`; omitted fields remain unchanged. Do not use a synthetic
-`Unknown` option and do not infer a select value from the author.
+The PR itself is authoritative for author and repository ownership. Intake records that provenance in Worker reference and uses it
+for formal-review independence and correction policy. It does not copy the author login, bot name, IDE product, or newly observed
+provider into the Project `Implementer` field.
 
-Security updates receive higher priority, but trusted automation is not approval. A tick claims and reviews at most the amount
-of work it can finish or safely hand off.
+`Implementer` is optional outside a deliberately routed future Implementation turn:
 
-## Dependabot review paths
+- empty means unknown, not applicable to the already-published implementation, or not yet selected;
+- intake, Review, rebase monitoring, Verification, Approval, supersession, and closure must work with it empty;
+- before new code work begins, Planning or Review deliberately selects a supported internal Implementer and copies it into
+  `Executor` through one guarded transition.
 
-GitHub documents Dependabot pull requests, management commands, and Actions integration here:
+Project 2 currently contains a `Dependabot` option for manual or historical classification. Universal intake deliberately leaves
+it unchanged/empty, just as it does for Dmitry, external contributors, IDE agents, and future bots.
 
-- [Dependabot pull requests](https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-pull-requests)
-- [Managing pull requests for dependency updates](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates)
-- [Dependabot pull request comment commands](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-pull-request-comment-commands)
-- [Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions)
-- [GitHub Projects auto-add](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically)
+## GitHub Project automation
 
-Route the reviewed exact head as follows:
+Use GitHub Projects' built-in auto-add for issues created by the delivery system or maintainers. This prevents newly planned tasks
+from being orphaned before Implementation.
 
-- **Acceptable low-risk update:** inspect dependency/lockfile scope, release or security information, compatibility, tests,
-  generated output, and exact-head CI. Submit an honest formal `APPROVE`, then advance to Verification when representative
-  outcome proof is still needed or directly to `Approval / Ready / Human` when existing evidence is sufficient.
-- **Risky runtime, framework, build-tool, browser, action, or security update:** choose a capable Verifier and exercise the
-  affected integration rather than treating green generic CI as complete proof.
-- **Stale base or merge conflict:** use `@dependabot rebase` when appropriate, keep the item in Review, and let ChatGPT own the
-  wait through `Execution = In progress`, `Executor = ChatGPT`, and a concrete Worker reference. Dependabot authorship does not
-  need to be represented in `Implementer` for this monitoring flow. Restart exact-head review only after a new head appears.
-- **Implementation incompatibility:** set the source PR to `Review / Blocked / Human / bedrin` and ask Dmitry to authorize a
-  linked compatibility issue or replacement update. The linked task goes through Planning, deliberately chooses an Implementer,
-  and produces an agent-owned replacement PR. Keep the source PR in Review with a Worker reference to that task until the
-  replacement supersedes it; then close the source PR with rationale.
-- **Requirement, major-version, or policy ambiguity:** move the PR item to `Planning / Ready` for ChatGPT or Dmitry. If the outcome
-  requires new code, Planning must choose a concrete Implementer before entering Implementation.
-- **Intentional rejection or ignore:** record the reason. Prefer visible repository configuration in `.github/dependabot.yml`
-  over a centrally stored one-off ignore when the policy should be shared by maintainers.
+Do not rely on blind `is:pr is:open` auto-add as the only PR intake mechanism. A simple Project workflow cannot decide whether a
+linked issue or the PR should be canonical and can create duplicate active lifecycle items. It is acceptable to retain the
+existing dependency PR auto-add filter:
 
-Do not normally push repository-specific fixes onto a Dependabot branch. A replacement agent-owned PR keeps branch ownership,
-review identity, and future Dependabot rebase behavior easier to reason about.
+```text
+is:pr is:open label:dependencies
+```
 
-## Verification examples by update class
+because the event loop still canonicalizes every PR before work. Auto-add is discovery assistance, not lifecycle initialization,
+review, or approval, and it is not retroactive.
 
-- **GitHub Action update:** inspect action ownership/release notes, changed permissions and inputs, and the exact workflow jobs
-  executing the new action version.
-- **Browser/test tooling:** run the complete affected browser matrix and inspect artifacts, screenshots, traces, and generated
-  output rather than relying only on typecheck/unit tests.
-- **Runtime framework/library:** run the affected integration or representative application path, including startup, request,
-  shutdown, compatibility, and failure behavior.
-- **Cryptography/security provider:** require the real provider/runtime path and supported-JDK compatibility evidence; a compile
-  or unrelated test suite is insufficient.
-- **Security update:** confirm the linked advisory is addressed without introducing a broader unsupported upgrade or silently
-  retaining the vulnerable path.
+## Universal event-loop intake adapter
 
-## Volume control
+Before ordinary queue selection, every ChatGPT tick scans all open PRs targeting `develop`, including same-repository PRs,
+maintainer PRs, configured-agent PRs, Dependabot, future bots, and forks.
 
-If routine dependency PR volume becomes costly, refine `.github/dependabot.yml` in a separate reviewed change. Prefer grouping
-compatible minor/patch development-tool updates while keeping major, runtime, cryptography, security, and GitHub Action updates
-separately reviewable. Do not add blind auto-approval or auto-merge as a volume-control mechanism.
+For each candidate it verifies:
 
-## Review identity and merge boundary
+1. repository, base branch, open/draft state, exact head, and mergeability/conflict state;
+2. author and same-repository versus fork ownership;
+3. labels, security/dependency metadata, and provider-specific controls;
+4. formal closing issues and their Project representation;
+5. whether the PR itself is already represented;
+6. current lifecycle fields, assignees, worker reference, review decision, unresolved threads, and exact-head CI;
+7. whether another canonical item or worker already owns the same implementation.
 
-A Dependabot-authored PR is independent from `bedrin-gpt`, so ChatGPT may submit an honest formal `APPROVE` or
-`REQUEST_CHANGES` after complete review. Verification remains outcome- and compatibility-oriented; green CI alone is not
-sufficient for a risky update.
+It then applies the canonicalization rules above with at most the guarded reconciliation it can verify now:
 
-GitHub supports auto-merge after required reviews and checks, but this workflow does not enable it. Dependabot PRs, like every
-other PR, move to `Approval / Ready` and are merged only after Dmitry's explicit instruction.
+- exactly one closing issue -> add/locate and hand off that issue;
+- no closing issue -> add/locate the PR;
+- several closing issues -> add/locate the PR in Planning;
+- draft -> monitor existing ownership or take no Review mutation;
+- duplicate representation -> preserve one canonical active item and make the duplicate non-claimable;
+- already correct -> no mutation.
+
+A guarded intake command omits `Implementer` from both `set` and `clear`, chooses a Verifier from actual compatibility and
+observable-risk obligations, and records the PR URL, exact head, branch, author, repository ownership, linked issues, and relevant
+metadata. Intake is not approval.
+
+## Review paths by PR ownership
+
+### Same-repository PR
+
+A PR from Dmitry, ChatGPT, Local/Cloud Codex, an IDE agent, or another trusted same-repository workflow can be reviewed normally.
+If Review finds defects:
+
+- submit one complete `REQUEST_CHANGES` when the reviewer identity is independent;
+- deliberately select ChatGPT or Local Codex for correction;
+- preserve and continue the exact branch and PR;
+- use Local Codex by default for complex, persistent, or existing-PR continuation;
+- never restart from `develop`, open a duplicate PR, rebase shared history, or force-push merely because a different executor now
+  owns the correction.
+
+A Project route may explicitly adopt an existing PR for Local Codex continuation even when the branch was created outside the
+delivery system. Branch authorship alone neither grants nor prevents adoption; verified repository ownership, permissions, and the
+guarded route do.
+
+### Fork PR
+
+Do not run privileged code from an untrusted head or silently take ownership of a contributor branch. Review the exact head and:
+
+- submit contributor-facing `REQUEST_CHANGES` and wait for a new head;
+- keep the canonical item in Review with ChatGPT owning the monitored wait when appropriate;
+- create a linked replacement task only when Dmitry deliberately chooses to internalize the work;
+- never push to the fork as an autonomous shortcut, even when GitHub exposes maintainer-edit capability.
+
+### Dependabot or other managed automation
+
+Dependabot is a specialization of the same intake:
+
+- inspect the exact dependency/lockfile/workflow scope and update risk;
+- for a stale base or conflict, use the documented bot rebase command and keep ChatGPT owning the observable wait;
+- do not normally push repository-specific fixes onto the bot branch;
+- when compatibility code is required, create and route a linked internal replacement task/PR;
+- do not auto-approve or auto-merge merely because the author is trusted automation.
+
+Future bots use their documented control surface when available; unknown automation is treated as provenance, not invented as a
+new Project executor.
+
+## Review and verification
+
+Review always inspects the complete exact-head diff, authoritative issue(s), PR body/commits, tests, unresolved threads, matching
+CI, generated output, permissions, dependencies, and compatibility. Formal APPROVE or REQUEST_CHANGES requires an identity
+independent from the PR author. When `bedrin-gpt` authored the PR, ChatGPT may still complete technical Review but must record the
+identity limitation and route final acceptance to Dmitry.
+
+An acceptable PR advances to Verification when representative outcome proof remains or directly to `Approval / Ready / Human`
+when existing evidence is sufficient. Risky browser, runtime, framework, cryptography, security, workflow, packaging, or
+cross-version changes require the representative proof described in [`verification.md`](verification.md); green generic CI is not
+system verification.
+
+## Completion and linked issues
+
+The canonical Project item remains `Approval / Ready` until Dmitry explicitly merges or closes. After an actual merge or deliberate
+closure, the event loop reconciles the canonical item to Done and records the merge/closure SHA and outcome. For a canonical PR
+with several linked issues, the same observed merge may then complete or reopen each issue according to the Planning decision; do
+not mark them Done merely because they were mentioned.
+
+No intake, review, correction, verification, or Project automation enables auto-merge. Merge authority remains with Dmitry.

--- a/docs/ai-delivery/routing.md
+++ b/docs/ai-delivery/routing.md
@@ -1,10 +1,10 @@
 # Task routing
 
-Dmitry and ChatGPT choose planned roles during Planning or when external-PR review discovers new implementation work. Routing is a
-risk, capability, evidence, latency, and cost decision. Current Sniffy defaults are editable in [`profile.yml`](profile.yml); this
-document defines the semantics and decision process.
+Dmitry and ChatGPT choose planned roles during Planning or when Review discovers new implementation work. Routing is a risk,
+capability, evidence, latency, continuity, and cost decision. Current Sniffy defaults are editable in [`profile.yml`](profile.yml);
+this document defines the semantics and decision process.
 
-## Separate axes: role, executor, model, identity
+## Separate axes: role, executor, model, identity, provenance
 
 Do not collapse these independent choices:
 
@@ -12,28 +12,29 @@ Do not collapse these independent choices:
 - **Executor** — ChatGPT, Codex Cloud, Local Codex, IDE agent, automation, or human.
 - **Model/profile** — provider-managed, Sol, reasoning effort, or another executor-specific setting.
 - **GitHub identity** — the account that publishes, comments, or formally reviews.
+- **Provenance** — who created the current PR/branch and whether it is same-repository, fork, or managed automation.
 
 Codex Cloud is not assumed to be Terra, Sol, or any other model. Its current model is recorded as `provider-managed` unless the
-product exposes and the task explicitly selects a verified model. The current Local Codex profile is intentionally fixed to Sol
+product exposes and the task explicitly selects a verified value. The current Local Codex profile is intentionally fixed to Sol
 with extra-high reasoning; the dispatcher does not pretend to choose a cheaper model dynamically for that automation.
 
 ## Roles
 
 A task may assign responsibilities independently:
 
-- **Supervisor/router:** refines the issue or external-PR intake, proposes routing, tracks delivery, rotates the control log, and
-  coordinates corrections. ChatGPT is the default.
+- **Supervisor/router:** canonicalizes issues and PRs, refines Planning, proposes routing, tracks delivery, rotates the control log,
+  and coordinates corrections. ChatGPT is the default.
 - **Implementer:** changes code/docs and proves the change in its own environment after Sniffy deliberately routes an
   `Implementation` turn.
 - **Reviewer:** inspects the complete exact-head diff, scope, tests, review threads, and CI evidence. ChatGPT is the default.
-- **Verifier:** validates the observable result against the issue in a representative environment.
+- **Verifier:** validates the observable result against the issue/PR in a representative environment.
 - **Formal reviewer:** submits APPROVE or REQUEST_CHANGES using an identity independent from the PR author.
 - **Privileged operator:** changes DNS, domains, repository settings, secrets, rulesets, Pages, or protected infrastructure.
 - **Merger:** merges only after Dmitry's explicit instruction.
 
 The same executor may hold several roles when independence is unnecessary. ChatGPT may implement through `bedrin-gpt`, but that
-identity cannot formally approve its own PR. A Dependabot-authored or external-contributor PR is independent from `bedrin-gpt`;
-that authorship remains PR provenance and is not automatically copied into the Project Implementer field.
+identity cannot formally approve its own PR. A Dmitry-, Dependabot-, IDE-, or contributor-authored PR remains provenance; it is not
+automatically copied into the Project Implementer field.
 
 ## Routing fields
 
@@ -47,11 +48,15 @@ The current lifecycle materializes:
 
 - `Executor` — product/runtime responsible for the next action;
 - `Assignee` — concrete GitHub identity or human responsible now;
-- `Worker reference` — concrete chat, task, process, worktree, branch, PR, or direct tick ownership.
+- `Worker reference` — concrete canonical item, chat, task, process, worktree, branch, PR, exact head, or direct tick ownership.
 
-External-PR intake does not infer `Implementer` from author, bot, or provider identity. All flows must tolerate an empty value and
-route from current `Status`, `Execution`, and `Executor`. Before entering Implementation, Planning or a linked replacement task
-must deliberately select a supported Implementer and copy that route into `Executor`.
+Universal PR intake does not infer `Implementer` from author, bot, IDE, or provider identity. All flows must tolerate an empty value
+and route from current `Status`, `Execution`, and `Executor`. Before entering Implementation, Planning or Review must deliberately
+select a supported Implementer and copy that route into `Executor`.
+
+The canonical Project item may be an issue or PR. Routing must first apply the canonicalization rules in
+[`pull-request-intake.md`](pull-request-intake.md); do not send two executors to an issue and its PR as if they were independent
+implementations.
 
 All executors mutate Project fields through [`control-plane.md`](control-plane.md). Assignment and source/review operations remain
 separate verified GitHub actions.
@@ -60,32 +65,40 @@ separate verified GitHub actions.
 
 | Executor | Prefer when | Avoid or escalate when |
 | --- | --- | --- |
-| ChatGPT | issue refinement, PR intake, GitHub state, focused connector-backed edits, CI diagnosis, exact-head artifacts, review, browser verification from available artifacts | required source/dependencies cannot be obtained, long writable checkout or service state is needed, or formal self-review would be dishonest |
-| Codex Cloud | bounded, well-specified fresh-branch implementation; public dependencies; deterministic Cloud-available proof; useful parallelism | existing-branch surgery, persistent services/artifacts, private/local access, unresolved architecture, or repeated non-convergence |
-| Local Codex app/CLI | complex architecture, lifecycle/concurrency, cross-version Java, persistent caches/services/Docker/browser, existing PR continuation, representative local verification, or Cloud escalation | host credentials/network are unsafe, sandbox policy is unclear, or a simpler executor can finish truthfully |
+| ChatGPT | issue/PR canonicalization, Planning, GitHub state, focused connector-backed edits, CI diagnosis, exact-head artifacts, Review, browser verification from available artifacts | required source/dependencies cannot be obtained, long writable checkout or service state is needed, or formal self-review would be dishonest |
+| Codex Cloud | bounded, well-specified fresh-branch implementation; public dependencies; deterministic Cloud-available proof; useful parallelism; explicitly recoverable existing Cloud branch | arbitrary existing-PR adoption, branch surgery, persistent services/artifacts, private/local access, unresolved architecture, or repeated non-convergence |
+| Local Codex app/CLI | complex architecture, lifecycle/concurrency, cross-version Java, persistent caches/services/Docker/browser, existing same-repository PR continuation/adoption, representative local verification, or Cloud escalation | fork/Dependabot branch adoption, unsafe host credentials/network, sandbox ambiguity, or a simpler executor can finish truthfully |
 | IDE agent | Dmitry intentionally wants interactive pair programming in VS Code/IntelliJ | unattended ownership, independent review, or reproducible publication is required but not configured |
 | Human | product/risk decisions, privileged operations, subjective acceptance, credentials/secrets, destructive migration, merge | routine bounded implementation or proof another executor can perform safely |
 
-Dependabot normally supplies an already-published external implementation rather than serving as the current Executor. The PR
-itself records that fact. ChatGPT owns Review and rebase monitoring, while the chosen Verifier owns outcome proof. Project 2
-currently contains a `Dependabot` Implementer option for manual/historical classification, but normal intake leaves it empty.
+Dependabot normally supplies an already-published implementation rather than serving as current Executor. The PR itself records
+that fact. ChatGPT owns Review and bot-operation monitoring, while the chosen Verifier owns outcome proof. Project 2 retains a
+`Dependabot` Implementer option for manual/historical use; normal intake leaves it empty.
 
 ## Capability preflight
 
 Before routing, confirm the exact environment can:
 
-- obtain the required source and exact revision;
+- obtain the canonical item, required source, and exact revision;
 - use installed or downloadable dependencies;
 - reach required network endpoints;
 - start required runtimes, containers, browsers, or services;
 - access credentials without exposing them;
 - preserve or continue the required branch/PR;
-- publish expected commits, PRs, artifacts, and evidence;
+- publish expected commits, PR updates, artifacts, and evidence;
 - provide independent review identity when required.
 
+For existing PR continuation also confirm:
+
+- same-repository ownership rather than fork/managed-bot branch;
+- the exact remote head branch and SHA;
+- effective push permission for the selected executor;
+- no competing worker or user session currently owns the branch;
+- the route explicitly says continuation/adoption rather than fresh work.
+
 Do not infer capability from a product name. ChatGPT's GitHub connector, web access, command sandbox, browser, and local runtimes
-are separate capabilities. Codex Cloud's clean environment does not make an ambiguous task well specified. Local persistence
-does not repair a missing product decision.
+are separate capabilities. Codex Cloud's clean environment does not make an ambiguous task well specified. Local persistence does
+not repair a missing product decision or grant permission to modify a contributor branch.
 
 ## Risk-axis routing
 
@@ -99,7 +112,7 @@ Count independent decisions and proof obligations, not changed lines. Relevant a
 - browser, visual, local-service, hardware, credential, or network proof;
 - dependency/security compatibility;
 - migration and rollback;
-- Git history or existing PR constraints;
+- Git history, branch ownership, existing PR, or fork constraints;
 - publication and review identity.
 
 Several interacting axes require a read-only design/proof preflight. Local Codex is the current strong execution route after the
@@ -110,19 +123,40 @@ invent unresolved decisions.
 
 Use this order for a new Implementation turn:
 
-1. **Require a deliberate route.** If `Implementer` is empty, first choose a supported implementation executor through Planning
-   or a linked replacement task. Never derive it from the current PR author.
-2. **ChatGPT direct capability check.** Can the current ChatGPT execution truthfully edit, test, inspect, publish, and verify the
-   requested focused change with available source, dependencies, connectors, and identity? If yes, it may implement directly.
-3. **Codex Cloud first for suitable bounded work.** Prefer Cloud for well-specified fresh-branch fixes, tests, documentation,
-   dependency updates, CI follow-ups, and localized refactors whose proof fits the Cloud environment.
-4. **Local Codex for complexity or persistence.** Route directly to Local Codex for concurrency/lifecycle, complex cross-version
-   Java, architecture-heavy work, Docker/services/browser state, existing PR continuation, unusual history constraints, or
-   representative local verification.
-5. **Human for authority or privilege.** Route unresolved product/risk decisions and privileged operations to Dmitry.
+1. **Require a deliberate route.** If `Implementer` is empty, first choose a supported implementation executor through Planning or
+   Review. Never derive it from the current PR author.
+2. **Classify fresh versus continuation.** A published same-repository PR normally continues on its exact branch and PR. A fork or
+   managed-bot PR normally remains contributor/bot-owned or is superseded by a linked internal task.
+3. **ChatGPT direct capability check.** Can the current ChatGPT execution truthfully edit, test, inspect, publish, and verify the
+   focused change with available source, dependencies, connectors, branch access, and identity? If yes, it may implement directly.
+4. **Codex Cloud first for suitable fresh work.** Prefer Cloud for well-specified fresh-branch fixes, tests, documentation,
+   dependency updates, CI follow-ups, and localized refactors whose proof fits the Cloud environment. Do not send an arbitrary
+   existing PR to Cloud merely because Cloud is available.
+5. **Local Codex for complexity, persistence, or existing PRs.** Route complex/cross-version/service/browser work and
+   same-repository existing-PR continuation to Local Codex by default. The worker reuses the exact branch/PR even when Dmitry,
+   ChatGPT, or an IDE agent originally created it.
+6. **Human for authority or privilege.** Route unresolved product/risk decisions and privileged operations to Dmitry.
 
-“Cloud first” is an executor/environment decision, not a claim about the Cloud model. “Local Sol/extra-high” is explicit current
-Sniffy configuration, not a generic rule for all repositories.
+“Cloud first” is an executor/environment decision for fresh suitable work, not a model claim. “Local Sol/extra-high” is explicit
+current Sniffy configuration, not a generic rule for all repositories.
+
+## Existing PR adoption and continuity
+
+A same-repository PR may enter the delivery process after being created outside it. Adoption means the canonical Project item
+explicitly routes correction to a configured Implementer; it does not mean opening a new issue/branch/PR.
+
+For an adopted continuation:
+
+- identify the canonical issue or PR and every formal closing issue;
+- guard current lifecycle state and exact PR head when the PR itself is canonical;
+- set `Status = Implementation`, `Execution = Ready`, `Implementer = <selected executor>`, and matching `Executor`;
+- keep Worker reference pinned to the exact existing PR and branch;
+- selected worker fetches and updates that branch without reset, rebase, force-push, or replacement PR;
+- all useful user/agent commits and unrelated-but-intentional changes are preserved;
+- after publication, the same canonical item returns to `Review / Ready / ChatGPT` with the new exact head.
+
+Do not adopt fork or Dependabot branches for direct autonomous correction. Use contributor-facing Request Changes, provider bot
+commands, or a linked internal replacement task. A future policy may relax this only with explicit trust/permission rules.
 
 ## Review convergence checkpoint
 
@@ -137,20 +171,19 @@ Trigger a **convergence checkpoint** when all are true:
 
 Before sending another implementation request, ChatGPT must critically re-evaluate:
 
-- Is the authoritative issue still correct and sufficiently precise?
+- Is the authoritative issue/PR still correct and sufficiently precise?
 - Did the implementation follow the intended architecture, or is the direction itself wrong?
 - Are the remaining findings local mistakes, misunderstood acceptance criteria, or an executor capability/context gap?
 - Would another narrow patch preserve a flawed design or accumulate contradictory instructions?
 - Does the proof matrix require a different environment?
-- Should the task return to Planning, remain with the same implementer under rewritten guidance, or change executor?
+- Should the task return to Planning, remain with the same implementer, adopt/escalate the existing PR to Local Codex, or block?
 
 The checkpoint produces one explicit result:
 
 - **Continue same executor:** direction is sound; supersede ambiguous guidance and issue one coherent correction request.
-- **Escalate executor:** preserve the existing branch/PR and route continuation to Local Codex, normally when Cloud lacks context,
-  persistence, environment, or has failed to converge.
-- **Return to Planning:** architecture, requirements, scope, or proof strategy must be re-baselined before more code changes.
-- **Block for Dmitry:** a product, risk, or privileged decision is required.
+- **Adopt/escalate existing PR:** preserve the exact branch/PR and route continuation to Local Codex.
+- **Return to Planning:** architecture, requirements, canonicalization, scope, or proof strategy must be re-baselined.
+- **Block for Dmitry:** a product, risk, privilege, or branch-ownership decision is required.
 
 Do not count infrastructure-only noise as a substantive correction cycle. Do not mechanically escalate merely because a test
 failed; the checkpoint is about repeated substantive Review blockers.
@@ -159,15 +192,16 @@ failed; the checkpoint is about repeated substantive Review blockers.
 
 Changing executor does not mean discarding published work:
 
-- keep the same authoritative issue;
-- continue the exact existing branch and PR when safe;
+- keep the same canonical item and linked requirements;
+- continue the exact existing same-repository branch and PR when safe;
 - preserve useful commits and evidence;
 - explicitly mark superseded guidance;
-- update `Implementer` only when a new implementation route is deliberately selected, update `Executor`, worker reference, and
+- update `Implementer` only when a new implementation route is deliberately selected, update `Executor`, Worker reference, and
   correction metadata through one guarded control command;
 - start the normal worker-monitoring cadence only after the new dispatch is concretely acknowledged.
 
-Do not reset, rebase, force-push, open a duplicate PR, or restart from `develop` merely because Cloud work moved to Local Codex.
+Do not reset, rebase, force-push, open a duplicate PR, or restart from `develop` merely because work moved between ChatGPT, IDE,
+Cloud, and Local Codex.
 
 ## Editable Sniffy defaults
 
@@ -175,16 +209,17 @@ Use [`profile.yml`](profile.yml) for operational choices Dmitry may tune without
 
 - executor identities;
 - direct-ChatGPT preference;
-- first external implementation executor;
-- complex/persistent executor;
+- first external implementation executor for fresh work;
+- complex/persistent and existing-PR continuation executor;
 - Local Codex model and reasoning effort;
-- external-PR implementer inference policy;
+- universal PR intake and canonicalization behavior;
+- implementer inference policy;
 - convergence trigger and preferred escalation executor;
 - control-log rotation thresholds.
 
 If a profile value conflicts with an explicit current issue or Dmitry's instruction, the issue/instruction wins. If a desired
-change alters lifecycle meaning, claim safety, review independence, or merge authority, update the policy rather than hiding it in
-the profile.
+change alters lifecycle meaning, claim safety, review independence, canonicalization, or merge authority, update the policy rather
+than hiding it in the profile.
 
 ## Issue routing block
 
@@ -192,6 +227,9 @@ the profile.
 ## Delivery routing
 
 - Supervisor: ChatGPT
+- Canonical Project item: <Issue URL | PR URL>
+- Existing PR/branch/head: <URL | none> / <branch | none> / <SHA | none>
+- Work mode: <fresh | continuation | adopted-continuation>
 - Implementer: <ChatGPT | Codex Cloud | Local Codex | IDE Agent | Human>
 - Verifier: <ChatGPT | Codex Cloud | Local Codex | Human | Mixed>
 - Default reviewer: ChatGPT
@@ -199,10 +237,9 @@ the profile.
 - Privileged operator: <none or named human>
 - GitHub author identity: <account>
 - Executor model/profile: <provider-managed | Sol / extra-high | other verified value>
-- Capability assumptions: <source, dependencies, network, services, browser, credentials>
-- Base/head and existing PR constraints: <details>
-- Rationale: <risk axes, evidence, latency, and cost>
+- Capability assumptions: <source, dependencies, network, services, browser, credentials, branch permissions>
+- Rationale: <risk axes, evidence, continuity, latency, and cost>
 ```
 
-This block is for issue Planning and therefore selects an Implementer before Implementation. External PR intake may omit the
-field because no new implementation turn has been routed.
+This block selects an Implementer before a new Implementation turn. Universal PR intake may leave it empty because no correction
+has yet been routed.

--- a/docs/ai-delivery/supervision.md
+++ b/docs/ai-delivery/supervision.md
@@ -1,7 +1,7 @@
 # Supervision and delivery control
 
 This policy applies whenever ChatGPT supervises work performed by Codex Cloud, Local Codex, an IDE agent, ChatGPT itself,
-automation such as Dependabot, or a human contributor.
+automation such as Dependabot, an external contributor, or a human.
 
 ## Lifecycle authority
 
@@ -17,6 +17,7 @@ work should resume, stops autonomous processing, and routes the next action to D
 
 Do not replace lifecycle fields with optimistic prose. Track supporting facts independently:
 
+- canonical issue/PR decision;
 - guarded claim/transition result;
 - concrete dispatch acknowledgement;
 - local completion and local proof;
@@ -25,7 +26,20 @@ Do not replace lifecycle fields with optimistic prose. Track supporting facts in
 - verification outcome;
 - actual merge or deliberate closure.
 
-A local commit is not publication; publication is not review; review is not verification; verification is not merge.
+A local commit is not publication; publication is not lifecycle handoff; handoff is not review; review is not verification;
+verification is not merge.
+
+## Canonical issue and PR supervision
+
+Before supervising a PR, apply [`pull-request-intake.md`](pull-request-intake.md):
+
+- one formal closing issue -> supervise lifecycle on that issue and keep the PR exact head in Worker reference;
+- no closing issue -> supervise lifecycle on the PR itself;
+- several closing issues -> supervise Planning on the PR and suppress duplicate linked-issue work until scope is resolved.
+
+If both an issue and its PR appear in Project 2, do not start two workers or Reviews. Preserve one canonical active item and make
+the duplicate non-claimable through a guarded reconciliation. Every status report names both the canonical item and exact PR head
+when implementation exists.
 
 ## Lifecycle handoff
 
@@ -36,18 +50,19 @@ A worker completes one lifecycle turn and writes the next route through the comm
   `Planning / Ready / Human`.
 - Planning approval may write `Implementation / Ready / Executor := Implementer` only when Implementer is non-empty and
   deliberately selected.
-- Implementation publication writes `Review / Ready / Executor := ChatGPT` by default.
-- External PR intake writes `Review / Ready / Executor := ChatGPT`, the selected Verifier, and evidence fields while leaving
+- Implementation publication marks the PR ready when local proof is complete, then writes the canonical item to
+  `Review / Ready / Executor = ChatGPT` with PR URL and exact head in Worker reference.
+- Universal PR intake performs the same Review handoff for a non-draft PR that appeared outside the delivery system, leaving
   Implementer unchanged/empty.
+- A multi-issue PR enters `Planning / Ready / ChatGPT` before Review.
 - Successful Review writes `Verification / Ready / Executor := Verifier` or `Approval / Ready / Human` when evidence is already
   sufficient.
 - Successful Verification writes `Approval / Ready / Human`.
 - Approval becomes `Done` only after actual merge or deliberate closure.
 
-A blank Implementer is valid outside a routed Implementation turn. It must not prevent intake, Review, rebase monitoring,
-Verification, Approval, blocking, supersession, or closure. When Review or Verification discovers that new code is needed and
-Implementer is empty, deliberately choose a supported executor through Planning or create a linked replacement task before
-entering Implementation. Do not infer that route from the external PR author.
+A blank Implementer is valid outside a routed Implementation turn. It must not prevent canonicalization, intake, Review, rebase or
+contributor monitoring, Verification, Approval, blocking, supersession, or closure. When Review or Verification discovers that new
+code is needed and Implementer is empty, deliberately choose a supported executor before entering Implementation.
 
 Every handoff clears stale worker ownership and lease data. GitHub assignment is updated separately and verified; a Project field
 transition does not prove assignment succeeded.
@@ -58,35 +73,39 @@ transition does not prove assignment succeeded.
   acknowledgement. A review mention alone is not implementation dispatch.
 - An app-native Local Codex item is dispatched only after a verified claim plus a concrete worker task/chat/worktree.
 - A headless Local Codex item is dispatched only after a verified claim plus process/worktree/branch record.
+- An adopted existing PR is dispatched only after the canonical Project item explicitly routes the exact same-repository PR,
+  branch, and head to the selected executor.
 - An IDE agent is working only while the human explicitly owns the interactive session or remote evidence proves activity.
 - A ChatGPT scheduled tick is working only after its guarded claim succeeded and it began the exact lifecycle operation.
 - A ChatGPT direct-execution task is working only after the exact GitHub or sandbox operation began.
 
-`In progress` with no verified claim/current worker reference is invalid. When execution or external dispatch cannot start,
-release to `Ready`. Set `Blocked` only when Dmitry must decide or act; set `Executor = Human`, assign `bedrin`, and record the
-exact requested action.
+`In progress` with no verified claim/current worker or observable external-operation reference is invalid. When execution or
+external dispatch cannot start, release to `Ready`. Set `Blocked` only when Dmitry must decide or act; set `Executor = Human`,
+assign `bedrin`, and record the exact requested action.
 
-## Queue polling and worker monitoring
+## Queue polling, PR intake, and worker monitoring
 
 Queue polling and worker follow-up are responsibilities of the same event loop:
 
-- **Queue polling** finds `Ready` work and claims it. Desired logical cadence is every 15 minutes.
-- **External PR intake** reconciles eligible PRs before ordinary queue work without inventing an Implementer.
-- **Worker monitoring** observes an existing claimed implementation/correction after 15 minutes, again 15 minutes later, then
-  hourly while incomplete.
+- **Universal PR intake** scans every open PR targeting `develop`, canonicalizes issue versus PR, and materializes reviewable work
+  before ordinary queue selection.
+- **Queue polling** finds canonical `Ready` work and claims it. Desired logical cadence is every 15 minutes.
+- **Worker/operation monitoring** observes an existing implementation, correction, CI wait, contributor update, bot rebase, or
+  draft publication after 15 minutes, again 15 minutes later, then hourly while incomplete.
 - **Control-log maintenance** rotates the active technical issue when a needed command would exceed the documented threshold.
 
-Do not create an additional monitoring Scheduled Task. A normal dispatcher tick first checks whether an existing owned worker is
-due for observation; only then may it claim unrelated work.
+Do not create an additional monitoring Scheduled Task. A normal dispatcher tick first checks whether an existing owned worker or
+PR operation is due for observation; only then may it claim unrelated work.
 
-Every new delegated task, retry, continuation, executor change, or Request Changes return starts the normal observation cycle:
+Every new delegated task, retry, continuation, adopted PR, executor change, or Request Changes return starts the normal
+observation cycle:
 
 1. observe after 15 minutes;
 2. if incomplete, observe 15 minutes later;
 3. if still incomplete, observe hourly.
 
-Each observation re-reads lifecycle fields, intended executor and assignee, worker record, expected branch/PR, acknowledgement or
-new head, review threads, and current CI. `Implementer` is read when relevant but may be empty; current ownership comes from
+Each observation re-reads canonical fields, linked issues/PR, intended executor and assignee, worker record, exact branch/head,
+acknowledgement or new head, draft state, review threads, and current CI. `Implementer` may be empty; current ownership comes from
 `Executor`, `Assignee`, and Worker reference. Notify the target conversation only on meaningful progress, completion, or a real
 blocker. Routine “still running” telemetry remains in the scheduler/worker transcript.
 
@@ -96,21 +115,32 @@ monitoring when lifecycle handoff completes or Dmitry owns a blocked next action
 ## Branch and PR continuity
 
 - Fresh work uses one new branch from current `develop` and one intended PR unless independently useful slices were approved.
-- Continuation work reuses the exact open branch and PR.
+- Continuation/adopted-continuation work reuses the exact open same-repository branch and PR, regardless of whether Dmitry,
+  ChatGPT, Codex, or an IDE agent originally created it.
+- The canonical route, effective push permission, and absence of competing ownership authorize adoption; author identity alone does
+  not.
 - Changing executor preserves useful published work; do not reset to `develop`, rebase, force-push, or create a duplicate PR.
 - When `develop` moves materially before handoff, normally merge current `origin/develop` into the feature branch and rerun
   exact-head proof. Do not use a stale green run as final evidence.
 - Preserve completed work when publication fails. Recover the existing commit/workspace rather than rebuilding by default.
+- Implementation publication is incomplete until the PR is ready for review and the canonical item has a verified guarded
+  `Review / Ready / ChatGPT` handoff.
 
-For Dependabot and other automation-owned PRs:
+For fork PRs:
+
+- review the contributor's exact head without privileged execution of untrusted code;
+- submit contributor-facing Request Changes and monitor for a new head;
+- do not autonomously push to the fork or adopt the branch;
+- create a linked internal replacement task only after an explicit routing decision.
+
+For Dependabot and other managed automation PRs:
 
 - review the bot's exact head directly when the update is self-contained;
-- request the bot's documented rebase rather than rewriting its branch for a stale base or conflict;
-- keep `Executor = ChatGPT` while waiting for that observable rebase and record the old head plus next observation point;
-- do not require or set `Implementer` merely to monitor the external operation;
+- request the documented rebase rather than rewriting its branch for a stale base or conflict;
+- keep `Executor = ChatGPT` while waiting and record old head plus next observation point;
+- do not require or set Implementer merely to monitor the external operation;
 - do not normally push compatibility fixes onto the bot branch;
-- create a linked issue and agent-owned replacement PR when implementation changes are required, selecting an Implementer for
-  that linked work;
+- create a linked issue and agent-owned replacement PR when implementation changes are required;
 - keep the source PR blocked/superseded with explicit links and rationale.
 
 ## Review and correction
@@ -118,6 +148,7 @@ For Dependabot and other automation-owned PRs:
 Review audits the whole acceptance-to-proof matrix, not only the visible delta. Inspect:
 
 - complete exact-head diff and scope;
+- every authoritative/closing issue and later decision;
 - architecture, module/API ownership, compatibility, lifecycle, and resource safety;
 - test design, discovery, and implementer proof;
 - dependencies, workflows, permissions, and standard-tooling rationale;
@@ -127,25 +158,32 @@ Review audits the whole acceptance-to-proof matrix, not only the visible delta. 
 
 Report independent findings together. One comprehensive Request Changes is better than serial discovery of unrelated blockers.
 
-A Request Changes result does not justify blindly assigning the external author as Implementer. For a Sniffy-owned implementation
-PR, return to its already selected implementation route. For an external PR with empty Implementer, either keep the PR in Review
-while the external author updates it voluntarily, or route deliberate replacement/correction work through Planning with a
-supported Implementer.
+A Request Changes result does not justify assigning the PR author as Implementer. Choose among:
+
+- same-repository focused correction by ChatGPT on the exact branch;
+- same-repository complex/persistent correction by Local Codex adopted continuation;
+- contributor-owned correction for a fork PR;
+- documented bot operation for Dependabot/managed automation;
+- linked internal replacement task when direct branch correction is unsafe or inappropriate;
+- return to Planning when scope, canonicalization, architecture, or proof is unresolved.
+
+After correction, the implementation worker publishes a new exact head and hands the same canonical item back to Review. Do not
+create a second issue or PR solely because ownership changed.
 
 ### Convergence checkpoint
 
 The checkpoint is not a timer and does not create another process. It is a required Review decision inside the normal lifecycle.
 
 Trigger it when a substantive Request Changes returned work to Implementation, the corrected head came back to Review, and the
-next complete Review still finds substantive blockers. Before another correction dispatch, ChatGPT performs the critical
-analysis in [`routing.md`](routing.md): verify the issue, architecture, acceptance criteria, proof strategy, executor capability,
-and whether another narrow patch would converge.
+next complete Review still finds substantive blockers. Before another correction dispatch, ChatGPT performs the critical analysis
+in [`routing.md`](routing.md): verify the canonical item, architecture, acceptance criteria, proof strategy, executor capability,
+branch continuity, and whether another narrow patch would converge.
 
 The checkpoint must explicitly choose one route:
 
 - continue the same executor with coherent superseding guidance;
-- preserve the branch/PR and escalate continuation to Local Codex;
-- return to Planning and re-baseline the architecture/requirements/proof matrix;
+- preserve/adopt the branch and PR and escalate continuation to Local Codex;
+- return to Planning and re-baseline architecture/requirements/canonicalization/proof;
 - block for one exact Dmitry decision or action.
 
 Do not automatically send a third list of local edits. Do not automatically escalate for infrastructure noise or an ordinary
@@ -159,24 +197,25 @@ acknowledged. The convergence checkpoint itself needs no schedule.
 Formal review must use an identity independent from the PR author.
 
 - When independent review is available and proof passes, submit `APPROVE`.
-- When blockers remain, submit one precise `REQUEST_CHANGES`, then explicitly return the task to an already selected internal
-  Implementation route or create the linked replacement task required by PR intake policy.
+- When blockers remain, submit one precise `REQUEST_CHANGES`, then explicitly route the canonical item to an implementation or
+  external-author correction path.
 - When the active identity cannot review its own PR, leave exact ready-for-Dmitry-review or blocking feedback and state the
   identity limitation.
 
-A Dependabot-authored PR is independent from `bedrin-gpt`, so ChatGPT may formally approve or request changes after a complete
-exact-head review. That identity rule comes from the PR author, not the optional Project Implementer field.
+A Dmitry-, Dependabot-, external-contributor-, or other independently authored PR may receive a formal `bedrin-gpt` review.
+A `bedrin-gpt`-authored PR cannot. That identity rule comes from the PR author, not the optional Project Implementer field.
 
 ## Target-comment noise policy
 
 The central control issue stores technical Project transition commands. Do not post claim intents, field commands, lease
 arbitration, polling notices, or winner/loser messages on the target item.
 
-The target issue/PR should contain only human-useful plans, review decisions, publication/verification evidence, real blockers,
-and meaningful handoffs. Preserve technical control commands for troubleshooting in the rotating log rather than deleting them.
+The canonical issue/PR should contain only human-useful plans, review decisions, publication/verification evidence, real blockers,
+and meaningful handoffs. Linked PR review conversations remain the right place for formal reviews and inline findings. Preserve
+technical control commands for troubleshooting in the rotating log rather than deleting them.
 
 ## Merge and privileged boundaries
 
 No agent or supervising workflow may merge, enable auto-merge, bypass protection, rewrite shared history, or perform privileged
 repository/hosting operations without Dmitry's explicit instruction. `Approval / Ready` is the human acceptance queue. This
-boundary also applies to Dependabot even though GitHub supports bot commands and auto-merge.
+boundary applies to all PR sources.


### PR DESCRIPTION
Stacked on #765.

## Problem

The current event loop only reconciles dependency PRs and ordinary queue work that is already materialized in Project 2. A ready same-repository PR created outside the delivery flow—such as Dmitry coding with Codex in IntelliJ—can therefore remain invisible even when its CI is green. PR #763 exposed the same gap after its linked issue was not materialized and no canonical Implementation-to-Review handoff occurred.

GitHub issues and pull requests are both valid Project items, but the delivery policy did not define which one owns lifecycle state when both describe the same implementation.

## Design

Introduce universal PR intake for every open PR targeting `develop`, regardless of author, label, bot/provider, branch creator, or whether an issue existed first.

Canonicalization is deterministic:

- exactly one formal closing issue: the issue is canonical and the PR is exact-head implementation evidence;
- no formal closing issue: the non-draft PR itself is canonical;
- multiple formal closing issues: the PR is canonical in Planning until combined scope, proof, and completion propagation are resolved;
- draft PRs are monitored only when an existing canonical item already owns their Implementation; they do not enter Review;
- accidental issue/PR duplicate representation must not produce duplicate Review or workers.

## Existing PR continuation

A same-repository PR may be adopted for correction even when Dmitry, ChatGPT, an IDE agent, or another configured worker created it:

- preserve the exact branch and PR;
- route a deliberate Implementer/Executor through the canonical item;
- use Local Codex by default for complex, persistent, or existing-PR continuation;
- do not reset, rebase, force-push, restart from `develop`, or create a replacement PR merely because executor ownership changed.

Fork and Dependabot branches are not adopted for direct autonomous correction. They use contributor feedback, documented bot commands, or a linked internal replacement task.

Codex Cloud remains the preferred external executor for suitable bounded fresh work and must not turn arbitrary existing PRs into duplicate fresh branches/PRs.

## Changes

- replace dependency-only ChatGPT intake with universal develop-PR scanning and canonicalization;
- define canonical issue/PR lifecycle semantics across lifecycle, event-loop, routing, supervision, and intake docs;
- expand the Local Codex dispatcher and worker templates to accept canonical Issue or PullRequest items and an explicit `adopted-continuation` mode;
- document the Cloud boundary for arbitrary existing PRs;
- add profile knobs for universal intake, canonicalization, and existing-PR continuation routing;
- add delivery-policy contract tests and run them from the existing least-privilege `AI delivery control` validation job whenever canonical prompts/docs change.

## Compatibility and permissions

- depends on #765's optional-Implementer semantics;
- does not change the `delivery-control/v1` runtime mutation implementation;
- adds no workflow job, secret, write permission, event trigger, merge behavior, or privileged operation;
- retains the existing `Dependabot` Project option without using it for automatic routing;
- does not enable blind `is:pr is:open` Project auto-add as a substitute for canonicalization.

## Validation

- `AI delivery control` run `30580894936`: success on exact head;
  - delivery-control syntax and tests passed;
  - universal PR intake/canonicalization policy tests passed;
  - Local Codex adopted-continuation and Cloud duplicate-prevention contracts passed;
  - workflow/profile YAML parsing passed.
- `Check Pull Request` run `30580894978`: in progress at the time of this update.

The first policy-contract run exposed two overly literal assertions around Markdown line wrapping; the assertions were corrected without changing policy semantics, and the replacement exact-head run passed.

## Limitations and rollout

- This is a policy/prompt adapter, not a new event-driven GitHub workflow. Stateless ChatGPT ticks perform the universal scan and guarded canonicalization.
- Existing long-lived Scheduled Task definitions retain their embedded prompt text until manually replaced, but every tick still rereads current repository policy.
- After merge, smoke-test a standalone maintainer PR, a single-linked-issue PR, a multi-issue PR, and one Local Codex adopted continuation.

## Published head

`d6a243107206256f820e96cb1891ea976821306d`
