### PR TITLE
Expose merge conflicts to the AI delivery dispatcher

### DIFF
--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -19,12 +19,14 @@ ProjectV2 reads are unavailable or fail.
 4. Use only the snapshot's explicit `fields`/`fieldValues` as ProjectV2 read state. An absent field value is represented as `null`;
    do not infer it from prose, authorship, prior chat state, or defaults. The file contains active Sniffy items only. The raw files
    are diagnostic and are not the ordinary queue.
-5. Before ordinary queue selection, inspect snapshot PR items for `content.mergeable = CONFLICTING` or
-   `content.mergeStateStatus = DIRTY`. Treat each same-repository, non-Dependabot agent PR as a priority continuation/reconciliation
-   obligation. Re-read the live PR first and require it still to be open, target `develop`, have the same exact head, and remain
-   conflicted. Preserve the existing branch and PR; deliberately route conflict resolution to an eligible implementation executor,
-   then start the normal 15-minute, second-15-minute, and hourly observation cycle. Fork PRs wait for their contributor, and
-   Dependabot PRs use `@dependabot rebase`; never adopt or rewrite those branches through this rule.
+5. Before ordinary queue selection, inspect the snapshot's top-level `pullRequests` observations for `mergeable = CONFLICTING` or
+   `mergeStateStatus = DIRTY`. This collection is independent of Project item type; use `closingIssueNumbers` to resolve the
+   canonical issue-versus-PR identity before routing, without activating a duplicate PR lifecycle item. Treat each same-repository,
+   non-Dependabot agent PR as a priority continuation/reconciliation obligation. Re-read the live PR first and require it still to
+   be open, target `develop`, have the same exact head, and remain conflicted. Preserve the existing branch and PR; deliberately
+   route conflict resolution to an eligible implementation executor, then start the normal 15-minute, second-15-minute, and hourly
+   observation cycle. Fork PRs wait for their contributor, and Dependabot PRs use `@dependabot rebase`; never adopt or rewrite those
+   branches through this rule.
 6. Re-read current issue/PR open/draft state, exact branch/head, formal closing links, assignment, reviews, threads, matching CI,
    and mergeability through live GitHub operations before acting. Snapshot source metadata and mergeability are discovery hints,
    not mutation authority.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -19,16 +19,23 @@ ProjectV2 reads are unavailable or fail.
 4. Use only the snapshot's explicit `fields`/`fieldValues` as ProjectV2 read state. An absent field value is represented as `null`;
    do not infer it from prose, authorship, prior chat state, or defaults. The file contains active Sniffy items only. The raw files
    are diagnostic and are not the ordinary queue.
-5. Re-read current issue/PR open/draft state, exact branch/head, formal closing links, assignment, reviews, threads, and matching CI
-   through live GitHub operations before acting. Snapshot source metadata never replaces those live reads.
-6. Use snapshot values to construct guarded `delivery-control/v1` expected fields. A successful mutation still depends on the
+5. Before ordinary queue selection, inspect snapshot PR items for `content.mergeable = CONFLICTING` or
+   `content.mergeStateStatus = DIRTY`. Treat each same-repository, non-Dependabot agent PR as a priority continuation/reconciliation
+   obligation. Re-read the live PR first and require it still to be open, target `develop`, have the same exact head, and remain
+   conflicted. Preserve the existing branch and PR; deliberately route conflict resolution to an eligible implementation executor,
+   then start the normal 15-minute, second-15-minute, and hourly observation cycle. Fork PRs wait for their contributor, and
+   Dependabot PRs use `@dependabot rebase`; never adopt or rewrite those branches through this rule.
+6. Re-read current issue/PR open/draft state, exact branch/head, formal closing links, assignment, reviews, threads, matching CI,
+   and mergeability through live GitHub operations before acting. Snapshot source metadata and mergeability are discovery hints,
+   not mutation authority.
+7. Use snapshot values to construct guarded `delivery-control/v1` expected fields. A successful mutation still depends on the
    control workflow's live serialized ProjectV2 comparison and verification.
-7. On `confused`, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run. On
+8. On `confused`, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run. On
    `+1`, the control workflow's internal final-state verification is authoritative for that command.
-8. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command. The status
+9. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command. The status
    workflow is triggered after delivery-control completion and also runs four times per hour. Do not chain dependent Project writes
    from an older materialized view.
-9. If the status issue, pointer, artifact, or snapshot is missing, expired, inaccessible, malformed, mismatched, or stale, make no
-   snapshot-dependent Project claim or transition. Report the exact status-read blocker; do not guess.
-10. Exclude issues labeled `ai-delivery-control` or `ai-delivery-status` from canonical work selection even if Project automation
+10. If the status issue, pointer, artifact, or snapshot is missing, expired, inaccessible, malformed, mismatched, or stale, make no
+    snapshot-dependent Project claim or transition. Report the exact status-read blocker; do not guess.
+11. Exclude issues labeled `ai-delivery-control` or `ai-delivery-status` from canonical work selection even if Project automation
     materialized them.

--- a/.github/scripts/delivery-status-mergeability.js
+++ b/.github/scripts/delivery-status-mergeability.js
@@ -6,7 +6,56 @@ function indexPullRequests(values) {
   return new Map((Array.isArray(values) ? values : []).map(value => [Number(value.number), value]));
 }
 
-function enrichSnapshot(snapshot, pullRequests) {
+function indexClosingIssues(values) {
+  const result = new Map();
+  for (const value of Array.isArray(values) ? values : []) {
+    const references = value?.closingIssuesReferences ?? {};
+    const nodes = Array.isArray(references.nodes) ? references.nodes : [];
+    if (Number.isInteger(references.totalCount) && references.totalCount > nodes.length) {
+      throw new Error(`Closing-issue export for PR #${value.number} is incomplete`);
+    }
+    result.set(
+      Number(value.number),
+      nodes.map(node => Number(node.number)).filter(Number.isSafeInteger).sort((left, right) => left - right)
+    );
+  }
+  return result;
+}
+
+function authorLogin(author) {
+  if (typeof author === 'string') return author;
+  return author?.login ?? author?.name ?? null;
+}
+
+function normalizeOpenPullRequests(values, closingIssuesByNumber) {
+  return (Array.isArray(values) ? values : [])
+    .filter(value => String(value?.state ?? '').toUpperCase() === 'OPEN')
+    .map(value => {
+      const number = Number(value.number);
+      if (!closingIssuesByNumber.has(number)) {
+        throw new Error(`Missing formal closing-issue export for open PR #${value.number}`);
+      }
+      return {
+        number,
+        url: value.url ?? null,
+        author: authorLogin(value.author),
+        repositoryOwnership: value.isCrossRepository === true
+          ? 'fork'
+          : value.isCrossRepository === false ? 'same-repository' : null,
+        isCrossRepository: value.isCrossRepository ?? null,
+        isDraft: value.isDraft ?? false,
+        baseRefName: value.baseRefName ?? null,
+        headRefName: value.headRefName ?? null,
+        headRefOid: value.headRefOid ?? null,
+        mergeable: value.mergeable ?? null,
+        mergeStateStatus: value.mergeStateStatus ?? null,
+        closingIssueNumbers: closingIssuesByNumber.get(number)
+      };
+    })
+    .sort((left, right) => left.number - right.number);
+}
+
+function enrichSnapshot(snapshot, pullRequests, closingIssues = []) {
   const byNumber = indexPullRequests(pullRequests);
   for (const item of snapshot.items || []) {
     const type = String(item?.content?.type || '').toUpperCase();
@@ -16,21 +65,28 @@ function enrichSnapshot(snapshot, pullRequests) {
     item.content.mergeable = source.mergeable ?? null;
     item.content.mergeStateStatus = source.mergeStateStatus ?? null;
   }
+  snapshot.pullRequests = normalizeOpenPullRequests(pullRequests, indexClosingIssues(closingIssues));
   snapshot.semantics = {
     ...(snapshot.semantics || {}),
-    mergeability: 'snapshot hint only; re-read the live PR before dispatch or mutation'
+    mergeability: 'snapshot hint only; re-read the live PR before dispatch or mutation',
+    pullRequests: 'all open repository PRs, independent of canonical Project item representation'
+  };
+  snapshot.counts = {
+    ...(snapshot.counts || {}),
+    openPullRequestCount: snapshot.pullRequests.length
   };
   return snapshot;
 }
 
 function main(argv) {
-  const [snapshotPath, pullRequestsPath] = argv;
-  if (!snapshotPath || !pullRequestsPath) {
-    throw new Error('Usage: delivery-status-mergeability.js <snapshot.json> <pull-requests.json>');
+  const [snapshotPath, pullRequestsPath, closingIssuesPath] = argv;
+  if (!snapshotPath || !pullRequestsPath || !closingIssuesPath) {
+    throw new Error('Usage: delivery-status-mergeability.js <snapshot.json> <pull-requests.json> <closing-issues.json>');
   }
   const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
   const pullRequests = JSON.parse(fs.readFileSync(pullRequestsPath, 'utf8'));
-  enrichSnapshot(snapshot, pullRequests);
+  const closingIssues = JSON.parse(fs.readFileSync(closingIssuesPath, 'utf8'));
+  enrichSnapshot(snapshot, pullRequests, closingIssues);
   fs.writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
 }
 
@@ -43,4 +99,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = {enrichSnapshot};
+module.exports = {enrichSnapshot, normalizeOpenPullRequests};

--- a/.github/scripts/delivery-status-mergeability.js
+++ b/.github/scripts/delivery-status-mergeability.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const fs = require('node:fs');
+
+function indexPullRequests(values) {
+  return new Map((Array.isArray(values) ? values : []).map(value => [Number(value.number), value]));
+}
+
+function enrichSnapshot(snapshot, pullRequests) {
+  const byNumber = indexPullRequests(pullRequests);
+  for (const item of snapshot.items || []) {
+    const type = String(item?.content?.type || '').toUpperCase();
+    if (type !== 'PULLREQUEST' && type !== 'PULL_REQUEST') continue;
+    const source = byNumber.get(Number(item.content.number));
+    if (!source) continue;
+    item.content.mergeable = source.mergeable ?? null;
+    item.content.mergeStateStatus = source.mergeStateStatus ?? null;
+  }
+  snapshot.semantics = {
+    ...(snapshot.semantics || {}),
+    mergeability: 'snapshot hint only; re-read the live PR before dispatch or mutation'
+  };
+  return snapshot;
+}
+
+function main(argv) {
+  const [snapshotPath, pullRequestsPath] = argv;
+  if (!snapshotPath || !pullRequestsPath) {
+    throw new Error('Usage: delivery-status-mergeability.js <snapshot.json> <pull-requests.json>');
+  }
+  const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+  const pullRequests = JSON.parse(fs.readFileSync(pullRequestsPath, 'utf8'));
+  enrichSnapshot(snapshot, pullRequests);
+  fs.writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {enrichSnapshot};

--- a/.github/scripts/delivery-status-mergeability.test.js
+++ b/.github/scripts/delivery-status-mergeability.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 const {enrichSnapshot} = require('./delivery-status-mergeability');
 
@@ -27,4 +29,10 @@ test('preserves unknown mergeability explicitly', () => {
   const result = enrichSnapshot(snapshot, [{number: 780}]);
   assert.equal(result.items[0].content.mergeable, null);
   assert.equal(result.items[0].content.mergeStateStatus, null);
+});
+
+test('workflow exports and applies mergeability before artifact publication', () => {
+  const workflow = fs.readFileSync(path.join(__dirname, '../workflows/delivery-status.yml'), 'utf8');
+  assert.match(workflow, /--json[^\n]*mergeable,mergeStateStatus/);
+  assert.match(workflow, /delivery-status-mergeability\.js[\s\\]*status-artifact\/project-2-status\.json/);
 });

--- a/.github/scripts/delivery-status-mergeability.test.js
+++ b/.github/scripts/delivery-status-mergeability.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {enrichSnapshot} = require('./delivery-status-mergeability');
+
+test('adds merge conflict indicators to pull request items only', () => {
+  const snapshot = {
+    items: [
+      {content: {type: 'PullRequest', number: 780}},
+      {content: {type: 'Issue', number: 782}}
+    ],
+    semantics: {}
+  };
+  const result = enrichSnapshot(snapshot, [
+    {number: 780, mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY'}
+  ]);
+
+  assert.equal(result.items[0].content.mergeable, 'CONFLICTING');
+  assert.equal(result.items[0].content.mergeStateStatus, 'DIRTY');
+  assert.equal(result.items[1].content.mergeable, undefined);
+  assert.match(result.semantics.mergeability, /re-read the live PR/);
+});
+
+test('preserves unknown mergeability explicitly', () => {
+  const snapshot = {items: [{content: {type: 'PullRequest', number: 780}}]};
+  const result = enrichSnapshot(snapshot, [{number: 780}]);
+  assert.equal(result.items[0].content.mergeable, null);
+  assert.equal(result.items[0].content.mergeStateStatus, null);
+});

--- a/.github/scripts/delivery-status-mergeability.test.js
+++ b/.github/scripts/delivery-status-mergeability.test.js
@@ -6,33 +6,110 @@ const path = require('node:path');
 const test = require('node:test');
 const {enrichSnapshot} = require('./delivery-status-mergeability');
 
-test('adds merge conflict indicators to pull request items only', () => {
+function closingIssues(number, issues = []) {
+  return {
+    number,
+    closingIssuesReferences: {
+      totalCount: issues.length,
+      nodes: issues.map(issueNumber => ({number: issueNumber}))
+    }
+  };
+}
+
+test('publishes open PR observations independently of canonical Project item type', () => {
   const snapshot = {
     items: [
-      {content: {type: 'PullRequest', number: 780}},
       {content: {type: 'Issue', number: 782}}
     ],
-    semantics: {}
+    semantics: {},
+    counts: {activeItemCount: 1}
   };
   const result = enrichSnapshot(snapshot, [
-    {number: 780, mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY'}
-  ]);
+    {
+      number: 783,
+      state: 'OPEN',
+      url: 'https://github.com/sniffy/sniffy/pull/783',
+      author: {login: 'bedrin-gpt'},
+      isCrossRepository: false,
+      isDraft: false,
+      baseRefName: 'develop',
+      headRefName: 'agent/merge-conflict-snapshot',
+      headRefOid: '42594d311f6077d5557653c95f1942b5b224a5ae',
+      mergeable: 'CONFLICTING',
+      mergeStateStatus: 'DIRTY'
+    }
+  ], [closingIssues(783, [782])]);
+
+  assert.equal(result.items[0].content.mergeable, undefined);
+  assert.deepEqual(result.pullRequests, [{
+    number: 783,
+    url: 'https://github.com/sniffy/sniffy/pull/783',
+    author: 'bedrin-gpt',
+    repositoryOwnership: 'same-repository',
+    isCrossRepository: false,
+    isDraft: false,
+    baseRefName: 'develop',
+    headRefName: 'agent/merge-conflict-snapshot',
+    headRefOid: '42594d311f6077d5557653c95f1942b5b224a5ae',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    closingIssueNumbers: [782]
+  }]);
+  assert.equal(result.counts.openPullRequestCount, 1);
+  assert.match(result.semantics.mergeability, /re-read the live PR/);
+  assert.match(result.semantics.pullRequests, /independent of canonical Project item/);
+});
+
+test('also enriches represented pull request items', () => {
+  const snapshot = {items: [{content: {type: 'PullRequest', number: 780}}]};
+  const result = enrichSnapshot(snapshot, [
+    {number: 780, state: 'OPEN', mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY'}
+  ], [closingIssues(780)]);
 
   assert.equal(result.items[0].content.mergeable, 'CONFLICTING');
   assert.equal(result.items[0].content.mergeStateStatus, 'DIRTY');
-  assert.equal(result.items[1].content.mergeable, undefined);
-  assert.match(result.semantics.mergeability, /re-read the live PR/);
 });
 
 test('preserves unknown mergeability explicitly', () => {
   const snapshot = {items: [{content: {type: 'PullRequest', number: 780}}]};
-  const result = enrichSnapshot(snapshot, [{number: 780}]);
+  const result = enrichSnapshot(snapshot, [
+    {number: 780, state: 'OPEN', isCrossRepository: true}
+  ], [closingIssues(780)]);
   assert.equal(result.items[0].content.mergeable, null);
   assert.equal(result.items[0].content.mergeStateStatus, null);
+  assert.equal(result.pullRequests[0].mergeable, null);
+  assert.equal(result.pullRequests[0].mergeStateStatus, null);
+  assert.equal(result.pullRequests[0].repositoryOwnership, 'fork');
+});
+
+test('omits closed PRs and fails closed when formal-link observations are missing', () => {
+  const closed = {number: 779, state: 'CLOSED'};
+  assert.deepEqual(enrichSnapshot({items: []}, [closed], []).pullRequests, []);
+  assert.throws(
+    () => enrichSnapshot({items: []}, [{number: 783, state: 'OPEN'}], []),
+    /Missing formal closing-issue export for open PR #783/
+  );
+  assert.throws(
+    () => enrichSnapshot({items: []}, [{number: 783, state: 'OPEN'}], [{
+      number: 783,
+      closingIssuesReferences: {totalCount: 2, nodes: [{number: 782}]}
+    }]),
+    /Closing-issue export for PR #783 is incomplete/
+  );
 });
 
 test('workflow exports and applies mergeability before artifact publication', () => {
   const workflow = fs.readFileSync(path.join(__dirname, '../workflows/delivery-status.yml'), 'utf8');
   assert.match(workflow, /--json[^\n]*mergeable,mergeStateStatus/);
+  assert.match(workflow, /closingIssuesReferences\(first:\s*100\)/);
   assert.match(workflow, /delivery-status-mergeability\.js[\s\\]*status-artifact\/project-2-status\.json/);
+});
+
+test('dispatcher scans independent PR observations without changing fork or Dependabot policy', () => {
+  const instructions = fs.readFileSync(path.join(__dirname, '../../.chatgpt/status-snapshot-instructions.md'), 'utf8');
+  assert.match(instructions, /top-level `pullRequests` observations/);
+  assert.match(instructions, /use `closingIssueNumbers` to resolve the\s+canonical issue-versus-PR identity/);
+  assert.match(instructions, /Fork PRs wait for their contributor/);
+  assert.match(instructions, /Dependabot PRs use `@dependabot rebase`/);
+  assert.match(instructions, /never adopt or rewrite those\s+branches through this rule/);
 });

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -9,11 +9,14 @@ on:
       - .github/scripts/delivery-status.test.js
       - .github/scripts/delivery-status-policy.test.js
       - .github/scripts/delivery-status-runner-policy.test.js
+      - .github/scripts/delivery-status-mergeability.js
+      - .github/scripts/delivery-status-mergeability.test.js
       - .github/workflows/delivery-status.yml
       - docs/ai-delivery/README.md
       - docs/ai-delivery/profile.yml
       - docs/ai-delivery/status-snapshot.md
       - docs/ai-delivery/ubuntu-slim-capability-experiment.md
+      - docs/ai-delivery/merge-conflict-reconciliation.md
   workflow_run:
     workflows: [AI delivery control]
     types: [completed]
@@ -42,10 +45,13 @@ jobs:
           node --check .github/scripts/delivery-status.test.js
           node --check .github/scripts/delivery-status-policy.test.js
           node --check .github/scripts/delivery-status-runner-policy.test.js
+          node --check .github/scripts/delivery-status-mergeability.js
+          node --check .github/scripts/delivery-status-mergeability.test.js
           node --test \
             .github/scripts/delivery-status.test.js \
             .github/scripts/delivery-status-policy.test.js \
-            .github/scripts/delivery-status-runner-policy.test.js
+            .github/scripts/delivery-status-runner-policy.test.js \
+            .github/scripts/delivery-status-mergeability.test.js
       - name: Parse workflow and profile YAML
         run: >-
           ruby -e 'require "yaml";
@@ -114,7 +120,7 @@ jobs:
             --repo "$STATUS_REPOSITORY" \
             --state all \
             --limit 1000 \
-            --json number,state,isDraft,mergedAt,closedAt,createdAt,updatedAt,title,url,author,labels,headRefName,headRefOid,baseRefName,isCrossRepository \
+            --json number,state,isDraft,mergedAt,closedAt,createdAt,updatedAt,title,url,author,labels,headRefName,headRefOid,baseRefName,isCrossRepository,mergeable,mergeStateStatus \
             > status-artifact/repository-pull-requests.raw.json
 
           node .github/scripts/delivery-status.js normalize \
@@ -132,6 +138,10 @@ jobs:
             --event "$GITHUB_EVENT_NAME" \
             --upstream-run-id "$UPSTREAM_RUN_ID" \
             --head-sha "$source_sha"
+
+          node .github/scripts/delivery-status-mergeability.js \
+            status-artifact/project-2-status.json \
+            status-artifact/repository-pull-requests.raw.json
 
           {
             echo "generated_at=$generated_at"

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -123,6 +123,27 @@ jobs:
             --json number,state,isDraft,mergedAt,closedAt,createdAt,updatedAt,title,url,author,labels,headRefName,headRefOid,baseRefName,isCrossRepository,mergeable,mergeStateStatus \
             > status-artifact/repository-pull-requests.raw.json
 
+          status_owner="${STATUS_REPOSITORY%%/*}"
+          status_name="${STATUS_REPOSITORY#*/}"
+          # GraphQL pagination requires the literal $endCursor variable.
+          # shellcheck disable=SC2016
+          GH_TOKEN="$REPOSITORY_TOKEN" gh api graphql --paginate \
+            -f owner="$status_owner" \
+            -f name="$status_name" \
+            -f query='query($owner: String!, $name: String!, $endCursor: String) {
+              repository(owner: $owner, name: $name) {
+                pullRequests(first: 100, after: $endCursor, states: OPEN) {
+                  nodes {
+                    number
+                    closingIssuesReferences(first: 100) { totalCount nodes { number } }
+                  }
+                  pageInfo { hasNextPage endCursor }
+                }
+              }
+            }' \
+            | jq -sc '[.[].data.repository.pullRequests.nodes[] | {number, closingIssuesReferences}]' \
+            > "$RUNNER_TEMP/repository-pull-request-closing-issues.raw.json"
+
           node .github/scripts/delivery-status.js normalize \
             --fields status-artifact/project-fields.raw.json \
             --items status-artifact/project-items.raw.json \
@@ -141,7 +162,8 @@ jobs:
 
           node .github/scripts/delivery-status-mergeability.js \
             status-artifact/project-2-status.json \
-            status-artifact/repository-pull-requests.raw.json
+            status-artifact/repository-pull-requests.raw.json \
+            "$RUNNER_TEMP/repository-pull-request-closing-issues.raw.json"
 
           {
             echo "generated_at=$generated_at"

--- a/docs/ai-delivery/merge-conflict-reconciliation.md
+++ b/docs/ai-delivery/merge-conflict-reconciliation.md
@@ -8,16 +8,25 @@ PR #780 is the motivating incident: it was open, non-draft, same-repository, age
 
 ## Status signal
 
-The status workflow exports GitHub's `mergeable` and `mergeStateStatus` values for repository PRs and attaches them to matching active Project PR items:
+The status workflow exports a normalized top-level `pullRequests` collection for every open repository PR, independently of which
+issue or PR is the canonical Project item. Each observation includes the PR number and URL, author, same-repository/fork ownership,
+base branch, head branch and exact SHA, `mergeable`, `mergeStateStatus`, and formal closing issue numbers:
 
 ```json
 {
+  "number": 783,
+  "repositoryOwnership": "same-repository",
+  "headRefOid": "42594d311f6077d5557653c95f1942b5b224a5ae",
   "mergeable": "CONFLICTING",
-  "mergeStateStatus": "DIRTY"
+  "mergeStateStatus": "DIRTY",
+  "closingIssueNumbers": [782]
 }
 ```
 
-These values are discovery hints. GitHub may temporarily report unknown mergeability while recomputing, and a snapshot can become stale. Before dispatch or Project mutation, the tick must re-read the live PR and verify that it remains open, targets `develop`, has the same exact head, and remains conflicted.
+This keeps issue-canonical implementations visible without reactivating their duplicate PR Project items. The values remain
+discovery hints: GitHub may temporarily report unknown mergeability while recomputing, and a snapshot can become stale. Before
+dispatch or Project mutation, the tick must resolve canonical identity from the formal closing links, then re-read the live PR and
+verify that it remains open, targets `develop`, has the same exact head, and remains conflicted.
 
 ## Routing
 

--- a/docs/ai-delivery/merge-conflict-reconciliation.md
+++ b/docs/ai-delivery/merge-conflict-reconciliation.md
@@ -1,0 +1,34 @@
+# Agent pull-request merge conflict reconciliation
+
+## Purpose
+
+An open implementation PR can become unmergeable after `develop` advances even when its exact-head CI and review were previously healthy. Merge conflicts are implementation work, not passive review or approval waiting. The delivery loop must discover them before ordinary queue selection and preserve the existing PR and branch while routing a continuation.
+
+PR #780 is the motivating incident: it was open, non-draft, same-repository, agent-authored, and `CONFLICTING`, but the status snapshot contained no mergeability signal.
+
+## Status signal
+
+The status workflow exports GitHub's `mergeable` and `mergeStateStatus` values for repository PRs and attaches them to matching active Project PR items:
+
+```json
+{
+  "mergeable": "CONFLICTING",
+  "mergeStateStatus": "DIRTY"
+}
+```
+
+These values are discovery hints. GitHub may temporarily report unknown mergeability while recomputing, and a snapshot can become stale. Before dispatch or Project mutation, the tick must re-read the live PR and verify that it remains open, targets `develop`, has the same exact head, and remains conflicted.
+
+## Routing
+
+Before ordinary queue selection:
+
+- same-repository agent PR: preserve the exact branch and PR, route a continuation to an eligible implementation executor, and resolve conflicts by merging current `develop` into the feature branch; do not rebase, reset, force-push, or create a replacement PR;
+- Dependabot or managed automation: use its documented rebase command and monitor the resulting head;
+- fork PR: request contributor conflict resolution and monitor for a new head; do not push to the fork autonomously.
+
+After concrete dispatch, observe after 15 minutes, again after 15 minutes, then hourly while incomplete. A new head must receive matching CI and normal review/verification before approval.
+
+## Boundaries
+
+Conflict detection never grants merge or auto-merge authority. It does not bypass unresolved review threads, required CI, verification, or human approval. Snapshot mergeability does not replace the live exact-head guard used by Project transitions.

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -50,6 +50,11 @@ Every successful run uploads one artifact named `ai-delivery-status-project-2` w
 - `repository-issues.raw.json` — live issue state and metadata from `gh issue list --state all`;
 - `repository-pull-requests.raw.json` — live pull-request state, draft/head/base/ownership metadata, and labels from `gh pr list --state all`.
 
+The normalized snapshot also contains a top-level `pullRequests` collection for every open repository PR, whether the PR or one
+of its formal closing issues is the canonical Project item. Each observation records number, URL, author, same-repository/fork
+ownership, draft/base/branch/exact-head identity, mergeability, merge-state status, and formal closing issue numbers. This is the
+pre-queue discovery surface for merge-conflict reconciliation; it does not make the PR a second lifecycle item.
+
 The normalizer fails when GitHub reports more fields or items than were returned, rather than publishing a silently truncated view.
 Each normalized item contains:
 


### PR DESCRIPTION
Closes #782

## Problem

Agent-authored same-repository PRs can become unmergeable after `develop` advances. The status snapshot previously exposed mergeability only on active Project PR items, so a PR that formally closed one canonical issue remained invisible to the pre-queue conflict scan.

## Design

- export GitHub `mergeable` and `mergeStateStatus` from `gh pr list`;
- fetch formal closing issues for every open repository PR through one paginated GraphQL export;
- publish an additive top-level `pullRequests` observation list in `project-2-status.json`, independent of canonical Project item type, with PR number/URL, author, same-repository or fork ownership, draft/base/branch/exact-head identity, mergeability, merge-state status, and formal closing issue numbers;
- retain mergeability on represented Project PR items for compatibility;
- make dispatcher instructions scan that independent collection before ordinary selection, resolve canonical identity from formal closing links, and re-read live PR state before routing;
- preserve the existing branch/PR, use `@dependabot rebase` for Dependabot, wait for fork contributors, and retain the 15-minute, second-15-minute, then hourly supervision cadence.

## Compatibility and dependencies

The normalized snapshot change is additive. Existing Project item fields and raw artifact files remain intact. No dependency, Java/API, permission, merge, deployment, or privileged-operation change is introduced.

## Validation

Published head: `94163ab3dcaa50724d5a05c0bbc9033d9824595f`

Local:

- Node 24.14 syntax checks passed for all delivery-status scripts and tests.
- `node --test .github/scripts/delivery-status.test.js .github/scripts/delivery-status-policy.test.js .github/scripts/delivery-status-runner-policy.test.js .github/scripts/delivery-status-mergeability.test.js`: 26 tests passed.
- Python YAML parsing passed for the workflow and profile; the local host lacks Ruby, while exact-head CI ran the repository's Ruby parser.
- pinned `rhysd/actionlint:1.7.12` passed.
- `git diff --check` passed.
- a live read-only export fixture produced nine open-PR observations and surfaced PR #783 independently of the issue Project item with `closingIssueNumbers: [782]`.

Exact-head CI:

- [Check Pull Request run 30693954417](https://github.com/sniffy/sniffy/actions/runs/30693954417): all 26 jobs passed across frontend, website, analysis, JDK 8/11/17/21/25, Windows, macOS, Linux, IBM J9, and emulated architectures.
- [AI delivery status run 30693954423](https://github.com/sniffy/sniffy/actions/runs/30693954423): validation passed.
- [AI delivery control run 30693954422](https://github.com/sniffy/sniffy/actions/runs/30693954422): validation passed.
- dependency submission and all four Codecov checks passed; the standalone CodeQL check concluded neutral after the successful Analyze job.

## Limitations and residual risk

Snapshot mergeability remains an eventually consistent discovery hint; the dispatcher must re-read the live PR and exact head before any dispatch or mutation. Formal closing references are fetched up to 100 per PR and the normalizer fails closed if GitHub reports a larger total. No merge or auto-merge is authorized.