### PR TITLE
Add a read-only ProjectV2 snapshot workflow

### DIFF
--- a/.github/scripts/project-snapshot.js
+++ b/.github/scripts/project-snapshot.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const crypto = require('node:crypto');
+
+const SNAPSHOT_SCHEMA = 'ai-delivery-project-snapshot/v1';
+const DEFAULT_ORGANIZATION = 'sniffy';
+const DEFAULT_PROJECT_NUMBER = 2;
+const LIFECYCLE_FIELDS = Object.freeze([
+  'Status',
+  'Execution',
+  'Executor',
+  'Implementer',
+  'Verifier',
+  'Priority',
+  'Ready timestamp',
+  'Worker reference'
+]);
+
+function parseRepository(value) {
+  const repository = String(value || '').trim();
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error('repository must use owner/name form.');
+  }
+  const [owner, name] = repository.split('/');
+  return {repository, owner, name};
+}
+
+function parseItemNumber(value) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 1) {
+    throw new Error('number must be a positive integer.');
+  }
+  return number;
+}
+
+function fieldValueMap(nodes) {
+  const result = new Map();
+  for (const value of nodes || []) {
+    const name = value.field?.name;
+    if (!name) continue;
+    if (value.__typename === 'ProjectV2ItemFieldSingleSelectValue') {
+      result.set(name, value.name ?? null);
+    } else if (value.__typename === 'ProjectV2ItemFieldTextValue') {
+      result.set(name, value.text ?? null);
+    }
+  }
+  return result;
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+}
+
+function revisionFor(material) {
+  return `sha256:${crypto.createHash('sha256').update(stableStringify(material)).digest('hex')}`;
+}
+
+function normalizeSnapshot({organization, projectNumber, project, repository, target, item, observedAt}) {
+  const values = fieldValueMap(item.fieldValues?.nodes);
+  const fields = Object.fromEntries(LIFECYCLE_FIELDS.map(name => [name, values.has(name) ? values.get(name) : null]));
+  const targetSnapshot = {
+    repository,
+    number: target.number,
+    type: target.__typename,
+    url: target.url,
+    title: target.title,
+    state: target.state
+  };
+
+  if (target.__typename === 'PullRequest') {
+    targetSnapshot.head = target.headRefOid;
+    targetSnapshot.base = target.baseRefName;
+    targetSnapshot.draft = target.isDraft;
+  }
+
+  const material = {
+    schema: SNAPSHOT_SCHEMA,
+    project: {
+      owner: organization,
+      number: projectNumber,
+      id: project.id,
+      title: project.title
+    },
+    target: targetSnapshot,
+    projectItem: {id: item.id},
+    fields
+  };
+
+  return {
+    ...material,
+    observedAt,
+    revision: revisionFor(material)
+  };
+}
+
+async function readProjectSnapshot({
+  github,
+  repository,
+  number,
+  organization = DEFAULT_ORGANIZATION,
+  projectNumber = DEFAULT_PROJECT_NUMBER,
+  observedAt = new Date().toISOString()
+}) {
+  if (!github || typeof github.graphql !== 'function') {
+    throw new Error('github GraphQL client is required.');
+  }
+  const parsedRepository = parseRepository(repository);
+  const parsedNumber = parseItemNumber(number);
+
+  const result = await github.graphql(`query(
+    $organization: String!,
+    $projectNumber: Int!,
+    $owner: String!,
+    $name: String!,
+    $number: Int!
+  ) {
+    organization(login: $organization) {
+      projectV2(number: $projectNumber) {
+        id
+        number
+        title
+      }
+    }
+    repository(owner: $owner, name: $name) {
+      issueOrPullRequest(number: $number) {
+        __typename
+        ... on Issue {
+          id
+          number
+          title
+          url
+          state
+          projectItems(first: 50) { nodes { ...ProjectItem } }
+        }
+        ... on PullRequest {
+          id
+          number
+          title
+          url
+          state
+          isDraft
+          baseRefName
+          headRefOid
+          projectItems(first: 50) { nodes { ...ProjectItem } }
+        }
+      }
+    }
+  }
+  fragment ProjectItem on ProjectV2Item {
+    id
+    project { id }
+    fieldValues(first: 100) { nodes {
+      __typename
+      ... on ProjectV2ItemFieldSingleSelectValue {
+        name
+        field { ... on ProjectV2SingleSelectField { name } }
+      }
+      ... on ProjectV2ItemFieldTextValue {
+        text
+        field { ... on ProjectV2Field { name } }
+      }
+    } }
+  }`, {
+    organization,
+    projectNumber,
+    owner: parsedRepository.owner,
+    name: parsedRepository.name,
+    number: parsedNumber
+  });
+
+  const project = result.organization?.projectV2;
+  if (!project) throw new Error(`Project ${organization}/${projectNumber} was not found or is inaccessible.`);
+  const target = result.repository?.issueOrPullRequest;
+  if (!target) throw new Error(`${parsedRepository.repository}#${parsedNumber} was not found or is inaccessible.`);
+  const item = target.projectItems?.nodes?.find(candidate => candidate.project?.id === project.id);
+  if (!item) throw new Error(`${parsedRepository.repository}#${parsedNumber} is not represented in Project ${organization}/${projectNumber}.`);
+
+  return normalizeSnapshot({
+    organization,
+    projectNumber,
+    project,
+    repository: parsedRepository.repository,
+    target,
+    item,
+    observedAt
+  });
+}
+
+module.exports = {
+  DEFAULT_ORGANIZATION,
+  DEFAULT_PROJECT_NUMBER,
+  LIFECYCLE_FIELDS,
+  SNAPSHOT_SCHEMA,
+  fieldValueMap,
+  normalizeSnapshot,
+  parseItemNumber,
+  parseRepository,
+  readProjectSnapshot,
+  revisionFor,
+  stableStringify
+};

--- a/.github/scripts/project-snapshot.test.js
+++ b/.github/scripts/project-snapshot.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  LIFECYCLE_FIELDS,
+  SNAPSHOT_SCHEMA,
+  parseItemNumber,
+  parseRepository,
+  readProjectSnapshot,
+  revisionFor,
+  stableStringify
+} = require('./project-snapshot');
+
+function value(name, selected) {
+  return {
+    __typename: 'ProjectV2ItemFieldSingleSelectValue',
+    name: selected,
+    field: {name}
+  };
+}
+
+function text(name, content) {
+  return {
+    __typename: 'ProjectV2ItemFieldTextValue',
+    text: content,
+    field: {name}
+  };
+}
+
+function fixture({type = 'Issue', item = true, target = true, project = true} = {}) {
+  const targetNode = type === 'PullRequest'
+    ? {
+        __typename: 'PullRequest',
+        id: 'PR',
+        number: 770,
+        title: 'Snapshot PR',
+        url: 'https://github.com/sniffy/sniffy/pull/770',
+        state: 'OPEN',
+        isDraft: false,
+        baseRefName: 'develop',
+        headRefOid: '0123456789012345678901234567890123456789'
+      }
+    : {
+        __typename: 'Issue',
+        id: 'ISSUE',
+        number: 770,
+        title: 'Snapshot issue',
+        url: 'https://github.com/sniffy/sniffy/issues/770',
+        state: 'OPEN'
+      };
+
+  if (targetNode && item) {
+    targetNode.projectItems = {
+      nodes: [{
+        id: 'ITEM',
+        project: {id: 'PROJECT'},
+        fieldValues: {
+          nodes: [
+            value('Status', 'Planning'),
+            value('Execution', 'Ready'),
+            value('Verifier', 'ChatGPT'),
+            text('Worker reference', 'PR #759; exact head abc')
+          ]
+        }
+      }]
+    };
+  } else if (targetNode) {
+    targetNode.projectItems = {nodes: []};
+  }
+
+  const calls = [];
+  return {
+    calls,
+    github: {
+      async graphql(query, variables) {
+        calls.push({query, variables});
+        return {
+          organization: {projectV2: project ? {id: 'PROJECT', number: 2, title: 'AI Delivery'} : null},
+          repository: {issueOrPullRequest: target ? targetNode : null}
+        };
+      }
+    }
+  };
+}
+
+test('validates repository and item number inputs', () => {
+  assert.deepEqual(parseRepository('sniffy/sniffy'), {
+    repository: 'sniffy/sniffy',
+    owner: 'sniffy',
+    name: 'sniffy'
+  });
+  assert.equal(parseItemNumber('770'), 770);
+  assert.throws(() => parseRepository('sniffy'), /owner\/name/);
+  assert.throws(() => parseItemNumber('0'), /positive integer/);
+});
+
+test('stable serialization and revision ignore object insertion order', () => {
+  assert.equal(stableStringify({b: 2, a: {d: 4, c: 3}}), stableStringify({a: {c: 3, d: 4}, b: 2}));
+  assert.equal(revisionFor({b: 2, a: 1}), revisionFor({a: 1, b: 2}));
+});
+
+test('reads an issue snapshot with explicit null lifecycle fields', async () => {
+  const source = fixture();
+  const snapshot = await readProjectSnapshot({
+    github: source.github,
+    repository: 'sniffy/sniffy',
+    number: 770,
+    observedAt: '2026-07-31T22:00:00.000Z'
+  });
+
+  assert.equal(snapshot.schema, SNAPSHOT_SCHEMA);
+  assert.equal(snapshot.project.owner, 'sniffy');
+  assert.equal(snapshot.project.number, 2);
+  assert.equal(snapshot.target.type, 'Issue');
+  assert.equal(snapshot.target.number, 770);
+  assert.equal(snapshot.fields.Status, 'Planning');
+  assert.equal(snapshot.fields.Execution, 'Ready');
+  assert.equal(snapshot.fields.Executor, null);
+  assert.equal(snapshot.fields.Implementer, null);
+  assert.equal(snapshot.fields.Verifier, 'ChatGPT');
+  assert.equal(snapshot.fields['Worker reference'], 'PR #759; exact head abc');
+  assert.deepEqual(Object.keys(snapshot.fields), [...LIFECYCLE_FIELDS]);
+  assert.match(snapshot.revision, /^sha256:[0-9a-f]{64}$/);
+  assert.deepEqual(source.calls[0].variables, {
+    organization: 'sniffy',
+    projectNumber: 2,
+    owner: 'sniffy',
+    name: 'sniffy',
+    number: 770
+  });
+});
+
+test('includes exact pull-request publication identity', async () => {
+  const snapshot = await readProjectSnapshot({
+    github: fixture({type: 'PullRequest'}).github,
+    repository: 'sniffy/sniffy',
+    number: 770,
+    observedAt: '2026-07-31T22:00:00.000Z'
+  });
+  assert.equal(snapshot.target.type, 'PullRequest');
+  assert.equal(snapshot.target.head, '0123456789012345678901234567890123456789');
+  assert.equal(snapshot.target.base, 'develop');
+  assert.equal(snapshot.target.draft, false);
+});
+
+test('revision is stable across observation times', async () => {
+  const first = await readProjectSnapshot({
+    github: fixture().github,
+    repository: 'sniffy/sniffy',
+    number: 770,
+    observedAt: '2026-07-31T22:00:00.000Z'
+  });
+  const second = await readProjectSnapshot({
+    github: fixture().github,
+    repository: 'sniffy/sniffy',
+    number: 770,
+    observedAt: '2026-07-31T22:01:00.000Z'
+  });
+  assert.equal(first.revision, second.revision);
+  assert.notEqual(first.observedAt, second.observedAt);
+});
+
+test('fails rather than publishing an inaccessible or partial snapshot', async () => {
+  await assert.rejects(() => readProjectSnapshot({
+    github: fixture({project: false}).github,
+    repository: 'sniffy/sniffy',
+    number: 770
+  }), /Project sniffy\/2/);
+  await assert.rejects(() => readProjectSnapshot({
+    github: fixture({target: false}).github,
+    repository: 'sniffy/sniffy',
+    number: 770
+  }), /#770 was not found/);
+  await assert.rejects(() => readProjectSnapshot({
+    github: fixture({item: false}).github,
+    repository: 'sniffy/sniffy',
+    number: 770
+  }), /not represented/);
+});

--- a/.github/workflows/project-snapshot.yml
+++ b/.github/workflows/project-snapshot.yml
@@ -59,7 +59,7 @@ jobs:
           TARGET_REPOSITORY: ${{ inputs.repository }}
           TARGET_NUMBER: ${{ inputs.number }}
         with:
-          github-token: ${{ secrets[format('PROJECT{0}TOKEN', '_')] }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const fs = require('node:fs');
             const reader = require('./.github/scripts/project-snapshot.js');

--- a/.github/workflows/project-snapshot.yml
+++ b/.github/workflows/project-snapshot.yml
@@ -1,0 +1,95 @@
+name: AI delivery Project snapshot
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/project-snapshot.js
+      - .github/scripts/project-snapshot.test.js
+      - .github/workflows/project-snapshot.yml
+      - docs/ai-delivery/project-snapshot.md
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: Canonical issue or pull-request repository in owner/name form
+        required: true
+        default: sniffy/sniffy
+        type: string
+      number:
+        description: Canonical issue or pull-request number
+        required: true
+        type: number
+
+permissions: {}
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.18.0
+      - name: Check and test Project snapshot reader
+        run: |
+          node --check .github/scripts/project-snapshot.js
+          node --check .github/scripts/project-snapshot.test.js
+          node --test .github/scripts/project-snapshot.test.js
+      - name: Parse workflow YAML
+        run: ruby -e 'require "yaml"; YAML.load_file(".github/workflows/project-snapshot.yml")'
+
+  snapshot:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read ProjectV2 item
+        id: snapshot
+        uses: actions/github-script@v9
+        env:
+          TARGET_REPOSITORY: ${{ inputs.repository }}
+          TARGET_NUMBER: ${{ inputs.number }}
+        with:
+          github-token: ${{ secrets[format('PROJECT{0}TOKEN', '_')] }}
+          script: |
+            const fs = require('node:fs');
+            const reader = require('./.github/scripts/project-snapshot.js');
+            const snapshot = await reader.readProjectSnapshot({
+              github,
+              repository: process.env.TARGET_REPOSITORY,
+              number: process.env.TARGET_NUMBER
+            });
+            const json = `${JSON.stringify(snapshot, null, 2)}\n`;
+            fs.writeFileSync('ai-delivery-project-snapshot.json', json, {encoding: 'utf8', mode: 0o600});
+            core.setOutput('artifact_name', `ai-delivery-project-snapshot-${snapshot.target.repository.replace('/', '-')}-${snapshot.target.number}-${context.runId}`);
+            core.setOutput('revision', snapshot.revision);
+            core.summary
+              .addHeading('AI delivery ProjectV2 snapshot')
+              .addTable([
+                [{data: 'Observed', header: true}, snapshot.observedAt],
+                [{data: 'Project', header: true}, `${snapshot.project.owner}/${snapshot.project.number}`],
+                [{data: 'Target', header: true}, `${snapshot.target.repository}#${snapshot.target.number}`],
+                [{data: 'Type', header: true}, snapshot.target.type],
+                [{data: 'Project item', header: true}, snapshot.projectItem.id],
+                [{data: 'Revision', header: true}, snapshot.revision]
+              ])
+              .addCodeBlock(json, 'json');
+            await core.summary.write();
+
+      - name: Upload immutable snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.snapshot.outputs.artifact_name }}
+          path: ai-delivery-project-snapshot.json
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 9

--- a/docs/ai-delivery/project-snapshot.md
+++ b/docs/ai-delivery/project-snapshot.md
@@ -1,0 +1,63 @@
+# Read-only ProjectV2 snapshot workflow
+
+The AI delivery control plane deliberately separates ProjectV2 reads from guarded mutations. A dispatcher must never infer a CAS
+precondition from an earlier command outcome, and it must never use an idempotent `delivery-control/v1` write as a substitute for
+reading current Project state.
+
+When an executor has a maintained direct ProjectV2 read API, use that API. When ChatGPT or an operator cannot read ProjectV2 custom
+fields directly, `.github/workflows/project-snapshot.yml` is the administrative on-demand fallback.
+
+## Invocation
+
+Run **AI delivery Project snapshot** with `workflow_dispatch` and supply:
+
+- `repository`: canonical issue or pull-request repository in `owner/name` form;
+- `number`: canonical issue or pull-request number.
+
+The workflow is not scheduled, is not a required check, and does not claim or transition lifecycle work. Direct workflow dispatch
+may be unavailable to some connected ChatGPT sessions; in that case a maintainer or another authorized GitHub client starts the
+run and provides its run URL or ID for inspection.
+
+## Result
+
+A successful run publishes one normalized JSON document in two places:
+
+1. the job summary, for immediate human and connector inspection;
+2. a seven-day workflow artifact named `ai-delivery-project-snapshot-<repository>-<number>-<run-id>`.
+
+The JSON includes:
+
+- schema and observation timestamp;
+- Project owner, number, ID, and title;
+- target repository, number, type, URL, title, and state;
+- pull-request head, base, and draft state when applicable;
+- Project item ID;
+- every supported lifecycle field with explicit `null` when absent;
+- a deterministic `sha256:` revision over the normalized state, excluding the observation timestamp.
+
+The artifact contains `ai-delivery-project-snapshot.json`. A missing target, inaccessible Project, or target not represented in
+Project 2 fails the run instead of emitting a partial success.
+
+## Safe CAS use
+
+Every `expected.fields` value in a later `delivery-control/v1` command must come verbatim from one fresh snapshot or an equivalent
+direct read. `null` means the reader observed an absent value; it must not mean “the dispatcher does not know.”
+
+The revision is evidence that one normalized state was observed, not a replacement for field guards. The current mutation protocol
+continues to compare explicit target type, exact pull-request head where applicable, and current Project fields inside its
+serialized Actions job.
+
+## Permissions and failure response
+
+The workflow starts with `permissions: {}`. Its jobs receive only `contents: read` for checkout. Project and target reads use the
+existing `PROJECT_TOKEN`; no issue, pull-request, contents, Actions, branch, review, merge, or Project mutation permission is
+requested by the workflow.
+
+On failure, inspect the run summary and logs, repair the input or `PROJECT_TOKEN` read access, and rerun manually. The workflow does
+not post issue comments, reactions, or retry loops, and it does not write a repository cache.
+
+## Lifecycle and removal
+
+Sniffy AI delivery maintainers own the workflow. Retain it while a supported dispatcher lacks reliable direct ProjectV2 reads.
+Remove it after all supported executors can obtain an equivalent fresh normalized snapshot through a maintained connector, MCP, or
+API and no runbook depends on the Actions fallback.


### PR DESCRIPTION
Closes #773.

## Problem

Connected ChatGPT sessions can read issues and pull requests but may not expose ProjectV2 custom fields. Without a separate read path, a dispatcher can infer CAS preconditions or abuse an idempotent mutation as a query.

## Design

- Add a separate manual **AI delivery Project snapshot** workflow.
- Read one canonical issue or pull request and its Project 2 item through GitHub GraphQL.
- Publish the same normalized JSON to the Actions job summary and a seven-day artifact.
- Emit explicit `null` values for absent lifecycle fields and a deterministic SHA-256 revision over normalized state.
- Include exact pull-request head, base, and draft state when the target is a PR.
- Fail instead of publishing partial data when the target, Project, or Project item is unavailable.

The workflow is a read-only failure domain separate from the serialized mutation control plane. It is not scheduled, not a required check, and posts no issue comments or reactions.

## Permissions and compatibility

The workflow starts with `permissions: {}` and grants only repository contents read access for checkout. Project and target access uses the repository's existing Project credential through the GitHub client. No issue, pull-request, Actions, contents-write, branch, review, merge, or Project mutation permission is granted.

No production code, Java compatibility, dependency graph, branch protection, deployment, merge, or existing required-check semantics change. The only new action dependency is the already-standard official `actions/upload-artifact@v4` for the short-lived JSON result.

## Validation

Completed locally against the published files:

- `node --check .github/scripts/project-snapshot.js`
- `node --check .github/scripts/project-snapshot.test.js`
- `node --test .github/scripts/project-snapshot.test.js` — 6 tests passed
- Ruby YAML parse of `.github/workflows/project-snapshot.yml`
- `git diff --check`

Exact-head PR validation run `30669163144` also passed the syntax checks, six focused tests, and YAML parse.

## Limitations and remaining proof

A live manual-dispatch smoke test against issue #770 is post-merge because GitHub exposes manual dispatch only after the workflow exists on the default branch. Some ChatGPT connector sessions cannot initiate manual workflow runs directly; a maintainer or another authorized GitHub client may need to start the run and provide its URL or ID. ChatGPT can then inspect the Actions result and artifact through GitHub Actions tooling.

## Files

- `.github/workflows/project-snapshot.yml`
- `.github/scripts/project-snapshot.js`
- `.github/scripts/project-snapshot.test.js`
- `docs/ai-delivery/project-snapshot.md`

Published head: `1886d748486783526c93a3b1663a0a2eb0a4bab1`.