### PR TITLE
Teach executors to emit readable delivery-control comments

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -60,8 +60,10 @@ ProjectV2 read protocol:
 - Never select issues labeled ai-delivery-control or ai-delivery-status as delivery work.
 
 ProjectV2 control protocol:
-- Every executor uses the same rotating technical control issue and delivery-control/v1 JSON commands documented in
-  control-plane.md.
+- Every executor uses the same rotating technical control issue and delivery-control/v1 commands documented in control-plane.md.
+  For every new control-issue comment, emit its concise human-readable Markdown wrapper with the exact start/end markers and
+  lowercase `json` fence. Derive the display-only prose from the JSON, but always treat the marked JSON as authoritative; never
+  emit bare JSON for an autonomous command.
 - Locate the newest open issue with the configured ai-delivery-control label; create it with that label if none exists. Do not
   post /project-status, /project-field, claim-intent, winner, loser, withdrawal, lease, or polling comments on the target issue or
   pull request.

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -49,7 +49,10 @@ the worker's PR, merge, or enable auto-merge.
    Implementer/Executor=Local Codex. Reuse the exact branch and PR. Do not adopt fork or Dependabot branches for direct correction.
 9. Select deterministically by Project priority, ready timestamp, repository, item type, then item number. The helper has already
    normalized and sorted candidates; do not create an alternative ordering from raw Project data.
-10. Claim through the one active technical control issue using one guarded delivery-control/v1 command. Guard current Status,
+10. Claim through the one active technical control issue using one guarded delivery-control/v1 command. Post every new command
+    with the concise human-readable Markdown wrapper from control-plane.md, including its exact start/end markers and lowercase
+    `json` fence. Derive the display-only prose from the JSON, treat the marked JSON as authoritative, and never emit bare JSON.
+    Guard current Status,
     Execution=Ready, Executor=Local Codex, and exact PR head when the canonical item is a PR; set Execution=In progress plus
     claim token/lease inside the provisional Worker reference. The guarded transition is the authoritative current-state recheck.
     Inspect the reaction and re-read the resulting target Project state before spawning.

--- a/.codex/local/worker-task-prompt.md
+++ b/.codex/local/worker-task-prompt.md
@@ -31,8 +31,10 @@ and unresolved threads, current CI, Project fields, worker record, remote develo
 `docs/ai-delivery/{profile,lifecycle,control-plane,pull-request-intake,routing,supervision,verification}.md`. Verify this task still
 owns the exact claim token/generation and worker reference.
 
-Use the common rotating technical control issue for every ProjectV2 transition. Never post /project-status, /project-field,
-claim arbitration, lease, or polling comments on the target item. A handoff is complete only after the guarded
+Use the common rotating technical control issue for every ProjectV2 transition. Post every new command with the concise
+human-readable Markdown wrapper from control-plane.md, including its exact start/end markers and lowercase `json` fence. Derive
+the display-only prose from the JSON, treat the marked JSON as authoritative, and never emit bare JSON. Never post /project-status,
+/project-field, claim arbitration, lease, or polling comments on the target item. A handoff is complete only after the guarded
 `delivery-control/v1` command has a terminal reaction and the canonical Project state has been re-read. A command setting
 Status=Review must identify the exact PR: target+expected.head for a canonical PR, or reviewPullRequest.number/head for a
 canonical issue. Re-read PR draft/head state after the command as well as Project fields.

--- a/.github/scripts/delivery-policy.test.js
+++ b/.github/scripts/delivery-policy.test.js
@@ -68,6 +68,37 @@ test('Cloud does not turn arbitrary existing PRs into duplicate fresh work', () 
   assert.match(cloud, /existing-PR continuation normally goes to Local Codex/i);
 });
 
+test('delivery executors require readable control comments with authoritative marked JSON', () => {
+  const commandPrompts = [
+    '.chatgpt/scheduled-task-prompt.md',
+    '.codex/local/scheduled-task-prompt.md',
+    '.codex/local/worker-task-prompt.md'
+  ];
+  const executorDocs = [
+    'docs/ai-delivery/executors/chatgpt.md',
+    'docs/ai-delivery/executors/codex-cloud.md',
+    'docs/ai-delivery/executors/codex-local.md'
+  ];
+
+  for (const file of [...commandPrompts, ...executorDocs]) {
+    const content = read(file);
+    assert.match(content, /human-readable Markdown wrapper/i, `${file} must require the readable wrapper`);
+    assert.match(content, /exact (?:start\/end )?markers|exact markers/i, `${file} must preserve protocol markers`);
+    assert.match(content, /lowercase\s+`json` fence/i, `${file} must preserve the lowercase JSON fence`);
+    assert.match(content, /marked JSON.*authoritative|authoritative marked JSON/is, `${file} must make JSON authoritative`);
+  }
+  for (const file of commandPrompts) {
+    assert.match(read(file), /never\s+emit bare JSON/i, `${file} must reject bare autonomous output`);
+  }
+
+  const control = read('docs/ai-delivery/control-plane.md');
+  assert.equal((control.match(/<!-- delivery-control-command:start -->/g) || []).length, 1);
+  assert.equal((control.match(/<!-- delivery-control-command:end -->/g) || []).length, 1);
+  assert.match(control, /display-only[\s\S]*sole authoritative `delivery-control\/v1` command/i);
+  assert.match(control, /Legacy comments containing only a valid JSON object remain accepted/i);
+  assert.match(control, /workflow_dispatch` continues to accept the raw JSON object/i);
+});
+
 test('every implementation executor publishes a non-draft exact-head PR before Review', () => {
   const files = [
     'AGENTS.md',

--- a/docs/ai-delivery/control-plane.md
+++ b/docs/ai-delivery/control-plane.md
@@ -23,9 +23,9 @@ the same parser and transition implementation, not a separate executor protocol.
 Maintain one open technical issue with the label `ai-delivery-control`. Use a human-readable title such as
 `AI Delivery Control Log — 2026-07`.
 
-The issue is machine-oriented:
+The issue is a technical ledger:
 
-- post only complete JSON commands;
+- post concise human-readable command summaries with the authoritative JSON command in the wrapper below;
 - do not discuss product or review decisions there;
 - keep meaningful reviews, verification evidence, blockers, and human handoffs on the target issue or pull request;
 - do not delete completed commands merely to reduce visual noise.
@@ -35,18 +35,29 @@ label. Immediately before posting, re-read the issue and confirm that it is stil
 
 ## Command format
 
-A command comment is one valid JSON object. Pretty-printed JSON is allowed.
+For new control-issue comments, autonomous executors use this canonical Markdown format. The prose is a short, display-only
+summary derived from the JSON so a maintainer can scan the target, expected state, requested state, and purpose. Automation and
+executors must never parse or trust the prose: the marked JSON is the sole authoritative `delivery-control/v1` command. Preserve
+the exact markers and lowercase `json` fence.
 
+````markdown
+### AI delivery control
+
+Move `sniffy/sniffy#123` from **Review / Ready / ChatGPT** to **Implementation / In progress / Local Codex**.
+
+<details>
+<summary>Machine-readable command</summary>
+
+<!-- delivery-control-command:start -->
 ```json
 {
   "command": "delivery-control/v1",
   "target": {
     "repository": "sniffy/sniffy",
-    "number": 651
+    "number": 123
   },
   "expected": {
-    "type": "PullRequest",
-    "head": "46c47e02e8a5236cf1e7348fc6202da11ea1bbd3",
+    "type": "Issue",
     "fields": {
       "Status": "Review",
       "Execution": "Ready",
@@ -54,12 +65,22 @@ A command comment is one valid JSON object. Pretty-printed JSON is allowed.
     }
   },
   "set": {
+    "Status": "Implementation",
     "Execution": "In progress",
-    "Worker reference": "Sniffy Tick :00; token review-651-46c47e0; lease 2026-07-30T10:15:00Z"
-  },
-  "addIfMissing": false
+    "Executor": "Local Codex",
+    "Worker reference": "example claim"
+  }
 }
 ```
+<!-- delivery-control-command:end -->
+
+</details>
+````
+
+Legacy comments containing only a valid JSON object remain accepted for existing ledger entries, rollback compatibility, and
+maintainer-authorized debugging. They are not the preferred output for new autonomous issue comments. Pretty-printed JSON is
+allowed in either form. The JSON payload examples below omit the display wrapper only to focus on their additional fields; an
+executor posting them as new comments must use the canonical wrapper above.
 
 ### Review handoff and pull-request identity
 
@@ -194,7 +215,8 @@ For commands posted to the control issue:
 The command comment, reaction, Actions run, PR state, and current Project state form the technical audit trail. The target
 conversation contains only human-useful evidence or decisions.
 
-`workflow_dispatch` accepts the same JSON object in its `command` input and invokes the same implementation. Use it only for
+`workflow_dispatch` continues to accept the raw JSON object in its `command` input and invokes the same implementation. It does
+not use the issue-comment Markdown wrapper. Use it only for
 maintainer-authorized debugging or recovery when posting through the control issue is unavailable. Autonomous executors must
 not silently choose a different path.
 

--- a/docs/ai-delivery/executors/chatgpt.md
+++ b/docs/ai-delivery/executors/chatgpt.md
@@ -55,7 +55,8 @@ ChatGPT uses the same [`../control-plane.md`](../control-plane.md) protocol as C
 
 1. locate the one active technical control issue;
 2. choose and re-read the canonical issue or PR;
-3. post one guarded `delivery-control/v1` JSON command;
+3. post one guarded `delivery-control/v1` command using the human-readable Markdown wrapper from the control-plane document,
+   preserving its exact markers and lowercase `json` fence, deriving the display-only prose from the authoritative marked JSON;
 4. inspect the reaction and Actions result;
 5. re-read the resulting Project fields and any PR state coupled to the transition;
 6. only then claim ownership or report a handoff.

--- a/docs/ai-delivery/executors/codex-cloud.md
+++ b/docs/ai-delivery/executors/codex-cloud.md
@@ -78,8 +78,10 @@ A dry-run push is not proof of effective write permission.
 
 Cloud uses the same [`../control-plane.md`](../control-plane.md) protocol as every executor. It locates the active technical
 control issue, posts one guarded `delivery-control/v1` command for a claim or handoff, inspects the reaction, and re-reads Project
-state. It must not update Project fields through a private Cloud-only GraphQL path or post field/claim comments on the target
-item.
+state. Every new command comment uses the control-plane document's human-readable Markdown wrapper with exact markers and a
+lowercase `json` fence; its prose is derived display text and the marked JSON remains authoritative. Cloud must not emit bare JSON
+for autonomous issue comments, update Project fields through a private Cloud-only GraphQL path, or post field/claim comments on
+the target item.
 
 The canonical target may be an issue or PR. For fresh work it is normally an issue; for an explicitly recoverable Cloud-owned PR
 continuation the worker reference must name the exact branch/head and no duplicate PR may be created. A command setting

--- a/docs/ai-delivery/executors/codex-local.md
+++ b/docs/ai-delivery/executors/codex-local.md
@@ -102,7 +102,9 @@ Both adapters:
 - respect directed Assignee or empty pool ownership;
 - inspect canonicalization, lifecycle, profile, access, capacity, exact branch/PR/head, current worker, and due monitoring;
 - exclude duplicate representations and linked issues suppressed by an open canonical multi-issue PR;
-- use the one active technical control issue and one guarded `delivery-control/v1` command per claim/transition;
+- use the one active technical control issue and one guarded `delivery-control/v1` command per claim/transition, posting every new
+  command with the control-plane document's human-readable Markdown wrapper, exact markers, and lowercase `json` fence while
+  treating its marked JSON—not its derived display prose—as authoritative and never emitting bare JSON autonomously;
 - inspect the reaction and re-read Project state before spawning;
 - record concrete conversation/task or process/worktree and exact PR references;
 - release to `Ready` when spawn fails;


### PR DESCRIPTION
Closes #786

## Delivery relationship

Parent PR #785 is merged into `develop`. This PR preserves the original same-repository branch `agent/human-readable-delivery-control-prompts`, now targets `develop`, and contains only the prompt, protocol, executor-documentation, and focused contract-test step that was originally developed on top of #785.

## Problem

Repository-owned executor prompts still instruct autonomous agents to post bare JSON delivery-control ledger comments, even though the parser now supports a human-readable Markdown wrapper.

## Design

- Make the readable Markdown wrapper the canonical autonomous issue-comment format.
- Keep the exact markers and lowercase `json` fence, with the marked JSON as the sole authority and prose as derived display text.
- Preserve legacy bare-JSON parser compatibility and raw `workflow_dispatch` input.
- Update the ChatGPT, Codex Cloud, and Local Codex prompt/runbook surfaces without changing lifecycle, routing, guards, reactions, concurrency, or target-comment policy.
- Add focused repository contract assertions for prompt semantics and the canonical protocol example.

## Compatibility impact

Documentation and checked-in prompt behavior only. Legacy bare JSON remains accepted, `workflow_dispatch` remains raw JSON, and no parser, workflow, Java API, dependency, or Project schema behavior changes in this PR.

## Dependency changes

None.

## Tests and checks

- `node --check .github/scripts/delivery-control.js && node --check .github/scripts/delivery-control.test.js && node --check .github/scripts/delivery-control-post-mutation.test.js && node --check .github/scripts/delivery-policy.test.js`
- `node --test .github/scripts/delivery-control.test.js .github/scripts/delivery-control-post-mutation.test.js .github/scripts/delivery-policy.test.js` (35 tests passed)
- `git diff --check`
- Compared the original stacked diff against `origin/agent/human-readable-delivery-control`; only prompt, protocol, executor documentation, and focused contract-test files differed.
- After retargeting to `develop`, exact-head `AI delivery control`, `AI delivery status`, and `Check Pull Request` workflows succeeded.

YAML parse checks were not run because no YAML files changed. Cross-module Maven verification was not run because this documentation/Node contract-only change does not affect Java or release artifacts.

## Limitations and remaining risks

Existing deployed scheduled-task text must still be refreshed according to its documented operational process after merge. This PR does not authorize merge or auto-merge.

## Published head

`7815c81b6c46c17854b251d7643473117e12be39`
