### PR TITLE
ci: publish AI delivery Project status snapshots

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -30,15 +30,34 @@ Before any claim or mutation, read the current versions of:
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/profile.yml
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/lifecycle.md
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/control-plane.md
+- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/status-snapshot.md
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/event-loop.md
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/pull-request-intake.md
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/routing.md
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/supervision.md
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/verification.md
 - https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/executors/chatgpt.md
+- https://github.com/sniffy/sniffy/blob/develop/.chatgpt/status-snapshot-instructions.md
 
 Do not create another Scheduled Task, child ChatGPT task, or promise future/background work. Use this task/chat identifier plus
 the current UTC timestamp as the dispatcher reference.
+
+ProjectV2 read protocol:
+- Prefer a complete direct organization ProjectV2 read when the connected tool actually succeeds. If direct ProjectV2 access is
+  unavailable, incomplete, or fails, apply .chatgpt/status-snapshot-instructions.md before intake, reconciliation, continuation,
+  or ordinary queue selection.
+- Discover the newest open non-PR issue labeled ai-delivery-status; never hardcode its issue number. Parse and validate its pure
+  JSON pointer, require the configured protocol/repository/Project/artifact identity and freshness, then download the artifact by
+  numeric artifact ID through the default GitHub connector and read project-2-status.json.
+- Use only explicit snapshot field values, including null for absent values. Never infer Project state from prior chat turns,
+  issue prose, PR authorship, or defaults. Reject a missing, expired, inaccessible, malformed, mismatched, or stale snapshot and
+  make no snapshot-dependent claim or transition.
+- The snapshot is an eventually consistent selection aid, not a mutation ledger or lease. Re-read live issue/PR state, assignment,
+  formal closing links, branch/head, reviews, threads, and matching CI through GitHub before acting.
+- Every Project mutation still goes through delivery-control/v1, whose serialized workflow re-reads live ProjectV2 and verifies
+  expected and final values. A confused reaction means the snapshot lost a race; make no work mutation and do not retry from the
+  same snapshot. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command.
+- Never select issues labeled ai-delivery-control or ai-delivery-status as delivery work.
 
 ProjectV2 control protocol:
 - Every executor uses the same rotating technical control issue and delivery-control/v1 JSON commands documented in
@@ -46,8 +65,9 @@ ProjectV2 control protocol:
 - Locate the newest open issue with the configured ai-delivery-control label; create it with that label if none exists. Do not
   post /project-status, /project-field, claim-intent, winner, loser, withdrawal, lease, or polling comments on the target issue or
   pull request.
-- A claim or handoff is valid only after the command has the documented terminal reaction and the resulting Project fields have
-  been re-read.
+- A claim or handoff is valid only after the command has the documented terminal reaction. A +1 reaction means the control
+  workflow applied or observed the requested final state and verified it internally. When direct ProjectV2 reads are unavailable,
+  require a status snapshot generated after that command before any later dependent Project transition.
 - Use one guarded command for the complete multi-field claim or lifecycle transition. Include current Status, Execution,
   Executor, and exact PR head when applicable in expected state.
 - A command setting Status=Review must identify the exact review PR. For a canonical PR this is target + expected.head; for a
@@ -82,8 +102,9 @@ Perform this protocol:
    supported by a different head. Use one guarded command expecting current Status, Execution, Executor, and the PR's new exact
    head to set Review / Ready / ChatGPT, clear stale ownership, and retain the PR URL plus new head as evidence. Identify the PR
    structurally with target + expected.head when the PR is canonical, or reviewPullRequest.number/head when a canonical issue owns
-   it. Verify the terminal reaction, PR draft/head, and canonical Project state. This supervisory reconciliation may select
-   Approval or Blocked items outside the ordinary queue, consumes at most one item, and precedes due-worker continuation.
+   it. Verify the terminal reaction, PR draft/head, and canonical Project state directly or through the required post-command
+   status snapshot. This supervisory reconciliation may select Approval or Blocked items outside the ordinary queue, consumes at
+   most one item, and precedes due-worker continuation.
 3. Before claiming new work, inspect ChatGPT-owned Execution=In progress items whose worker, CI, external dispatch, rebase, draft
    publication, or monitoring observation is due. Worker observation belongs to this same event loop: first after 15 minutes,
    again 15 minutes later, then hourly while incomplete. Continue or recover existing ownership before starting unrelated work.
@@ -100,8 +121,9 @@ Perform this protocol:
 6. Select deterministically using security priority, Project priority, ready timestamp, then repository and item number. Never
    create a duplicate Project item, worker, branch, or pull request.
 7. Claim with one guarded delivery-control/v1 command. Set Execution=In progress plus the concrete tick/worker reference and
-   lease, inspect the terminal reaction, then re-read and verify ownership before work. If execution or external dispatch cannot
-   start, release to Ready. Set Blocked only when Dmitry must decide or act.
+   lease, inspect the terminal reaction, and verify ownership through direct ProjectV2 or the control workflow's internal +1
+   verification before work. If execution or external dispatch cannot start, release to Ready. Set Blocked only when Dmitry must
+   decide or act. Require a post-command status snapshot before a later dependent Project handoff.
 8. Perform exactly one lifecycle turn:
    - Planning: resolve outcome, canonical item, linked issues, decisions, non-goals, risk axes, Implementer when a future
      Implementation turn is actually needed, Verifier, and proof obligations. Do not use a PR author as a substitute for a
@@ -122,9 +144,11 @@ Perform this protocol:
      a representative environment. Do not rename unit tests or green CI as system verification.
 9. Publish human-useful evidence on the canonical target issue/PR. Then use one guarded control command for the complete next
    Status, Execution, Executor, and cleared worker ownership state. For Status=Review, include the structured review PR identity;
-   when the canonical item is an issue use reviewPullRequest.number/head. Inspect the terminal reaction and re-read both PR
-   draft/head state and Project fields before reporting the handoff. Update GitHub Assignee separately when supported and verify it.
-   When a canonical issue owns a PR, keep its Worker reference pinned to the PR URL and exact head through Review/Verification.
+   when the canonical item is an issue use reviewPullRequest.number/head. Inspect the terminal reaction and re-read PR draft/head
+   state. Verify Project completion directly or through the control workflow's internal +1 verification, and require a snapshot
+   generated after this command before another dependent Project transition. Update GitHub Assignee separately when supported and
+   verify it. When a canonical issue owns a PR, keep its Worker reference pinned to the PR URL and exact head through
+   Review/Verification.
 10. Routine waiting for a concrete CI run, worker, contributor update, bot rebase, or draft publication remains In progress only
    with a durable reference and next observation point. Blocked always routes an exact action to Human/bedrin.
 11. Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -1,0 +1,34 @@
+# Sniffy status-snapshot instructions for ChatGPT ticks
+
+Apply this supplement before Project intake, reconciliation, continuation, or ordinary queue selection when direct organization
+ProjectV2 reads are unavailable or fail.
+
+1. Search `sniffy/sniffy` for open issues labeled `ai-delivery-status`. Select the newest non-pull-request issue by issue number.
+   Never hardcode its number. Do not claim, assign, close, discuss work in, or add control commands to this technical issue.
+2. Parse the entire issue body as JSON. Require:
+   - `schemaVersion = 1`;
+   - `kind = ai-delivery-status/v1`;
+   - `source.repository = sniffy/sniffy`;
+   - `source.project.owner = sniffy` and `source.project.number = 2`;
+   - `artifact.name = ai-delivery-status-project-2`;
+   - a numeric `artifact.id` and file name `project-2-status.json`;
+   - `generatedAt` no older than `statusSnapshot.maxAgeMinutes` in `docs/ai-delivery/profile.yml`.
+3. Download that artifact by numeric ID with the default GitHub connector. Read `project-2-status.json` from the ZIP. Validate the
+   same schema/kind/repository/Project identity, require its `generatedAt` to match the pointer, and reject inconsistent counts or
+   an incomplete/malformed file.
+4. Use only the snapshot's explicit `fields`/`fieldValues` as ProjectV2 read state. An absent field value is represented as `null`;
+   do not infer it from prose, authorship, prior chat state, or defaults. The file contains active Sniffy items only. The raw files
+   are diagnostic and are not the ordinary queue.
+5. Re-read current issue/PR open/draft state, exact branch/head, formal closing links, assignment, reviews, threads, and matching CI
+   through live GitHub operations before acting. Snapshot source metadata never replaces those live reads.
+6. Use snapshot values to construct guarded `delivery-control/v1` expected fields. A successful mutation still depends on the
+   control workflow's live serialized ProjectV2 comparison and verification.
+7. On `confused`, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run. On
+   `+1`, the control workflow's internal final-state verification is authoritative for that command.
+8. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command. The status
+   workflow is triggered after delivery-control completion and also runs four times per hour. Do not chain dependent Project writes
+   from an older materialized view.
+9. If the status issue, pointer, artifact, or snapshot is missing, expired, inaccessible, malformed, mismatched, or stale, make no
+   snapshot-dependent Project claim or transition. Report the exact status-read blocker; do not guess.
+10. Exclude issues labeled `ai-delivery-control` or `ai-delivery-status` from canonical work selection even if Project automation
+    materialized them.

--- a/.github/scripts/delivery-status-policy.test.js
+++ b/.github/scripts/delivery-status-policy.test.js
@@ -15,7 +15,7 @@ test('ChatGPT scheduled ticks require the labeled status artifact fallback', () 
   const prompt = read('.chatgpt/scheduled-task-prompt.md');
   assert.match(prompt, /\.chatgpt\/status-snapshot-instructions\.md/);
   assert.match(prompt, /newest open non-PR issue labeled ai-delivery-status/i);
-  assert.match(prompt, /download the artifact by numeric artifact ID/i);
+  assert.match(prompt, /download the artifact by\s+numeric artifact ID/is);
   assert.match(prompt, /read project-2-status\.json/i);
   assert.match(prompt, /missing, expired, inaccessible, malformed, mismatched, or stale snapshot/i);
 });
@@ -43,7 +43,7 @@ test('status documentation preserves the read-only mutation boundary', () => {
   assert.match(documentation, /read-only materialized view/i);
   assert.match(documentation, /never\s+replaces.*guarded mutation protocol/is);
   assert.match(documentation, /No client may mutate Project fields directly from the snapshot/i);
-  assert.match(documentation, /newest open issue labeled `ai-delivery-status`/i);
+  assert.match(documentation, /newest open issue labeled ai-delivery-status/i);
 });
 
 test('workflow isolates validation and trusted status publication', () => {

--- a/.github/scripts/delivery-status-policy.test.js
+++ b/.github/scripts/delivery-status-policy.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.join(__dirname, '../..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+test('ChatGPT scheduled ticks require the labeled status artifact fallback', () => {
+  const prompt = read('.chatgpt/scheduled-task-prompt.md');
+  assert.match(prompt, /\.chatgpt\/status-snapshot-instructions\.md/);
+  assert.match(prompt, /newest open non-PR issue labeled ai-delivery-status/i);
+  assert.match(prompt, /download the artifact by numeric artifact ID/i);
+  assert.match(prompt, /read project-2-status\.json/i);
+  assert.match(prompt, /missing, expired, inaccessible, malformed, mismatched, or stale snapshot/i);
+});
+
+test('snapshot-backed commands retain live compare-and-set semantics', () => {
+  const prompt = read('.chatgpt/scheduled-task-prompt.md');
+  assert.match(prompt, /snapshot is an eventually consistent selection aid, not a mutation ledger or lease/i);
+  assert.match(prompt, /Every Project mutation still goes through delivery-control\/v1/i);
+  assert.match(prompt, /confused reaction means the snapshot lost a race/i);
+  assert.match(prompt, /snapshot generated after the preceding successful command/i);
+});
+
+test('profile fixes the status protocol, label, artifact and freshness contract', () => {
+  const profile = read('docs/ai-delivery/profile.yml');
+  assert.match(profile, /statusSnapshot:/);
+  assert.match(profile, /protocol:\s*ai-delivery-status\/v1/);
+  assert.match(profile, /issueLabel:\s*"ai-delivery-status"/);
+  assert.match(profile, /artifactName:\s*"ai-delivery-status-project-2"/);
+  assert.match(profile, /snapshotFile:\s*"project-2-status\.json"/);
+  assert.match(profile, /maxAgeMinutes:\s*30/);
+});
+
+test('status documentation preserves the read-only mutation boundary', () => {
+  const documentation = read('docs/ai-delivery/status-snapshot.md');
+  assert.match(documentation, /read-only materialized view/i);
+  assert.match(documentation, /never\s+replaces.*guarded mutation protocol/is);
+  assert.match(documentation, /No client may mutate Project fields directly from the snapshot/i);
+  assert.match(documentation, /newest open issue labeled `ai-delivery-status`/i);
+});
+
+test('workflow isolates validation and trusted status publication', () => {
+  const workflow = read('.github/workflows/delivery-status.yml');
+  assert.match(workflow, /permissions:\s*\{\}/);
+  assert.match(workflow, /cron:\s*'5,20,35,50 \* \* \* \*'/);
+  assert.match(workflow, /workflows:\s*\[AI delivery control\]/);
+  assert.match(workflow, /ref:\s*develop/);
+  assert.match(workflow, /issues:\s*write/);
+  assert.match(workflow, /pull-requests:\s*read/);
+  assert.doesNotMatch(workflow, /contents:\s*write/);
+});

--- a/.github/scripts/delivery-status.js
+++ b/.github/scripts/delivery-status.js
@@ -1,0 +1,359 @@
+'use strict';
+
+const fs = require('node:fs');
+
+const SCHEMA_VERSION = 1;
+const STATUS_KIND = 'ai-delivery-status/v1';
+const STATUS_LABEL = 'ai-delivery-status';
+const STATUS_TITLE = 'AI Delivery Status — Project 2';
+const TECHNICAL_LABELS = new Set(['ai-delivery-control', STATUS_LABEL]);
+const TERMINAL_PROJECT_STATUSES = new Set(['Draft', 'Done']);
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function lowerKeyMap(object) {
+  return new Map(Object.entries(object || {}).map(([key, value]) => [key.toLowerCase(), value]));
+}
+
+function fieldValue(item, fieldName) {
+  const values = lowerKeyMap(item);
+  if (!values.has(String(fieldName).toLowerCase())) return null;
+  const value = values.get(String(fieldName).toLowerCase());
+  return value === undefined ? null : value;
+}
+
+function repositoryName(item) {
+  const repository = item?.content?.repository ?? item?.repository ?? null;
+  if (typeof repository === 'string') return repository;
+  if (!repository || typeof repository !== 'object') return null;
+  return repository.nameWithOwner ?? repository.fullName ?? repository.name ?? null;
+}
+
+function labelNames(item) {
+  return asArray(item?.source?.labels ?? item?.labels ?? item?.content?.labels).flatMap(label => {
+    if (typeof label === 'string') return [label];
+    if (label && typeof label === 'object' && typeof label.name === 'string') return [label.name];
+    return [];
+  });
+}
+
+function contentType(item) {
+  return String(item?.content?.type ?? item?.type ?? '').toUpperCase();
+}
+
+function contentState(item) {
+  return String(item?.source?.state ?? item?.content?.state ?? item?.state ?? '').toUpperCase();
+}
+
+function isTechnicalItem(item) {
+  return labelNames(item).some(label => TECHNICAL_LABELS.has(label));
+}
+
+function isActiveItem(item) {
+  if (isTechnicalItem(item)) return false;
+
+  const type = contentType(item);
+  const state = contentState(item);
+  const status = fieldValue(item, 'Status');
+
+  if (type === 'DRAFT_ISSUE' || type === 'DRAFTISSUE') return true;
+  if (state === 'OPEN') return true;
+  if (!state) return true;
+  return !TERMINAL_PROJECT_STATUSES.has(status);
+}
+
+function normalizeField(field) {
+  return {
+    id: field?.id ?? null,
+    name: field?.name ?? null,
+    dataType: field?.type ?? field?.dataType ?? null,
+    options: field?.options ?? null,
+    configuration: field?.configuration ?? null
+  };
+}
+
+function normalizeContent(item) {
+  const content = item?.content ?? {};
+  const source = item?.source ?? {};
+  const type = content.type ?? item?.type ?? source.__typename ?? null;
+  return {
+    type,
+    repository: repositoryName(item),
+    number: content.number ?? item?.number ?? null,
+    url: content.url ?? item?.url ?? null,
+    title: source.title ?? content.title ?? item?.title ?? null,
+    state: source.state ?? content.state ?? item?.state ?? null,
+    stateReason: source.stateReason ?? null,
+    isDraft: source.isDraft ?? content.isDraft ?? content.draft ?? item?.isDraft ?? item?.draft ?? false,
+    mergedAt: source.mergedAt ?? null,
+    closedAt: source.closedAt ?? null,
+    headRefName: source.headRefName ?? null,
+    headRefOid: source.headRefOid ?? null,
+    baseRefName: source.baseRefName ?? null,
+    isCrossRepository: source.isCrossRepository ?? null,
+    author: source.author ?? content.author ?? item?.author ?? null,
+    createdAt: source.createdAt ?? content.createdAt ?? item?.createdAt ?? null,
+    updatedAt: source.updatedAt ?? content.updatedAt ?? item?.updatedAt ?? null,
+    labels: labelNames(item)
+  };
+}
+
+function normalizeItem(item, fields) {
+  const normalizedFields = fields.map(field => ({
+    fieldId: field.id,
+    name: field.name,
+    dataType: field.dataType,
+    value: fieldValue(item, field.name)
+  }));
+  return {
+    projectItemId: item?.id ?? null,
+    content: normalizeContent(item),
+    fields: Object.fromEntries(normalizedFields.map(field => [field.name, field.value])),
+    fieldValues: normalizedFields
+  };
+}
+
+function itemSortKey(item) {
+  const content = item.content;
+  return [
+    content.repository ?? '',
+    Number.isFinite(Number(content.number)) ? Number(content.number) : Number.MAX_SAFE_INTEGER,
+    String(content.type ?? ''),
+    content.title ?? '',
+    item.projectItemId ?? ''
+  ];
+}
+
+function compareKeys(left, right) {
+  const a = itemSortKey(left);
+  const b = itemSortKey(right);
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] < b[index]) return -1;
+    if (a[index] > b[index]) return 1;
+  }
+  return 0;
+}
+
+function verifyComplete(raw, collectionName) {
+  const values = asArray(raw?.[collectionName]);
+  const totalCount = raw?.totalCount;
+  if (Number.isInteger(totalCount) && totalCount > values.length) {
+    throw new Error(`${collectionName} export is incomplete: returned ${values.length} of ${totalCount}`);
+  }
+  return values;
+}
+
+function sourceIndex(values) {
+  return new Map(asArray(values).map(value => [Number(value.number), value]));
+}
+
+function attachSource(item, repository, issuesByNumber, pullRequestsByNumber) {
+  if (repositoryName(item) !== repository) return item;
+  const type = contentType(item);
+  const number = Number(item?.content?.number ?? item?.number);
+  if (type === 'DRAFT_ISSUE' || type === 'DRAFTISSUE') return item;
+  const source = type === 'PULLREQUEST' || type === 'PULL_REQUEST'
+    ? pullRequestsByNumber.get(number)
+    : issuesByNumber.get(number);
+  if (!source) {
+    throw new Error(`Missing live repository state for ${type || 'item'} #${number}`);
+  }
+  return {...item, source};
+}
+
+function buildSnapshot({fieldsRaw, itemsRaw, issuesRaw = [], pullRequestsRaw = [], generatedAt, repository, projectOwner, projectNumber, workflowRun}) {
+  const fields = verifyComplete(fieldsRaw, 'fields').map(normalizeField);
+  const allItems = verifyComplete(itemsRaw, 'items');
+  const issuesByNumber = sourceIndex(issuesRaw);
+  const pullRequestsByNumber = sourceIndex(pullRequestsRaw);
+  const enrichedItems = allItems.map(item => attachSource(item, repository, issuesByNumber, pullRequestsByNumber));
+  const activeItems = enrichedItems
+    .filter(isActiveItem)
+    .map(item => normalizeItem(item, fields))
+    .filter(item => !repository || item.content.repository === repository)
+    .sort(compareKeys);
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    kind: STATUS_KIND,
+    generatedAt,
+    source: {
+      repository,
+      project: {owner: projectOwner, number: Number(projectNumber)},
+      workflowRun
+    },
+    semantics: {
+      active: 'open source item, Project draft issue, or non-terminal closed/merged source item',
+      terminalProjectStatuses: [...TERMINAL_PROJECT_STATUSES],
+      excludedTechnicalLabels: [...TECHNICAL_LABELS]
+    },
+    counts: {
+      fieldCount: fields.length,
+      exportedItemCount: allItems.length,
+      activeItemCount: activeItems.length
+    },
+    fields,
+    items: activeItems
+  };
+}
+
+function pointerPayload({generatedAt, repository, projectOwner, projectNumber, artifact, workflowRun, counts}) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    kind: STATUS_KIND,
+    generatedAt,
+    source: {
+      repository,
+      project: {owner: projectOwner, number: Number(projectNumber)},
+      workflowRun
+    },
+    artifact: {
+      id: Number(artifact.id),
+      name: artifact.name,
+      url: artifact.url,
+      digest: artifact.digest,
+      snapshotFile: artifact.snapshotFile,
+      rawFieldsFile: artifact.rawFieldsFile,
+      rawItemsFile: artifact.rawItemsFile,
+      rawIssuesFile: artifact.rawIssuesFile,
+      rawPullRequestsFile: artifact.rawPullRequestsFile,
+      retentionDays: Number(artifact.retentionDays)
+    },
+    counts
+  };
+}
+
+async function ensureLabel({github, owner, repo, label = STATUS_LABEL}) {
+  try {
+    await github.rest.issues.getLabel({owner, repo, name: label});
+  } catch (error) {
+    if (error?.status !== 404) throw error;
+    await github.rest.issues.createLabel({
+      owner,
+      repo,
+      name: label,
+      color: '1d76db',
+      description: 'Machine-readable pointer to the latest AI delivery Project status artifact'
+    });
+  }
+}
+
+async function findOrCreateStatusIssue({github, owner, repo, label = STATUS_LABEL, title = STATUS_TITLE}) {
+  await ensureLabel({github, owner, repo, label});
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    labels: label,
+    state: 'open',
+    per_page: 100
+  });
+  const candidates = issues
+    .filter(issue => !issue.pull_request)
+    .sort((left, right) => right.number - left.number);
+  if (candidates.length > 0) {
+    return {issue: candidates[0], duplicateCount: candidates.length - 1, created: false};
+  }
+  const created = await github.rest.issues.create({
+    owner,
+    repo,
+    title,
+    labels: [label],
+    body: JSON.stringify({schemaVersion: SCHEMA_VERSION, kind: STATUS_KIND, state: 'initializing'}, null, 2)
+  });
+  return {issue: created.data, duplicateCount: 0, created: true};
+}
+
+async function publishStatusPointer({github, context, core, payload, label = STATUS_LABEL, title = STATUS_TITLE}) {
+  const {owner, repo} = context.repo;
+  const selected = await findOrCreateStatusIssue({github, owner, repo, label, title});
+  const body = `${JSON.stringify(payload, null, 2)}\n`;
+  const updated = await github.rest.issues.update({
+    owner,
+    repo,
+    issue_number: selected.issue.number,
+    title,
+    body,
+    labels: [label]
+  });
+
+  core.setOutput('status_issue_number', String(updated.data.number));
+  core.setOutput('status_issue_url', updated.data.html_url);
+  core.summary
+    .addHeading('AI delivery status pointer')
+    .addRaw(`Published artifact ${payload.artifact.id} to issue #${updated.data.number}.\n`);
+  if (selected.duplicateCount > 0) {
+    core.warning(`Found ${selected.duplicateCount + 1} open issues labeled ${label}; updated newest #${updated.data.number}.`);
+    core.summary.addRaw(`Warning: ${selected.duplicateCount} older open labeled issue(s) remain.\n`);
+  }
+  await core.summary.write();
+  return {issue: updated.data, ...selected};
+}
+
+function parseArguments(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value === undefined) throw new Error(`Invalid argument sequence near ${key ?? '<end>'}`);
+    result[key.slice(2)] = value;
+  }
+  return result;
+}
+
+function normalizeCommand(argv) {
+  const options = parseArguments(argv);
+  for (const required of ['fields', 'items', 'issues', 'pull-requests', 'output', 'generated-at', 'repository', 'project-owner', 'project-number', 'workflow-run-id']) {
+    if (!options[required]) throw new Error(`Missing --${required}`);
+  }
+  const fieldsRaw = JSON.parse(fs.readFileSync(options.fields, 'utf8'));
+  const itemsRaw = JSON.parse(fs.readFileSync(options.items, 'utf8'));
+  const issuesRaw = JSON.parse(fs.readFileSync(options.issues, 'utf8'));
+  const pullRequestsRaw = JSON.parse(fs.readFileSync(options['pull-requests'], 'utf8'));
+  const snapshot = buildSnapshot({
+    fieldsRaw,
+    itemsRaw,
+    issuesRaw,
+    pullRequestsRaw,
+    generatedAt: options['generated-at'],
+    repository: options.repository,
+    projectOwner: options['project-owner'],
+    projectNumber: options['project-number'],
+    workflowRun: {
+      id: Number(options['workflow-run-id']),
+      attempt: Number(options['workflow-run-attempt'] ?? 1),
+      event: options.event ?? null,
+      upstreamRunId: options['upstream-run-id'] ? Number(options['upstream-run-id']) : null,
+      headSha: options['head-sha'] ?? null
+    }
+  });
+  fs.writeFileSync(options.output, `${JSON.stringify(snapshot, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(snapshot.counts)}\n`);
+}
+
+if (require.main === module) {
+  try {
+    const [command, ...argv] = process.argv.slice(2);
+    if (command !== 'normalize') throw new Error(`Unknown command: ${command ?? '<missing>'}`);
+    normalizeCommand(argv);
+  } catch (error) {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  STATUS_KIND,
+  STATUS_LABEL,
+  STATUS_TITLE,
+  buildSnapshot,
+  ensureLabel,
+  fieldValue,
+  findOrCreateStatusIssue,
+  isActiveItem,
+  normalizeItem,
+  pointerPayload,
+  publishStatusPointer
+};

--- a/.github/scripts/delivery-status.js
+++ b/.github/scripts/delivery-status.js
@@ -7,7 +7,7 @@ const STATUS_KIND = 'ai-delivery-status/v1';
 const STATUS_LABEL = 'ai-delivery-status';
 const STATUS_TITLE = 'AI Delivery Status — Project 2';
 const TECHNICAL_LABELS = new Set(['ai-delivery-control', STATUS_LABEL]);
-const TERMINAL_PROJECT_STATUSES = new Set(['Draft', 'Done']);
+const TERMINAL_PROJECT_STATUSES = new Set(['Done']);
 
 function asArray(value) {
   return Array.isArray(value) ? value : [];
@@ -200,6 +200,10 @@ function buildSnapshot({fieldsRaw, itemsRaw, issuesRaw = [], pullRequestsRaw = [
 }
 
 function pointerPayload({generatedAt, repository, projectOwner, projectNumber, artifact, workflowRun, counts}) {
+  const artifactId = Number(artifact.id);
+  if (!Number.isSafeInteger(artifactId) || artifactId <= 0) {
+    throw new Error(`Invalid artifact id: ${artifact.id ?? '<missing>'}`);
+  }
   return {
     schemaVersion: SCHEMA_VERSION,
     kind: STATUS_KIND,
@@ -210,7 +214,7 @@ function pointerPayload({generatedAt, repository, projectOwner, projectNumber, a
       workflowRun
     },
     artifact: {
-      id: Number(artifact.id),
+      id: artifactId,
       name: artifact.name,
       url: artifact.url,
       digest: artifact.digest,

--- a/.github/scripts/delivery-status.js
+++ b/.github/scripts/delivery-status.js
@@ -43,6 +43,11 @@ function contentType(item) {
   return String(item?.content?.type ?? item?.type ?? '').toUpperCase();
 }
 
+function isDraftIssueType(type) {
+  const normalized = String(type ?? '').toUpperCase();
+  return normalized === 'DRAFT_ISSUE' || normalized === 'DRAFTISSUE';
+}
+
 function contentState(item) {
   return String(item?.source?.state ?? item?.content?.state ?? item?.state ?? '').toUpperCase();
 }
@@ -58,7 +63,7 @@ function isActiveItem(item) {
   const state = contentState(item);
   const status = fieldValue(item, 'Status');
 
-  if (type === 'DRAFT_ISSUE' || type === 'DRAFTISSUE') return true;
+  if (isDraftIssueType(type)) return true;
   if (state === 'OPEN') return true;
   if (!state) return true;
   return !TERMINAL_PROJECT_STATUSES.has(status);
@@ -153,7 +158,7 @@ function attachSource(item, repository, issuesByNumber, pullRequestsByNumber) {
   if (repositoryName(item) !== repository) return item;
   const type = contentType(item);
   const number = Number(item?.content?.number ?? item?.number);
-  if (type === 'DRAFT_ISSUE' || type === 'DRAFTISSUE') return item;
+  if (isDraftIssueType(type)) return item;
   const source = type === 'PULLREQUEST' || type === 'PULL_REQUEST'
     ? pullRequestsByNumber.get(number)
     : issuesByNumber.get(number);
@@ -172,7 +177,7 @@ function buildSnapshot({fieldsRaw, itemsRaw, issuesRaw = [], pullRequestsRaw = [
   const activeItems = enrichedItems
     .filter(isActiveItem)
     .map(item => normalizeItem(item, fields))
-    .filter(item => !repository || item.content.repository === repository)
+    .filter(item => !repository || item.content.repository === repository || isDraftIssueType(item.content.type))
     .sort(compareKeys);
 
   return {

--- a/.github/scripts/delivery-status.test.js
+++ b/.github/scripts/delivery-status.test.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  buildSnapshot,
+  findOrCreateStatusIssue,
+  pointerPayload,
+  publishStatusPointer
+} = require('./delivery-status');
+
+const fieldsRaw = {
+  totalCount: 4,
+  fields: [
+    {id: 'TITLE', name: 'Title', type: 'TITLE'},
+    {id: 'STATUS', name: 'Status', type: 'SINGLE_SELECT', options: [{id: 'DONE', name: 'Done'}]},
+    {id: 'EXECUTION', name: 'Execution', type: 'SINGLE_SELECT'},
+    {id: 'WORKER', name: 'Worker reference', type: 'TEXT'}
+  ]
+};
+
+function item(number, {state = 'OPEN', status = 'Planning', type = 'Issue', labels = [], execution, worker} = {}) {
+  return {
+    id: `ITEM-${number}`,
+    title: `Item ${number}`,
+    status,
+    execution,
+    'worker reference': worker,
+    labels: labels.map(name => ({name})),
+    content: {
+      type,
+      number,
+      state,
+      repository: 'sniffy/sniffy',
+      url: `https://github.com/sniffy/sniffy/issues/${number}`,
+      title: `Item ${number}`
+    }
+  };
+}
+
+function snapshot(items) {
+  const issuesRaw = [];
+  const pullRequestsRaw = [];
+  const projectItems = items.map(value => {
+    const copy = structuredClone(value);
+    const source = {
+      number: copy.content.number,
+      state: copy.content.state,
+      title: copy.content.title,
+      url: copy.content.url,
+      labels: copy.labels
+    };
+    delete copy.content.state;
+    if (String(copy.content.type).toLowerCase() === 'pullrequest') {
+      source.isDraft = copy.content.isDraft ?? false;
+      source.headRefName = 'agent/example';
+      source.headRefOid = '0123456789abcdef0123456789abcdef01234567';
+      source.baseRefName = 'develop';
+      source.isCrossRepository = false;
+      pullRequestsRaw.push(source);
+    } else if (String(copy.content.type).toLowerCase() !== 'draftissue') {
+      issuesRaw.push(source);
+    }
+    return copy;
+  });
+  return buildSnapshot({
+    fieldsRaw,
+    itemsRaw: {totalCount: projectItems.length, items: projectItems},
+    issuesRaw,
+    pullRequestsRaw,
+    generatedAt: '2026-08-01T00:00:00Z',
+    repository: 'sniffy/sniffy',
+    projectOwner: 'sniffy',
+    projectNumber: 2,
+    workflowRun: {id: 100, attempt: 1, event: 'schedule'}
+  });
+}
+
+test('normalizes every Project field and uses null for absent values', () => {
+  const result = snapshot([item(770, {execution: 'Ready'})]);
+  assert.deepEqual(result.items[0].fields, {
+    Title: 'Item 770',
+    Status: 'Planning',
+    Execution: 'Ready',
+    'Worker reference': null
+  });
+  assert.equal(result.items[0].fieldValues[1].fieldId, 'STATUS');
+});
+
+test('uses live repository metadata for pull-request state and exact head', () => {
+  const result = snapshot([item(11, {type: 'PullRequest'})]);
+  assert.equal(result.items[0].content.state, 'OPEN');
+  assert.equal(result.items[0].content.isDraft, false);
+  assert.equal(result.items[0].content.number, 11);
+  assert.equal(result.items[0].content.headRefName, 'agent/example');
+  assert.equal(result.items[0].content.headRefOid, '0123456789abcdef0123456789abcdef01234567');
+  assert.equal(result.items[0].content.baseRefName, 'develop');
+});
+
+test('keeps source and lifecycle drift while dropping terminal closed items', () => {
+  const result = snapshot([
+    item(1, {state: 'OPEN', status: 'Done'}),
+    item(2, {state: 'CLOSED', status: 'Review'}),
+    item(3, {state: 'CLOSED', status: 'Done'}),
+    item(4, {state: 'CLOSED', status: 'Draft'}),
+    item(5, {state: '', status: null, type: 'DraftIssue'})
+  ]);
+  assert.deepEqual(result.items.map(value => value.content.number), [1, 2, 5]);
+});
+
+test('excludes control and status issues from active work', () => {
+  const result = snapshot([
+    item(10, {labels: ['ai-delivery-control']}),
+    item(11, {labels: ['ai-delivery-status']}),
+    item(12)
+  ]);
+  assert.deepEqual(result.items.map(value => value.content.number), [12]);
+});
+
+test('orders items deterministically by repository, number, type and title', () => {
+  const result = snapshot([item(20), item(3), item(11, {type: 'PullRequest'})]);
+  assert.deepEqual(result.items.map(value => value.content.number), [3, 11, 20]);
+});
+
+test('fails closed when gh pagination output is incomplete', () => {
+  assert.throws(() => buildSnapshot({
+    fieldsRaw,
+    itemsRaw: {totalCount: 2, items: [item(1)]},
+    generatedAt: '2026-08-01T00:00:00Z',
+    repository: 'sniffy/sniffy',
+    projectOwner: 'sniffy',
+    projectNumber: 2,
+    workflowRun: {id: 100}
+  }), /items export is incomplete/);
+});
+
+test('fails closed when a represented issue has no live repository state', () => {
+  assert.throws(() => buildSnapshot({
+    fieldsRaw,
+    itemsRaw: {totalCount: 1, items: [item(1)]},
+    issuesRaw: [],
+    pullRequestsRaw: [],
+    generatedAt: '2026-08-01T00:00:00Z',
+    repository: 'sniffy/sniffy',
+    projectOwner: 'sniffy',
+    projectNumber: 2,
+    workflowRun: {id: 100}
+  }), /Missing live repository state for ISSUE #1/);
+});
+
+test('builds a machine-readable artifact pointer', () => {
+  const payload = pointerPayload({
+    generatedAt: '2026-08-01T00:00:00Z',
+    repository: 'sniffy/sniffy',
+    projectOwner: 'sniffy',
+    projectNumber: 2,
+    workflowRun: {id: 101, attempt: 1, event: 'schedule'},
+    artifact: {
+      id: '55',
+      name: 'ai-delivery-status-project-2',
+      url: 'https://github.com/example/artifacts/55',
+      digest: 'sha256:abc',
+      snapshotFile: 'project-2-status.json',
+      rawFieldsFile: 'project-fields.raw.json',
+      rawItemsFile: 'project-items.raw.json',
+      rawIssuesFile: 'repository-issues.raw.json',
+      rawPullRequestsFile: 'repository-pull-requests.raw.json',
+      retentionDays: '2'
+    },
+    counts: {activeItemCount: 1}
+  });
+  assert.equal(payload.artifact.id, 55);
+  assert.equal(payload.source.project.number, 2);
+  assert.equal(payload.artifact.snapshotFile, 'project-2-status.json');
+  assert.equal(payload.artifact.rawIssuesFile, 'repository-issues.raw.json');
+  assert.equal(payload.artifact.rawPullRequestsFile, 'repository-pull-requests.raw.json');
+});
+
+function githubDouble({issues = [], labelExists = true} = {}) {
+  const calls = [];
+  const issueApi = {
+    async getLabel() {
+      calls.push(['getLabel']);
+      if (!labelExists) { const error = new Error('missing'); error.status = 404; throw error; }
+      return {data: {name: 'ai-delivery-status'}};
+    },
+    async createLabel(input) { calls.push(['createLabel', input]); return {data: input}; },
+    async listForRepo() { throw new Error('paginate supplies results'); },
+    async create(input) { calls.push(['create', input]); return {data: {number: 99, html_url: 'https://example/99', ...input}}; },
+    async update(input) { calls.push(['update', input]); return {data: {number: input.issue_number, html_url: `https://example/${input.issue_number}`}}; }
+  };
+  return {
+    calls,
+    github: {
+      rest: {issues: issueApi},
+      async paginate() { return issues; }
+    }
+  };
+}
+
+test('creates the label and status issue when none exists', async () => {
+  const {github, calls} = githubDouble({labelExists: false});
+  const result = await findOrCreateStatusIssue({github, owner: 'sniffy', repo: 'sniffy'});
+  assert.equal(result.created, true);
+  assert.equal(result.issue.number, 99);
+  assert.ok(calls.some(([name]) => name === 'createLabel'));
+  assert.ok(calls.some(([name]) => name === 'create'));
+});
+
+test('selects the newest open labeled issue and reports duplicates', async () => {
+  const {github} = githubDouble({issues: [{number: 7}, {number: 9}, {number: 8, pull_request: {}}]});
+  const result = await findOrCreateStatusIssue({github, owner: 'sniffy', repo: 'sniffy'});
+  assert.equal(result.issue.number, 9);
+  assert.equal(result.duplicateCount, 1);
+});
+
+test('publishes pure JSON to the selected issue body', async () => {
+  const {github, calls} = githubDouble({issues: [{number: 12}]});
+  const outputs = {};
+  const core = {
+    summary: {addHeading() { return this; }, addRaw() { return this; }, async write() {}},
+    setOutput(name, value) { outputs[name] = value; },
+    warning() {}
+  };
+  const payload = {kind: 'ai-delivery-status/v1', artifact: {id: 55}};
+  await publishStatusPointer({github, context: {repo: {owner: 'sniffy', repo: 'sniffy'}}, core, payload});
+  const update = calls.find(([name]) => name === 'update')[1];
+  assert.deepEqual(JSON.parse(update.body), payload);
+  assert.deepEqual(update.labels, ['ai-delivery-status']);
+  assert.equal(outputs.status_issue_number, '12');
+});

--- a/.github/scripts/delivery-status.test.js
+++ b/.github/scripts/delivery-status.test.js
@@ -97,7 +97,7 @@ test('uses live repository metadata for pull-request state and exact head', () =
   assert.equal(result.items[0].content.baseRefName, 'develop');
 });
 
-test('keeps source and lifecycle drift while dropping terminal closed items', () => {
+test('keeps source and lifecycle drift while dropping only Done closed items', () => {
   const result = snapshot([
     item(1, {state: 'OPEN', status: 'Done'}),
     item(2, {state: 'CLOSED', status: 'Review'}),
@@ -105,7 +105,8 @@ test('keeps source and lifecycle drift while dropping terminal closed items', ()
     item(4, {state: 'CLOSED', status: 'Draft'}),
     item(5, {state: '', status: null, type: 'DraftIssue'})
   ]);
-  assert.deepEqual(result.items.map(value => value.content.number), [1, 2, 5]);
+  assert.deepEqual(result.items.map(value => value.content.number), [1, 2, 4, 5]);
+  assert.deepEqual(result.semantics.terminalProjectStatuses, ['Done']);
 });
 
 test('excludes control and status issues from active work', () => {
@@ -174,6 +175,19 @@ test('builds a machine-readable artifact pointer', () => {
   assert.equal(payload.artifact.snapshotFile, 'project-2-status.json');
   assert.equal(payload.artifact.rawIssuesFile, 'repository-issues.raw.json');
   assert.equal(payload.artifact.rawPullRequestsFile, 'repository-pull-requests.raw.json');
+});
+
+test('rejects a missing or nonnumeric artifact id before publishing a pointer', () => {
+  const common = {
+    generatedAt: '2026-08-01T00:00:00Z',
+    repository: 'sniffy/sniffy',
+    projectOwner: 'sniffy',
+    projectNumber: 2,
+    workflowRun: {id: 101},
+    counts: {}
+  };
+  assert.throws(() => pointerPayload({...common, artifact: {id: ''}}), /Invalid artifact id/);
+  assert.throws(() => pointerPayload({...common, artifact: {id: 'not-a-number'}}), /Invalid artifact id/);
 });
 
 function githubDouble({issues = [], labelExists = true} = {}) {

--- a/.github/scripts/delivery-status.test.js
+++ b/.github/scripts/delivery-status.test.js
@@ -19,7 +19,10 @@ const fieldsRaw = {
   ]
 };
 
-function item(number, {state = 'OPEN', status = 'Planning', type = 'Issue', labels = [], execution, worker} = {}) {
+function item(number, {state = 'OPEN', status = 'Planning', type = 'Issue', labels = [], execution, worker, repository} = {}) {
+  const itemRepository = repository === undefined
+    ? (String(type).toLowerCase() === 'draftissue' ? null : 'sniffy/sniffy')
+    : repository;
   return {
     id: `ITEM-${number}`,
     title: `Item ${number}`,
@@ -31,7 +34,7 @@ function item(number, {state = 'OPEN', status = 'Planning', type = 'Issue', labe
       type,
       number,
       state,
-      repository: 'sniffy/sniffy',
+      repository: itemRepository,
       url: `https://github.com/sniffy/sniffy/issues/${number}`,
       title: `Item ${number}`
     }
@@ -105,8 +108,18 @@ test('keeps source and lifecycle drift while dropping only Done closed items', (
     item(4, {state: 'CLOSED', status: 'Draft'}),
     item(5, {state: '', status: null, type: 'DraftIssue'})
   ]);
-  assert.deepEqual(result.items.map(value => value.content.number), [1, 2, 4, 5]);
+  assert.deepEqual(result.items.map(value => value.content.number), [5, 1, 2, 4]);
   assert.deepEqual(result.semantics.terminalProjectStatuses, ['Done']);
+});
+
+test('keeps repository-less Project drafts and excludes other repositories', () => {
+  const result = snapshot([
+    item(6, {state: '', type: 'DraftIssue'}),
+    item(7, {repository: 'other/example'})
+  ]);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0].content.type, 'DraftIssue');
+  assert.equal(result.items[0].content.repository, null);
 });
 
 test('excludes control and status issues from active work', () => {

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -1,0 +1,182 @@
+name: AI delivery status
+
+on:
+  pull_request:
+    paths:
+      - .chatgpt/scheduled-task-prompt.md
+      - .chatgpt/status-snapshot-instructions.md
+      - .github/scripts/delivery-status.js
+      - .github/scripts/delivery-status.test.js
+      - .github/workflows/delivery-status.yml
+      - docs/ai-delivery/README.md
+      - docs/ai-delivery/profile.yml
+      - docs/ai-delivery/status-snapshot.md
+  workflow_run:
+    workflows: [AI delivery control]
+    types: [completed]
+  schedule:
+    - cron: '5,20,35,50 * * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.18.0
+      - name: Check and test delivery status
+        run: |
+          node --check .github/scripts/delivery-status.js
+          node --check .github/scripts/delivery-status.test.js
+          node --test .github/scripts/delivery-status.test.js
+      - name: Parse workflow and profile YAML
+        run: >-
+          ruby -e 'require "yaml";
+          YAML.load_file(".github/workflows/delivery-status.yml");
+          YAML.load_file("docs/ai-delivery/profile.yml")'
+      - name: Lint GitHub Actions workflow
+        run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/delivery-status.yml
+
+  publish:
+    if: >-
+      github.event_name != 'pull_request' &&
+      (
+        github.event_name != 'workflow_run' ||
+        github.event.workflow_run.event != 'pull_request'
+      )
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    concurrency:
+      group: ai-delivery-status-${{ github.repository }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+
+      - name: Export Project fields and items
+        id: export
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          REPOSITORY_TOKEN: ${{ github.token }}
+          PROJECT_OWNER: sniffy
+          PROJECT_NUMBER: '2'
+          STATUS_REPOSITORY: sniffy/sniffy
+          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id || '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p status-artifact
+          generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          source_sha="$(git rev-parse HEAD)"
+
+          GH_TOKEN="$PROJECT_TOKEN" gh project field-list "$PROJECT_NUMBER" \
+            --owner "$PROJECT_OWNER" \
+            --limit 1000 \
+            --format json \
+            > status-artifact/project-fields.raw.json
+
+          GH_TOKEN="$PROJECT_TOKEN" gh project item-list "$PROJECT_NUMBER" \
+            --owner "$PROJECT_OWNER" \
+            --limit 1000 \
+            --format json \
+            > status-artifact/project-items.raw.json
+
+          GH_TOKEN="$REPOSITORY_TOKEN" gh issue list \
+            --repo "$STATUS_REPOSITORY" \
+            --state all \
+            --limit 1000 \
+            --json number,state,stateReason,title,url,author,labels,createdAt,updatedAt,closedAt \
+            > status-artifact/repository-issues.raw.json
+
+          GH_TOKEN="$REPOSITORY_TOKEN" gh pr list \
+            --repo "$STATUS_REPOSITORY" \
+            --state all \
+            --limit 1000 \
+            --json number,state,isDraft,mergedAt,closedAt,createdAt,updatedAt,title,url,author,labels,headRefName,headRefOid,baseRefName,isCrossRepository \
+            > status-artifact/repository-pull-requests.raw.json
+
+          node .github/scripts/delivery-status.js normalize \
+            --fields status-artifact/project-fields.raw.json \
+            --items status-artifact/project-items.raw.json \
+            --issues status-artifact/repository-issues.raw.json \
+            --pull-requests status-artifact/repository-pull-requests.raw.json \
+            --output status-artifact/project-2-status.json \
+            --generated-at "$generated_at" \
+            --repository "$STATUS_REPOSITORY" \
+            --project-owner "$PROJECT_OWNER" \
+            --project-number "$PROJECT_NUMBER" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --event "$GITHUB_EVENT_NAME" \
+            --upstream-run-id "$UPSTREAM_RUN_ID" \
+            --head-sha "$source_sha"
+
+          echo "generated_at=$generated_at" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "counts_json=$(jq -c '.counts' status-artifact/project-2-status.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Project status artifact
+        id: upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: ai-delivery-status-project-2
+          path: status-artifact/
+          if-no-files-found: error
+          retention-days: 2
+
+      - name: Publish latest artifact pointer
+        uses: actions/github-script@v9
+        env:
+          GENERATED_AT: ${{ steps.export.outputs.generated_at }}
+          COUNTS_JSON: ${{ steps.export.outputs.counts_json }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id || '' }}
+          SOURCE_SHA: ${{ steps.export.outputs.source_sha }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const status = require('./.github/scripts/delivery-status.js');
+            const workflowRun = {
+              id: Number(process.env.GITHUB_RUN_ID),
+              attempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+              event: process.env.GITHUB_EVENT_NAME,
+              upstreamRunId: process.env.UPSTREAM_RUN_ID ? Number(process.env.UPSTREAM_RUN_ID) : null,
+              headSha: process.env.SOURCE_SHA
+            };
+            const payload = status.pointerPayload({
+              generatedAt: process.env.GENERATED_AT,
+              repository: 'sniffy/sniffy',
+              projectOwner: 'sniffy',
+              projectNumber: 2,
+              workflowRun,
+              artifact: {
+                id: process.env.ARTIFACT_ID,
+                name: 'ai-delivery-status-project-2',
+                url: process.env.ARTIFACT_URL,
+                digest: process.env.ARTIFACT_DIGEST,
+                snapshotFile: 'project-2-status.json',
+                rawFieldsFile: 'project-fields.raw.json',
+                rawItemsFile: 'project-items.raw.json',
+                rawIssuesFile: 'repository-issues.raw.json',
+                rawPullRequestsFile: 'repository-pull-requests.raw.json',
+                retentionDays: 2
+              },
+              counts: JSON.parse(process.env.COUNTS_JSON)
+            });
+            await status.publishStatusPointer({github, context, core, payload});

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -125,9 +125,11 @@ jobs:
             --upstream-run-id "$UPSTREAM_RUN_ID" \
             --head-sha "$source_sha"
 
-          echo "generated_at=$generated_at" >> "$GITHUB_OUTPUT"
-          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-          echo "counts_json=$(jq -c '.counts' status-artifact/project-2-status.json)" >> "$GITHUB_OUTPUT"
+          {
+            echo "generated_at=$generated_at"
+            echo "source_sha=$source_sha"
+            echo "counts_json=$(jq -c '.counts' status-artifact/project-2-status.json)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload Project status artifact
         id: upload

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -7,6 +7,7 @@ on:
       - .chatgpt/status-snapshot-instructions.md
       - .github/scripts/delivery-status.js
       - .github/scripts/delivery-status.test.js
+      - .github/scripts/delivery-status-policy.test.js
       - .github/workflows/delivery-status.yml
       - docs/ai-delivery/README.md
       - docs/ai-delivery/profile.yml
@@ -37,7 +38,8 @@ jobs:
         run: |
           node --check .github/scripts/delivery-status.js
           node --check .github/scripts/delivery-status.test.js
-          node --test .github/scripts/delivery-status.test.js
+          node --check .github/scripts/delivery-status-policy.test.js
+          node --test .github/scripts/delivery-status.test.js .github/scripts/delivery-status-policy.test.js
       - name: Parse workflow and profile YAML
         run: >-
           ruby -e 'require "yaml";

--- a/docs/ai-delivery/README.md
+++ b/docs/ai-delivery/README.md
@@ -5,8 +5,8 @@ Codex Cloud, Local Codex, an IDE-hosted coding agent, automation such as Dependa
 control-plane documentation for delivery. Repository engineering rules remain in the nearest applicable `AGENTS.md`.
 
 The current Sniffy routing knobs live in [`profile.yml`](profile.yml). Shared semantics belong in Markdown; the profile selects
-current executors, identities, Local Codex model/effort, control-log rotation thresholds, default routes, and universal PR intake
-behavior without redefining the lifecycle.
+current executors, identities, Local Codex model/effort, control-log rotation thresholds, default routes, universal PR intake
+behavior, and the repository-owned Project status read model without redefining the lifecycle.
 
 ## Terminology
 
@@ -25,6 +25,7 @@ behavior without redefining the lifecycle.
 | Runbook | Environment- or procedure-specific operating instructions | Codex Cloud setup, local worker |
 | Task prompt | One launch or continuation request | a rendered worker prompt for an issue or PR |
 | Control command | Guarded provider-neutral ProjectV2 transition | one `delivery-control/v1` JSON comment |
+| Status snapshot | Eventually consistent read-only ProjectV2 materialization | artifact pointer in an `ai-delivery-status` issue |
 
 Roles, executors, identities, and PR provenance are independent. ChatGPT is the default supervisor, but it may also implement,
 review, or verify a task. Codex Cloud and Local Codex may perform the same implementer role in different environments. Model
@@ -88,6 +89,12 @@ All configured executors use the same central control-issue protocol for Project
 is reserved for human-useful plans, reviews, evidence, blockers, and handoffs. Omitted Project fields remain unchanged, and an empty
 optional field is valid state rather than a reason to invent a new select option. See [`control-plane.md`](control-plane.md).
 
+Clients without reliable direct organization ProjectV2 reads use the repository-owned status snapshot in
+[`status-snapshot.md`](status-snapshot.md). The snapshot is a read-only, eventually consistent selection aid. It never authorizes a
+mutation: every claim and handoff still goes through `delivery-control/v1`, whose workflow re-reads and verifies live ProjectV2
+state. A stale or unavailable snapshot blocks snapshot-dependent autonomous selection rather than permitting remembered or guessed
+field values.
+
 Dmitry owns product decisions, accepted risk, privileged repository/hosting operations, final acceptance, and merge authorization.
 ChatGPT owns issue refinement, universal PR intake/canonicalization, routing proposals, supervision, code review, verification
 coordination, control-log rotation, and clear handoff. An executor owns only the lifecycle turn and proof explicitly routed to it.
@@ -105,17 +112,26 @@ Use this precedence when instructions differ:
 7. The selected executor runbook or skill.
 8. The concrete task prompt.
 
+The status snapshot is not inserted into this authority order as a new ledger. It is a materialized view of current Project fields
+for readers that cannot query ProjectV2 directly. Live GitHub source state and guarded control verification remain authoritative
+for the operations they cover.
+
 Historical tick chats, Codex conversations, and Actions logs are telemetry and evidence, not the only copy of durable delivery
 state.
 
 ## Documentation map
 
-- [`profile.yml`](profile.yml) — current Sniffy Project, field, identity, routing, Local Codex, intake, and rotation configuration.
+- [`profile.yml`](profile.yml) — current Sniffy Project, field, identity, routing, Local Codex, intake, control, status-snapshot, and
+  rotation configuration.
 - [`lifecycle.md`](lifecycle.md) — statuses, execution states, canonical issue/PR rules, optional planned routing, and corrections.
 - [`control-plane.md`](control-plane.md) — one guarded mutation protocol, optional/omitted fields, control issue, concurrency,
   reactions, and rotation.
+- [`status-snapshot.md`](status-snapshot.md) — read-only Project materialization, labeled pointer issue, artifact format, freshness,
+  active-item semantics, permissions, and ChatGPT read procedure.
 - [`event-loop.md`](event-loop.md) — reusable clock, universal PR intake/canonicalization, dispatcher, claims, and provider adapters.
 - [`.chatgpt/scheduled-task-prompt.md`](../../.chatgpt/scheduled-task-prompt.md) — exact prompt for four ChatGPT Scheduled Tasks.
+- [`.chatgpt/status-snapshot-instructions.md`](../../.chatgpt/status-snapshot-instructions.md) — mandatory Project read supplement
+  for ChatGPT ticks when direct ProjectV2 access is unavailable.
 - [`pull-request-intake.md`](pull-request-intake.md) — arbitrary PR discovery, canonical issue/PR selection, drafts, forks,
   Dependabot, review, correction, and completion.
 - [`chat-retention.md`](chat-retention.md) — persistent Scheduled Task chats, compact outputs, and bounded manual rotation.
@@ -139,6 +155,11 @@ maintenance action. No Scheduled Task may rely on previous chat turns as state.
 A no-op tick creates no GitHub mutation. A productive tick performs at most one canonicalization/reconciliation or lifecycle turn
 directly, or makes one supported external dispatch. Scheduled ChatGPT ticks cannot create child Scheduled Tasks.
 
+When direct ProjectV2 reads are unavailable, each tick must apply the configured status-snapshot supplement before queue selection:
+find the newest open issue labeled `ai-delivery-status`, validate its JSON pointer and freshness, download the artifact by numeric
+ID through the default GitHub connector, and read the explicit normalized fields. Technical `ai-delivery-control` and
+`ai-delivery-status` issues are never canonical work. See [`status-snapshot.md`](status-snapshot.md).
+
 Every open PR targeting `develop` is scanned. A single linked issue remains canonical; a standalone PR becomes the Project item;
 a multi-issue PR enters Planning. Same-repository corrections can be adopted by ChatGPT or Local Codex on the exact existing
 branch/PR. Forks and managed-bot branches use contributor/bot operations or a linked replacement task.
@@ -149,9 +170,10 @@ intake does not select it.
 
 ## Provider-specific files
 
-- `.chatgpt/` contains copy-paste Scheduled Task prompts, not durable delivery state.
+- `.chatgpt/` contains copy-paste Scheduled Task prompts and connector-read supplements, not durable delivery state.
 - `.codex/` contains Codex environment scripts and launch prompts, not general repository policy.
 - `.github/workflows/delivery-control.yml` and `.github/scripts/delivery-control.js` implement the provider-neutral mutation bridge.
+- `.github/workflows/delivery-status.yml` and `.github/scripts/delivery-status.js` implement the read-only Project status bridge.
 - `.github/scripts/delivery-policy.test.js` protects the canonical universal-intake and adopted-continuation prompt contract.
 - `.github/copilot-instructions.md` is a small Copilot adapter pointing to `AGENTS.md` and this directory.
 - `.agents/skills/` contains optional reusable procedures that an executor invokes only when applicable.

--- a/docs/ai-delivery/profile.yml
+++ b/docs/ai-delivery/profile.yml
@@ -15,6 +15,23 @@ controlPlane:
   rotateAfterCommands: 500
   rotateAfterDays: 30
 
+statusSnapshot:
+  protocol: ai-delivery-status/v1
+  documentation: docs/ai-delivery/status-snapshot.md
+  chatgptInstructions: .chatgpt/status-snapshot-instructions.md
+  workflow: .github/workflows/delivery-status.yml
+  issueTitle: "AI Delivery Status — Project 2"
+  issueLabel: "ai-delivery-status"
+  artifactName: "ai-delivery-status-project-2"
+  snapshotFile: "project-2-status.json"
+  rawFieldsFile: "project-fields.raw.json"
+  rawItemsFile: "project-items.raw.json"
+  rawIssuesFile: "repository-issues.raw.json"
+  rawPullRequestsFile: "repository-pull-requests.raw.json"
+  maxAgeMinutes: 30
+  retentionDays: 2
+  scheduleMinutes: [5, 20, 35, 50]
+
 fields:
   status: Status
   execution: Execution

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -1,0 +1,182 @@
+# AI delivery status snapshot
+
+The status snapshot is a repository-owned, read-only materialized view of Sniffy organization Project 2 for clients that can read
+repository issues and Actions artifacts but cannot reliably query organization ProjectV2 directly. It complements, and never
+replaces, the guarded mutation protocol in [`control-plane.md`](control-plane.md).
+
+## Components
+
+```text
+Project 2
+  -> AI delivery status workflow
+      -> raw field and item exports
+      -> normalized active-item JSON
+      -> short-retention Actions artifact
+      -> newest open issue labeled ai-delivery-status
+           contains the latest artifact pointer as JSON
+```
+
+The status issue is discovered by label. Its number is intentionally not configuration. The workflow creates the label and issue
+when no open labeled issue exists and otherwise updates the newest open labeled issue. Older duplicates are not silently deleted;
+the workflow warns in its summary and readers still choose the newest open issue by number.
+
+The status issue is technical control-plane metadata. It is not a delivery work item, must not be claimed, and is excluded from the
+normalized active queue together with issues labeled `ai-delivery-control`.
+
+## Workflow triggers and freshness
+
+[`.github/workflows/delivery-status.yml`](../../.github/workflows/delivery-status.yml) runs:
+
+- at minute `5`, `20`, `35`, and `50` of every hour, ahead of the four ChatGPT event-loop slots;
+- after non-PR completions of the `AI delivery control` workflow, so guarded mutations are materialized promptly;
+- through `workflow_dispatch` for maintainer-authorized diagnosis or recovery;
+- in validation-only mode for pull requests changing this adapter.
+
+The publish job is serialized with `cancel-in-progress: false`. It always checks out trusted `develop`, including for
+`workflow_run`, so a completed pull-request validation run cannot inject untrusted code into the secret-bearing publication job.
+
+A ChatGPT tick accepts only the protocol, repository, Project number, artifact name, and files configured in
+[`profile.yml`](profile.yml). The pointer and snapshot `generatedAt` timestamps must be no older than the configured maximum age.
+A stale, missing, malformed, expired, or inaccessible snapshot blocks snapshot-dependent autonomous Project selection. It does not
+justify guessing Project fields from prior chats, issue prose, or remembered state.
+
+## Artifact contents
+
+Every successful run uploads one artifact named `ai-delivery-status-project-2` with two-day retention:
+
+- `project-2-status.json` — normalized active items and complete field definitions;
+- `project-fields.raw.json` — unmodified `gh project field-list` JSON;
+- `project-items.raw.json` — unmodified `gh project item-list` JSON;
+- `repository-issues.raw.json` — live issue state and metadata from `gh issue list --state all`;
+- `repository-pull-requests.raw.json` — live pull-request state, draft/head/base/ownership metadata, and labels from `gh pr list --state all`.
+
+The normalizer fails when GitHub reports more fields or items than were returned, rather than publishing a silently truncated view.
+Each normalized item contains:
+
+- Project item ID;
+- source type, repository, number, URL, title, state, draft flag, author, timestamps, and labels when available;
+- a `fields` object with every current Project field name represented, using `null` when the item has no value;
+- a `fieldValues` array preserving each field ID, name, data type, and value.
+
+Field definitions preserve IDs, data types, options, and configuration returned by GitHub CLI. Readers use field names for policy
+semantics and retain IDs/options for diagnosis; they must not invent values for missing fields.
+
+## Active-item semantics
+
+The normalized file includes:
+
+- open issues;
+- open pull requests, including drafts as source telemetry;
+- Project draft issues;
+- closed or merged source items whose Project `Status` is neither `Draft` nor `Done`, so lifecycle/source drift remains visible;
+- open source items even when their Project status is terminal, so inverse drift remains visible.
+
+It excludes technical items labeled `ai-delivery-control` or `ai-delivery-status`. The complete raw export remains available for
+incident investigation.
+
+The normalized snapshot is scoped to `sniffy/sniffy`. Project 2 may later contain other repositories; those items remain in the raw
+export but are not eligible in the Sniffy active view.
+
+## Pointer format
+
+The status issue body is one JSON object:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "ai-delivery-status/v1",
+  "generatedAt": "2026-08-01T00:05:00Z",
+  "source": {
+    "repository": "sniffy/sniffy",
+    "project": {"owner": "sniffy", "number": 2},
+    "workflowRun": {
+      "id": 123456789,
+      "attempt": 1,
+      "event": "schedule",
+      "upstreamRunId": null,
+      "headSha": "..."
+    }
+  },
+  "artifact": {
+    "id": 987654321,
+    "name": "ai-delivery-status-project-2",
+    "url": "...",
+    "digest": "sha256:...",
+    "snapshotFile": "project-2-status.json",
+    "rawFieldsFile": "project-fields.raw.json",
+    "rawItemsFile": "project-items.raw.json",
+    "rawIssuesFile": "repository-issues.raw.json",
+    "rawPullRequestsFile": "repository-pull-requests.raw.json",
+    "retentionDays": 2
+  },
+  "counts": {
+    "fieldCount": 8,
+    "exportedItemCount": 100,
+    "activeItemCount": 12
+  }
+}
+```
+
+Readers parse the body as JSON, reject unknown `kind` or `schemaVersion`, validate repository and Project identity, and use the
+numeric artifact ID with the default GitHub connector's artifact download operation. The artifact URL is diagnostic; it is not a
+credential and is not the primary download mechanism.
+
+## ChatGPT read procedure
+
+The exact Scheduled Task supplement lives in
+[`.chatgpt/status-snapshot-instructions.md`](../../.chatgpt/status-snapshot-instructions.md). In summary, every stateless tick:
+
+1. searches open `sniffy/sniffy` issues with label `ai-delivery-status` and selects the newest issue by number;
+2. parses and validates the pointer body and freshness;
+3. downloads the artifact by `artifact.id` through the default GitHub connector;
+4. reads `project-2-status.json`, validates its identity, timestamp, and counts, and then uses its explicit fields for Project
+   selection and guarded expected values;
+5. re-reads live issue/PR, branch, head, review, assignment, and CI state from GitHub before any claim or source mutation.
+
+The snapshot is not a lease and does not prove current ownership. A candidate may have changed after generation.
+
+## Consistency and mutation boundary
+
+The snapshot is eventually consistent. It is safe for discovery and deterministic candidate selection because every Project
+mutation still goes through `delivery-control/v1`, whose serialized workflow re-reads live ProjectV2 and rejects stale expected
+values before changing anything.
+
+For a snapshot-backed client:
+
+- `confused` means the snapshot/expected state lost a race; perform no work mutation and refresh later;
+- `-1` means an unexpected control failure; inspect the control run and do not infer final state;
+- `+1` means the control workflow applied or observed the requested final values and verified them internally.
+
+After `+1`, a later dependent Project transition must use a status snapshot generated after that command. Work that does not require
+another immediate Project write may proceed from the verified claim reaction plus live source state. The `workflow_run` trigger
+normally refreshes the pointer promptly after control completion, while the scheduled runs provide bounded recovery if that event is
+missed.
+
+No client may mutate Project fields directly from the snapshot, treat the status issue as a command channel, or bypass exact-head
+and expected-field guards.
+
+## Permissions and failure response
+
+The workflow starts with `permissions: {}`:
+
+- validation receives `contents: read` only;
+- publication receives `contents: read`, `issues: write`, and `pull-requests: read` only;
+- Project reads use the existing `PROJECT_TOKEN` through GitHub CLI;
+- artifact upload uses the Actions runtime and does not grant branch, merge, deployment, secret, or Project mutation authority.
+
+On repeated failure, inspect:
+
+- missing, expired, unapproved, or insufficient `PROJECT_TOKEN` Project access;
+- GitHub CLI Project output/schema changes;
+- pagination/truncation failures;
+- artifact upload failure;
+- repository issue or label write failure.
+
+The snapshot workflow is a non-required operational signal, not source CI. A failed run prevents snapshot-dependent autonomous
+selection until a fresh pointer exists; maintainers may use `workflow_dispatch` after correcting the cause.
+
+## Removal condition
+
+Remove this adapter when the default connected client can reliably read complete organization ProjectV2 state and discover the
+latest artifact directly, or when another repository-owned read model provides equivalent freshness, least privilege, auditability,
+and guarded-mutation compatibility.

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -68,8 +68,11 @@ The normalized file includes:
 - open issues;
 - open pull requests, including drafts as source telemetry;
 - Project draft issues;
-- closed or merged source items whose Project `Status` is neither `Draft` nor `Done`, so lifecycle/source drift remains visible;
+- closed or merged source items whose Project `Status` is not `Done`, so lifecycle/source drift remains visible;
 - open source items even when their Project status is terminal, so inverse drift remains visible.
+
+`Done` is the only terminal Project lifecycle status for this filter. In particular, a closed source issue that remains in Project
+`Draft`, `Planning`, `Implementation`, `Review`, `Verification`, or `Approval` stays visible for reconciliation.
 
 It excludes technical items labeled `ai-delivery-control` or `ai-delivery-status`. The complete raw export remains available for
 incident investigation.


### PR DESCRIPTION
## Summary

- add a read-only `AI delivery status` workflow that runs at `:05/:20/:35/:50`, after non-PR `AI delivery control` completions, and on manual dispatch;
- export complete Project 2 field/item JSON plus live repository issue/PR metadata, normalize the active Sniffy view, and upload one short-retention artifact;
- create the `ai-delivery-status` label and one open technical status issue when absent, then update the newest open labeled issue with a pure-JSON pointer to the latest artifact;
- teach the main ChatGPT Scheduled Task prompt to discover the labeled status issue, validate freshness, download the artifact by numeric ID, use explicit Project fields, and retain guarded live compare-and-set semantics;
- document the pointer/artifact schema, active-item semantics, freshness/failure behavior, least-privilege boundary, and exact connector read procedure.

Fixes #775.

## Consistency and safety

The artifact is an eventually consistent read model for discovery and expected-field construction only. Project mutations remain exclusively behind the serialized `delivery-control/v1` compare-and-set workflow, which re-reads live ProjectV2 state. Technical issues labeled `ai-delivery-control` or `ai-delivery-status` are excluded from the active work queue.

The active view keeps all open source items, repository-less Project draft items, and closed/merged items whose Project lifecycle has not reached `Done`, including closed items left in `Draft`, so source/lifecycle drift remains observable. Items from other repositories remain in the raw export but not the normalized Sniffy queue.

The workflow starts with `permissions: {}`. PR validation receives `contents: read`; publication receives only `contents: read`, `issues: write`, and `pull-requests: read`. Organization Project reads use the existing `PROJECT_TOKEN`; this workflow does not receive Project mutation, branch-write, merge, deployment, or secret-management authority. `workflow_run` publication always checks out trusted `develop` and ignores upstream PR runs.

## Validation

- syntax checks for the normalizer, focused tests, and policy-contract tests;
- `node --test .github/scripts/delivery-status.test.js .github/scripts/delivery-status-policy.test.js` — 18 tests passed;
- YAML parse for `.github/workflows/delivery-status.yml` and `docs/ai-delivery/profile.yml`;
- CLI normalization smoke fixture;
- `actionlint` including embedded shellcheck;
- `git diff --check` and complete PR diff inspection.

The first secret-bearing publication smoke test is intentionally post-merge/manual: it must verify actual Project access, artifact ID/digest, automatic label/issue creation, and download through the default GitHub connector.

No merge or auto-merge is authorized.