### PR TITLE
Fix Octokit creation in delivery control

### DIFF
--- a/.github/workflows/delivery-control.yml
+++ b/.github/workflows/delivery-control.yml
@@ -142,9 +142,8 @@ jobs:
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const actionsGithub = require('@actions/github');
             const control = require('./.github/scripts/delivery-control.js');
-            const repositoryGithub = actionsGithub.getOctokit(process.env.REPOSITORY_TOKEN);
+            const repositoryGithub = getOctokit(process.env.REPOSITORY_TOKEN);
             await control.executeTransition({
               github,
               repositoryGithub,


### PR DESCRIPTION
## Problem

`actions/github-script@v9` uses the ESM-only `@actions/github` v9 package. The delivery-control transition step still calls `require('@actions/github')`, so valid control commands fail at runtime before the guarded ProjectV2 mutation can execute.

## Change

Use the `getOctokit` factory injected directly into the `github-script@v9` script context:

```js
const repositoryGithub = getOctokit(process.env.REPOSITORY_TOKEN);
```

This preserves the existing two-token design: `github` continues to use `PROJECT_TOKEN`, while `repositoryGithub` uses the repository-scoped `GITHUB_TOKEN`.

## Impact

Restores guarded delivery-control transitions without changing permissions, command semantics, Project fields, or token scope. No dependency or compatibility changes.

## Validation

- Exact branch comparison against `develop`: one workflow file, 1 addition, 2 deletions
- Re-read the published workflow at the exact branch head and confirmed the injected `getOctokit` call
- `AI delivery control` run `30612737430` passed at the exact head:
  - shell syntax and Node syntax checks
  - delivery-control and delivery-policy test suites
  - workflow and profile YAML parsing
- Broader `Check Pull Request` run `30612737428` is still in progress

Local `actionlint` was not run because this execution environment has no repository checkout/network access and does not provide `gh` or `actionlint`.

## Published head

`dc568a646de94163eb9b32acf90bd6040685ecb6`

Reference: https://github.com/actions/github-script#v9