### PR TITLE
Support human-readable delivery-control commands

### DIFF
--- a/.github/scripts/delivery-control.js
+++ b/.github/scripts/delivery-control.js
@@ -8,6 +8,30 @@ const PROJECT_NUMBER = 2;
 const BASE_BRANCH = 'develop';
 const DEFAULT_ACTORS = ['bedrin', 'bedrin-gpt', 'bedrin-codex-cloud', 'bedrin-codex-local'];
 const COMMIT_ID = /^[0-9a-f]{40}([0-9a-f]{24})?$/;
+const COMMAND_START_MARKER = '<!-- delivery-control-command:start -->';
+const COMMAND_END_MARKER = '<!-- delivery-control-command:end -->';
+
+function markedCommand(input) {
+  if (typeof input !== 'string') return input;
+  const startPositions = [...input.matchAll(/<!-- delivery-control-command:start -->/g)].map(match => match.index);
+  const endPositions = [...input.matchAll(/<!-- delivery-control-command:end -->/g)].map(match => match.index);
+  if (!startPositions.length && !endPositions.length) return input;
+  if (startPositions.length !== 1 || endPositions.length !== 1) {
+    throw new Error('Wrapped command must contain exactly one start marker and one end marker.');
+  }
+  const start = startPositions[0] + COMMAND_START_MARKER.length;
+  const end = endPositions[0];
+  if (start > end) throw new Error('Wrapped command markers must appear in start-then-end order.');
+
+  const marked = input.slice(start, end);
+  const fence = marked.match(/^\s*```json[ \t]*\r?\n([\s\S]*?)\r?\n```\s*$/);
+  if (!fence) throw new Error('Wrapped command must contain exactly one fenced `json` payload between the markers.');
+  if (!fence[1].trim()) throw new Error('Wrapped command JSON payload must not be empty.');
+  if (fence[1].includes('```')) {
+    throw new Error('Wrapped command must contain exactly one fenced `json` payload between the markers.');
+  }
+  return fence[1];
+}
 
 function object(value, name) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -41,9 +65,10 @@ function pullRequestReference(value, name) {
 }
 
 function parseCommand(input, repository = REPOSITORY) {
+  const extracted = markedCommand(input);
   let raw;
   try {
-    raw = typeof input === 'string' ? JSON.parse(input) : input;
+    raw = typeof extracted === 'string' ? JSON.parse(extracted) : extracted;
   } catch (error) {
     throw new Error(`Command must be valid JSON: ${error.message}`);
   }
@@ -433,6 +458,7 @@ module.exports = {
   ensureReviewPullRequestReady,
   executeTransition,
   idempotentRepeat,
+  markedCommand,
   mismatch,
   parseCommand,
   parseInvocation,

--- a/.github/scripts/delivery-control.test.js
+++ b/.github/scripts/delivery-control.test.js
@@ -9,6 +9,7 @@ const {
   desired,
   executeTransition,
   idempotentRepeat,
+  markedCommand,
   mismatch,
   parseCommand,
   parseInvocation
@@ -29,6 +30,23 @@ const claim = {
     'Worker reference': 'tick-00; token x; lease 2026-07-30T10:00:00Z'
   }
 };
+
+function wrapped(command = claim, prose = 'Move the requested item to its guarded destination.') {
+  return `### AI delivery control
+
+${prose}
+
+<details>
+<summary>Machine-readable command</summary>
+
+<!-- delivery-control-command:start -->
+\`\`\`json
+${JSON.stringify(command, null, 2)}
+\`\`\`
+<!-- delivery-control-command:end -->
+
+</details>`;
+}
 
 function coreDouble() {
   const outputs = {};
@@ -191,6 +209,29 @@ test('parses a fully guarded claim', () => {
   assert.deepEqual(parseCommand(JSON.stringify(claim)), {...claim, clear: [], addIfMissing: false});
 });
 
+test('parses canonical marked Markdown identically and ignores surrounding prose', () => {
+  const legacy = parseCommand(JSON.stringify(claim));
+  assert.deepEqual(parseCommand(wrapped()), legacy);
+  assert.deepEqual(parseCommand(wrapped(claim, '{"command":"display-only"} and ```json display only ```')), legacy);
+});
+
+test('requires an unambiguous marked JSON fence', () => {
+  const valid = wrapped();
+  const start = '<!-- delivery-control-command:start -->';
+  const end = '<!-- delivery-control-command:end -->';
+  assert.throws(() => markedCommand(valid.replace(start, '')), /exactly one start marker and one end marker/);
+  assert.throws(() => markedCommand(valid.replace(end, '')), /exactly one start marker and one end marker/);
+  assert.throws(() => markedCommand(valid.replace(start, `${start}\n${start}`)), /exactly one start marker/);
+  assert.throws(() => markedCommand(valid.replace(end, `${end}\n${end}`)), /exactly one start marker/);
+  assert.throws(() => markedCommand(`${end}\n\`\`\`json\n{}\n\`\`\`\n${start}`), /start-then-end order/);
+  assert.throws(() => markedCommand(`${start}\n\`\`\`json\n\n\`\`\`\n${end}`), /must not be empty/);
+  assert.throws(() => markedCommand(`${start}\n\`\`\`javascript\n{}\n\`\`\`\n${end}`), /fenced `json` payload/);
+  assert.throws(() => markedCommand(`${start}\n{}\n${end}`), /fenced `json` payload/);
+  assert.throws(() => markedCommand(`${start}\n\`\`\`json\n{}\n\`\`\`\n\`\`\`json\n{}\n\`\`\`\n${end}`), /fenced `json` payload/);
+  assert.throws(() => parseCommand(`${start}\n\`\`\`json\n{\n\`\`\`\n${end}`), /valid JSON/);
+  assert.throws(() => parseCommand('prose\n```json\n{}\n```'), /valid JSON/);
+});
+
 test('rejects unguarded transitions', () => {
   assert.throws(() => parseCommand({
     command: 'delivery-control/v1',
@@ -302,6 +343,23 @@ test('authorizes a labeled control-issue command and emits routing outputs', () 
   assert.deepEqual(JSON.parse(Buffer.from(core.outputs.payload_base64, 'base64')), parseCommand(claim));
 });
 
+test('emits identical payload and routing outputs for legacy and wrapped invocations', () => {
+  function invoke(body) {
+    const core = coreDouble();
+    parseInvocation({
+      context: {
+        actor: 'bedrin-gpt',
+        eventName: 'issue_comment',
+        repo: {owner: 'sniffy', repo: 'sniffy'},
+        payload: {issue: labeledIssue(), comment: {id: 123, body}}
+      },
+      core
+    });
+    return core.outputs;
+  }
+  assert.deepEqual(invoke(wrapped()), invoke(JSON.stringify(claim)));
+});
+
 test('rejects an unlabeled control issue', () => {
   const context = {
     actor: 'bedrin-gpt',
@@ -323,6 +381,10 @@ test('rejects unauthorized and malformed control commands before transition', ()
   context.actor = 'bedrin-gpt';
   context.payload.comment.body = '{';
   assert.throws(() => parseInvocation({context, core: coreDouble()}), /valid JSON/);
+  context.payload.comment.body = wrapped().replace('<!-- delivery-control-command:end -->', '');
+  const core = coreDouble();
+  assert.throws(() => parseInvocation({context, core}), /exactly one start marker and one end marker/);
+  assert.deepEqual(core.outputs, {});
 });
 
 test('applies external PR intake while leaving Implementer empty', async () => {


### PR DESCRIPTION
## Problem

Delivery-control ledger comments currently require bare JSON, which is difficult for maintainers to scan. Issue #784 requires backward-compatible support for a human-readable Markdown wrapper while preserving the marked JSON as the sole authoritative command.

## Design

- Add a deterministic extraction step before the existing `parseCommand` JSON parsing and validation.
- Preserve unmarked inputs unchanged for legacy bare-JSON compatibility.
- Accept only one exact start marker, one exact end marker in the correct order, and one non-empty fenced `json` payload between them.
- Reject missing, duplicated, reversed, empty, non-JSON-fenced, multi-fence, and malformed payloads without inspecting surrounding prose.
- Feed extracted JSON through the existing normalization and validation path without changing transition behavior.
- Add focused parser and invocation-equivalence coverage.

## Compatibility impact

Existing bare-JSON commands and object callers are unchanged. Wrapped Markdown commands normalize to the same command and routing outputs as their legacy equivalents. No public Java API, Project field, mutation, authorization, concurrency, acknowledgement, or agent-instruction behavior changes.

## Dependency changes

None.

## Tests and checks

- `node --check .github/scripts/delivery-control.js && node --check .github/scripts/delivery-control.test.js && node --check .github/scripts/delivery-control-post-mutation.test.js && node --check .github/scripts/delivery-policy.test.js`
- `node --test .github/scripts/delivery-control.test.js .github/scripts/delivery-control-post-mutation.test.js .github/scripts/delivery-policy.test.js` (34 tests passed)
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/delivery-control.yml"); YAML.load_file("docs/ai-delivery/profile.yml")'`
- `/tmp/actionlint .github/workflows/delivery-control.yml`
- `git diff --check`

## Limitations and remaining risks

The wrapper intentionally recognizes only the exact protocol markers and lowercase `json` fence defined by issue #784; arbitrary prose JSON and unmarked code fences remain invalid. The workflow-dispatch description remains unchanged because it continues to accurately identify the authoritative input as a JSON command and avoiding that optional wording edit keeps this scoped PR free of workflow changes.

## Published head

`21d4910d5e3b5f9abd256de96dd2a62243c7eb13`

Closes #784
