### PR TITLE
Return Request Changes from Verification to implementation

### DIFF
--- a/.github/scripts/review-return-verification.test.js
+++ b/.github/scripts/review-return-verification.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {commandFor} = require('./review-return');
+
+function selectValue(field, name) {
+  return {__typename: 'ProjectV2ItemFieldSingleSelectValue', name, field: {name: field}};
+}
+
+function textValue(field, text) {
+  return {__typename: 'ProjectV2ItemFieldTextValue', text, field: {name: field}};
+}
+
+test('returns a verified agent implementation to correction after Request Changes', () => {
+  const target = {
+    type: 'Issue',
+    number: 753,
+    pullRequest: {
+      number: 754,
+      branch: 'agent/playwright-1.62-coherent',
+      head: '9ff68a34f8c1dbdb3368ed5a0f4e1568ff7ebe49'
+    },
+    item: {
+      fieldValues: {
+        nodes: [
+          selectValue('Status', 'Verification'),
+          selectValue('Execution', 'Ready'),
+          selectValue('Implementer', 'Codex Cloud'),
+          selectValue('Executor', 'Local Codex'),
+          textValue('Worker reference', 'verification claim')
+        ]
+      }
+    }
+  };
+
+  const prepared = commandFor(target);
+  assert.equal(prepared.implementer, 'Codex Cloud');
+  assert.equal(prepared.command.expected.fields.Status, 'Verification');
+  assert.equal(prepared.command.expected.fields.Execution, 'Ready');
+  assert.equal(prepared.command.expected.fields.Executor, 'Local Codex');
+  assert.deepEqual(prepared.command.set, {
+    Status: 'Implementation',
+    Execution: 'Ready',
+    Executor: 'Codex Cloud',
+    'Worker reference': 'Continuation PR https://github.com/sniffy/sniffy/pull/754 (#754); branch agent/playwright-1.62-coherent; exact head 9ff68a34f8c1dbdb3368ed5a0f4e1568ff7ebe49'
+  });
+});

--- a/.github/scripts/review-return.js
+++ b/.github/scripts/review-return.js
@@ -5,7 +5,7 @@ const ORGANIZATION = 'sniffy';
 const PROJECT_NUMBER = 2;
 const BASE_BRANCH = 'develop';
 const AGENT_EXECUTORS = new Set(['ChatGPT', 'Codex Cloud', 'Local Codex']);
-const RETURNABLE_STATUSES = new Set(['Review', 'Approval']);
+const RETURNABLE_STATUSES = new Set(['Review', 'Verification', 'Approval']);
 const GUARDED_FIELDS = ['Status', 'Execution', 'Implementer', 'Executor', 'Worker reference'];
 
 function values(nodes) {
@@ -107,7 +107,7 @@ function commandFor(target) {
   const alreadyRouted = status === 'Implementation' && execution === 'Ready' && executor === implementer;
   const alreadyReturned = alreadyRouted && workerReference === desiredWorkerReference;
   if (!alreadyRouted && !RETURNABLE_STATUSES.has(status)) {
-    throw new Error(`Project item is ${status || '(clear)'}, not Review or Approval.`);
+    throw new Error(`Project item is ${status || '(clear)'}, not Review, Verification, or Approval.`);
   }
 
   const expectedFields = {};

--- a/.github/workflows/review-return.yml
+++ b/.github/workflows/review-return.yml
@@ -6,6 +6,7 @@ on:
       - .github/scripts/delivery-control.js
       - .github/scripts/review-return.js
       - .github/scripts/review-return.test.js
+      - .github/scripts/review-return-verification.test.js
       - .github/workflows/review-return.yml
       - docs/ai-delivery/review-return.md
   pull_request_review:
@@ -30,7 +31,10 @@ jobs:
         run: |
           node --check .github/scripts/review-return.js
           node --check .github/scripts/review-return.test.js
-          node --test .github/scripts/review-return.test.js
+          node --check .github/scripts/review-return-verification.test.js
+          node --test \
+            .github/scripts/review-return.test.js \
+            .github/scripts/review-return-verification.test.js
       - name: Parse workflow YAML
         run: ruby -e 'require "yaml"; YAML.load_file(".github/workflows/review-return.yml")'
       - name: Lint GitHub Actions workflow

--- a/docs/ai-delivery/review-return.md
+++ b/docs/ai-delivery/review-return.md
@@ -4,6 +4,8 @@
 
 When an authorized independent reviewer submits a formal `REQUEST_CHANGES` review on an agent-implemented pull request, the next action is implementation correction. This adapter returns the existing Project 2 work item to the original agent pool so the normal event loop can claim and continue the same branch and pull request.
 
+The formal review is also a maintainer feedback control after technical Review has already advanced the canonical item. A Request Changes submission therefore returns eligible work from `Review`, `Verification`, or `Approval`; Dmitry does not need to post a second dispatch comment merely because representative verification or human approval had already started.
+
 ## Trigger and target selection
 
 The `Return requested changes to implementer` workflow listens to submitted `pull_request_review` events. It runs only for same-repository pull requests targeting `develop`; it never checks out or executes the reviewed head.
@@ -20,7 +22,7 @@ The canonical item must already be represented in Project 2. A missing canonical
 
 The adapter uses the existing `delivery-control/v1` command shape and `executeTransition` implementation. It guards the current target type, exact head when the target is the PR, and the current `Status`, `Execution`, `Implementer`, `Executor`, and `Worker reference` values. For an issue-canonical continuation, the serialized transition re-reads the pull-request head immediately before and after Project mutation so a head change cannot silently publish a stale continuation reference.
 
-Eligible agent implementers are `ChatGPT`, `Codex Cloud`, and `Local Codex`. A successful formal Request Changes review applies:
+Eligible agent implementers are `ChatGPT`, `Codex Cloud`, and `Local Codex`. A successful formal Request Changes review from `Review`, `Verification`, or `Approval` applies:
 
 ```text
 Status: Implementation
@@ -31,7 +33,7 @@ Worker reference for a canonical PR: clear
 GitHub assignees: cleared and re-read as empty
 ```
 
-Replacing an issue's stale review claim with the durable PR/branch/head reference preserves adoption context while making the item pool-ready. A standalone PR carries its own identity and exact-head guard, so its stale Worker reference is cleared. Assignee release is complete only after a separate GitHub read confirms no assignee remains. An idempotent rerun still performs and verifies assignment release, including when Project mutation succeeded in an earlier attempt. The normal 15-minute event loop claims the item, continues the same branch and PR, and begins the standard 15-minute, 15-minute, then hourly supervision cycle after concrete dispatch.
+Replacing an issue's stale review or verification claim with the durable PR/branch/head reference preserves adoption context while making the item pool-ready. A standalone PR carries its own identity and exact-head guard, so its stale Worker reference is cleared. Assignee release is complete only after a separate GitHub read confirms no assignee remains. An idempotent rerun still performs and verifies assignment release, including when Project mutation succeeded in an earlier attempt. The normal 15-minute event loop claims the item, continues the same branch and PR, and begins the standard 15-minute, 15-minute, then hourly supervision cycle after concrete dispatch.
 
 `Blocked` work, human or automation implementers, fork pull requests, stale/superseded review decisions, and ambiguous Project representation are not automatically dispatched.
 


### PR DESCRIPTION
## Problem

The `Return requested changes to implementer` workflow handles formal `REQUEST_CHANGES` reviews only while the canonical Project item is in `Review` or `Approval`.

PR #754 exposed the missing lifecycle state: technical Review had already advanced canonical issue #753 to `Verification`, then Dmitry submitted a formal `REQUEST_CHANGES` review with an unresolved inline comment. The review-return adapter rejected `Verification`, so the item was not returned to implementation and the normal event loop had nothing eligible to claim.

A formal maintainer Request Changes review is intended to be sufficient feedback input. It must not require a second manual dispatch comment merely because Review already advanced to representative Verification.

## Design

- Treat `Verification` as a returnable pre-merge lifecycle state alongside `Review` and `Approval`.
- Preserve the existing guarded transition, canonical issue/PR selection, exact-head checks, implementer routing, branch/PR continuity, assignment release, security boundaries, and idempotency.
- Add a regression test modeled on issue #753 / PR #754: `Verification / Ready / Local Codex`, original `Implementer = Codex Cloud`, and a stale verification worker reference must become `Implementation / Ready / Codex Cloud` with the existing PR branch and exact head recorded.
- Document that Dmitry's formal `REQUEST_CHANGES` review is sufficient to return eligible work from Review, Verification, or Approval.

## Compatibility and security

No product, Java, frontend, dependency, or public API behavior changes. The runtime still checks out trusted `develop`, never executes the reviewed head, excludes forks and Dependabot, uses the existing guarded `delivery-control/v1` transition, and never merges or enables auto-merge.

## Validation

Executed locally:

- `node --check .github/scripts/review-return.js`
- `node --check .github/scripts/review-return-verification.test.js`
- `node --test .github/scripts/review-return-verification.test.js` — 1/1 passed
- Ruby YAML parse of `.github/workflows/review-return.yml`

The focused PR workflow runs the existing review-return suite plus the new regression test and pinned actionlint validation.

## Published state

Base: `develop` at `385cbac2692d4447fb38285eac02381eac8d22b1`

Head: `7d2b68af933c74157d2b516699efe070897ac5d2`

No merge or auto-merge is requested or enabled.