### PR TITLE
Test post-mutation Review PR verification

### DIFF
--- a/.github/scripts/delivery-control-post-mutation.test.js
+++ b/.github/scripts/delivery-control-post-mutation.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {executeTransition} = require('./delivery-control');
+
+const head = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const movedHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function coreDouble() {
+  const summary = {
+    addHeading() { return this; },
+    addRaw() { return this; },
+    addTable() { return this; },
+    async write() {}
+  };
+  return {
+    summary,
+    setOutput() {}
+  };
+}
+
+function fixture() {
+  let status = 'Implementation';
+  let projectWritten = false;
+  let pullReads = 0;
+
+  const statusField = {
+    __typename: 'ProjectV2SingleSelectField',
+    id: 'STATUS',
+    name: 'Status',
+    options: [
+      {id: 'STATUS-IMPLEMENTATION', name: 'Implementation'},
+      {id: 'STATUS-REVIEW', name: 'Review'}
+    ]
+  };
+
+  function projectItem() {
+    return {
+      id: 'ITEM',
+      project: {id: 'PROJECT'},
+      fieldValues: {
+        nodes: [{
+          __typename: 'ProjectV2ItemFieldSingleSelectValue',
+          name: status,
+          field: {name: 'Status'}
+        }]
+      }
+    };
+  }
+
+  const github = {
+    async graphql(query, variables) {
+      if (query.includes('organization(login:')) {
+        return {
+          organization: {projectV2: {id: 'PROJECT', fields: {nodes: [statusField]}}},
+          repository: {
+            issueOrPullRequest: {
+              __typename: 'PullRequest',
+              id: 'TARGET',
+              headRefOid: head
+            }
+          }
+        };
+      }
+
+      if (query.includes('repository(owner:') && query.includes('pullRequest(number:')) {
+        pullReads += 1;
+        return {
+          repository: {
+            pullRequest: {
+              id: 'REVIEW',
+              number: variables.number,
+              state: 'OPEN',
+              isDraft: false,
+              baseRefName: 'develop',
+              headRefOid: projectWritten ? movedHead : head,
+              closingIssuesReferences: {nodes: []}
+            }
+          }
+        };
+      }
+
+      if (query.includes('projectItems(first: 50)')) {
+        return {node: {projectItems: {nodes: [projectItem()]}}};
+      }
+
+      if (query.includes('updateProjectV2ItemFieldValue')) {
+        assert.equal(variables.field, 'STATUS');
+        assert.deepEqual(variables.value, {singleSelectOptionId: 'STATUS-REVIEW'});
+        status = 'Review';
+        projectWritten = true;
+        return {updateProjectV2ItemFieldValue: {projectV2Item: {id: 'ITEM'}}};
+      }
+
+      throw new Error(`Unexpected GraphQL operation: ${query.slice(0, 80)}`);
+    }
+  };
+
+  return {
+    github,
+    get projectWritten() { return projectWritten; },
+    get pullReads() { return pullReads; }
+  };
+}
+
+test('rejects a Review transition when the PR head moves after the Project mutation', async () => {
+  const command = {
+    command: 'delivery-control/v1',
+    target: {repository: 'sniffy/sniffy', number: 748},
+    expected: {
+      type: 'PullRequest',
+      head,
+      fields: {Status: 'Implementation'}
+    },
+    set: {Status: 'Review'}
+  };
+  const state = fixture();
+
+  await assert.rejects(
+    executeTransition({
+      github: state.github,
+      core: coreDouble(),
+      payloadBase64: Buffer.from(JSON.stringify(command)).toString('base64')
+    }),
+    /Post-mutation pull request #748 was not open, non-draft, and at the guarded Review head/
+  );
+
+  assert.equal(state.projectWritten, true);
+  assert.equal(state.pullReads, 3);
+});

--- a/.github/workflows/delivery-control.yml
+++ b/.github/workflows/delivery-control.yml
@@ -8,6 +8,7 @@ on:
       - .codex/local/worker-task-prompt.md
       - .github/scripts/delivery-control.js
       - .github/scripts/delivery-control.test.js
+      - .github/scripts/delivery-control-post-mutation.test.js
       - .github/scripts/delivery-policy.test.js
       - .github/workflows/delivery-control.yml
       - docs/ai-delivery/**
@@ -39,8 +40,9 @@ jobs:
         run: |
           node --check .github/scripts/delivery-control.js
           node --check .github/scripts/delivery-control.test.js
+          node --check .github/scripts/delivery-control-post-mutation.test.js
           node --check .github/scripts/delivery-policy.test.js
-          node --test .github/scripts/delivery-control.test.js .github/scripts/delivery-policy.test.js
+          node --test .github/scripts/delivery-control.test.js .github/scripts/delivery-control-post-mutation.test.js .github/scripts/delivery-policy.test.js
       - name: Parse workflow and profile YAML
         run: >-
           ruby -e 'require "yaml";


### PR DESCRIPTION
## Problem

PR #767 now re-reads the guarded Review pull request after writing Project fields, but its behavioral tests did not prove that final verification step. A future refactor could remove or move the final read while the documentation-only policy assertion remained green.

## Change

- add a focused regression test that moves the PR head only after the Project mutation;
- assert that `executeTransition` rejects the transition through the post-mutation PR verification path;
- run the new test in the existing `AI delivery control` validation job and include it in the workflow path filter.

## Scope

This is a stacked PR targeting `agent/ready-pr-review-handoff` (PR #767). It does not change production behavior, permissions, triggers, or lifecycle semantics.

## Validation

- `AI delivery control` run `30586754488`: passed, including Node syntax checks, the new regression test, existing behavioral/policy tests, and YAML parsing.
- `Check Pull Request` run `30586754464`: still in progress; completed steps are green so far.

Local repository checkout is unavailable in this environment because `github.com` DNS resolution is blocked.

## Published head

`db57ee03ac50614b75a67cfcb9d77c0529d64624`