### PR TITLE
Require blocking reviews to complete lifecycle handoff

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -136,8 +136,15 @@ Perform this protocol:
      has been selected. Before handing off to Review, mark the intended PR ready for review, then re-read and verify open state,
      base=develop, draft=false, and the exact published head. Do not claim Review publication while the PR remains draft.
    - Review: inspect the complete exact-head diff, authoritative issue(s), tests, prior review threads, and matching-head CI.
-     Submit APPROVE only with independent identity. Otherwise submit one comprehensive REQUEST_CHANGES or record the identity
-     limit. A same-repository PR may be returned to a deliberately selected ChatGPT or Local Codex continuation on the same branch.
+     Submit APPROVE only with independent identity. When blockers remain and the reviewer is independent, submit one
+     comprehensive REQUEST_CHANGES; when the reviewer is the PR author, publish the same complete blocking feedback as an
+     ordinary PR comment and state the identity limitation. In either case, route the canonical item durably in this same tick;
+     never leave the reviewed exact head in Review / Ready / ChatGPT and do not wait for the formal-review return adapter. Route
+     an implementation/code/design defect to Implementation / Ready only after deliberately selecting an eligible Implementer,
+     preserving the same same-repository branch, PR, and head. Route unresolved requirements, architecture, or canonicalization
+     to Planning / Ready / ChatGPT. Use Blocked / Human only for one exact Dmitry decision or action. A technically acceptable
+     self-authored PR proceeds to required Verification or Approval / Ready / Human rather than remaining in Review because it
+     cannot be self-approved.
      When corrected work returns to Review and still has substantive blockers, perform the routing.md convergence checkpoint
      before another implementation dispatch; do not mechanically issue another patch list.
    - Verification: validate the observable result against the authoritative issue or PR using the exact published head/artifact in
@@ -148,7 +155,9 @@ Perform this protocol:
    state. Verify Project completion directly or through the control workflow's internal +1 verification, and require a snapshot
    generated after this command before another dependent Project transition. Update GitHub Assignee separately when supported and
    verify it. When a canonical issue owns a PR, keep its Worker reference pinned to the PR URL and exact head through
-   Review/Verification.
+   Review/Verification. Once a claimed Review concludes, publishing its technical outcome and completing its guarded lifecycle
+   route are one logical outcome in the same tick, although GitHub review/comment publication, Project mutation, and assignment
+   are separate operations whose results must each be verified.
 10. Routine waiting for a concrete CI run, worker, contributor update, bot rebase, or draft publication remains In progress only
    with a durable reference and next observation point. Blocked always routes an exact action to Human/bedrin.
 11. Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged

--- a/.github/scripts/delivery-policy.test.js
+++ b/.github/scripts/delivery-policy.test.js
@@ -102,6 +102,36 @@ test('every implementation executor publishes a non-draft exact-head PR before R
   assert.match(workflow, /REPOSITORY_TOKEN:\s*\$\{\{ github\.token \}\}/);
 });
 
+test('blocking Review always publishes feedback and completes a same-tick durable route', () => {
+  const prompt = read('.chatgpt/scheduled-task-prompt.md');
+  const supervision = read('docs/ai-delivery/supervision.md');
+  const chatgpt = read('docs/ai-delivery/executors/chatgpt.md');
+  const reviewReturn = read('docs/ai-delivery/review-return.md');
+
+  assert.match(prompt, /reviewer is independent[\s\S]*comprehensive REQUEST_CHANGES/i);
+  assert.match(prompt, /reviewer is the PR author[\s\S]*ordinary\s+PR\s+comment[\s\S]*identity limitation/i);
+  assert.match(prompt, /In either case, route the canonical item durably in this same tick/i);
+  assert.match(prompt, /never leave the reviewed exact head in Review \/ Ready \/ ChatGPT/i);
+  assert.match(prompt, /do not wait for the formal-review return adapter/i);
+  assert.match(prompt, /technically acceptable[\s\S]*Verification or Approval \/ Ready \/ Human/i);
+
+  for (const [file, content] of [
+    ['docs/ai-delivery/supervision.md', supervision],
+    ['docs/ai-delivery/executors/chatgpt.md', chatgpt]
+  ]) {
+    assert.match(content, /technical Review outcome|technical outcome/i, `${file} must separate technical outcome from identity`);
+    assert.match(content, /same tick/i, `${file} must require immediate durable routing`);
+    assert.match(content, /ordinary\s+PR\s+comment/i, `${file} must define the self-review blocker path`);
+    assert.match(content, /Implementation \/ Ready/i, `${file} must define implementation-defect routing`);
+    assert.match(content, /Planning \/ Ready \/ ChatGPT/i, `${file} must define planning-defect routing`);
+    assert.match(content, /Blocked \/ Human/i, `${file} must preserve human-blocker semantics`);
+  }
+
+  assert.match(reviewReturn, /recovery path for independently submitted formal reviews/i);
+  assert.match(reviewReturn, /not the primary or only correction\s+route/i);
+  assert.match(reviewReturn, /ordinary blocker comment[\s\S]*no\s+`pull_request_review` event/i);
+});
+
 test('Local Codex uses one bounded normalized Project snapshot per tick', () => {
   const dispatcher = read('.codex/local/scheduled-task-prompt.md');
   const helper = read('.codex/local/project-queue-snapshot.sh');

--- a/docs/ai-delivery/executors/chatgpt.md
+++ b/docs/ai-delivery/executors/chatgpt.md
@@ -185,10 +185,18 @@ to Local Codex, return to Planning, or block for Dmitry. This is a Review decisi
 
 ## Review identity limitation
 
-A PR authored by `bedrin-gpt` cannot be formally approved by the same identity. ChatGPT still performs full Review and routed
-Verification, then leaves exact ready-for-Dmitry-review or blocking feedback. A Dmitry-, Dependabot-, external-contributor-, IDE-,
-or independently-agent-authored PR may receive an honest formal ChatGPT review. This decision uses the actual PR author, not the
-optional Project Implementer field.
+A PR authored by `bedrin-gpt` cannot be formally approved or receive formal `REQUEST_CHANGES` from the same identity. This limits
+the GitHub review submission, not the technical Review outcome or ChatGPT's lifecycle authority. For an independent author,
+ChatGPT publishes one complete formal `REQUEST_CHANGES` when blockers remain. For its own PR, it publishes the same complete
+blocking feedback as an ordinary PR comment and states the identity limitation. Both paths perform the guarded durable route in
+the same tick; they never leave that exact head in `Review / Ready / ChatGPT` or wait for the formal-review return adapter.
+
+Implementation, code, or design defects return to `Implementation / Ready` only after ChatGPT deliberately selects an eligible
+Implementer and preserves the same same-repository branch, PR, and head. Requirements, architecture, or canonicalization defects
+return to `Planning / Ready / ChatGPT`; `Blocked / Human` requires one exact Dmitry decision or action. If the self-authored PR is
+technically acceptable, ChatGPT routes it to required Verification or `Approval / Ready / Human` rather than parking it in
+Review. A Dmitry-, Dependabot-, external-contributor-, IDE-, or independently-agent-authored PR may receive an honest formal
+ChatGPT review. Identity is determined from the actual PR author, not the optional Project Implementer field.
 
 ## Website verification
 

--- a/docs/ai-delivery/review-return.md
+++ b/docs/ai-delivery/review-return.md
@@ -4,6 +4,12 @@
 
 When an authorized independent reviewer submits a formal `REQUEST_CHANGES` review on an agent-implemented pull request, the next action is implementation correction. This adapter returns the existing Project 2 work item to the original agent pool so the normal event loop can claim and continue the same branch and pull request.
 
+This event-driven adapter is a recovery path for independently submitted formal reviews, not the primary or only correction
+route. A ChatGPT Review turn explicitly performs its guarded lifecycle handoff in the same tick after publishing blocking
+feedback. When ChatGPT is also the PR author, it publishes an ordinary blocker comment and routes directly because no
+`pull_request_review` event can honestly be created. An independently submitted formal review may race with or recover a missed
+direct handoff; the adapter's guards and idempotence preserve the resulting state.
+
 ## Trigger and target selection
 
 The `Return requested changes to implementer` workflow listens to submitted `pull_request_review` events. It runs only for same-repository pull requests targeting `develop`; it never checks out or executes the reviewed head.

--- a/docs/ai-delivery/supervision.md
+++ b/docs/ai-delivery/supervision.md
@@ -63,6 +63,10 @@ A worker completes one lifecycle turn and writes the next route through the comm
 - Successful Verification writes `Approval / Ready / Human`.
 - Approval becomes `Done` only after actual merge or deliberate closure.
 
+Once a claimed Review concludes, its technical outcome and durable lifecycle route are one logical outcome in the same tick.
+GitHub review or comment publication, the guarded Project mutation, and assignment remain separate operations and each must be
+verified, but failure or inability to submit a formal review does not permit the exact head to remain `Review / Ready / ChatGPT`.
+
 The control plane re-checks the review PR after all expected-state guards pass and marks it ready if an executor left it draft. That
 is a final invariant and recovery mechanism, not permission for executors to skip publication. It verifies the same exact head
 before Project Review is written.
@@ -205,10 +209,17 @@ acknowledged. The convergence checkpoint itself needs no schedule.
 Formal review must use an identity independent from the PR author.
 
 - When independent review is available and proof passes, submit `APPROVE`.
-- When blockers remain, submit one precise `REQUEST_CHANGES`, then explicitly route the canonical item to an implementation or
-  external-author correction path.
-- When the active identity cannot review its own PR, leave exact ready-for-Dmitry-review or blocking feedback and state the
-  identity limitation.
+- When blockers remain and the identity is independent, submit one precise `REQUEST_CHANGES`, then explicitly route the canonical
+  item in the same Review tick.
+- When blockers remain and the active identity is the PR author, publish the same complete blocking feedback as an ordinary PR
+  comment, state the identity limitation, and explicitly route the canonical item in the same Review tick. Do not wait for the
+  formal-review return adapter.
+- Route an implementation, code, or design defect to `Implementation / Ready` only after deliberately selecting an eligible
+  Implementer and preserving the same same-repository branch, PR, and exact head. Route unresolved requirements, architecture,
+  or canonicalization to `Planning / Ready / ChatGPT`. Use `Blocked / Human` only when one exact Dmitry decision or action is
+  required.
+- When proof passes but the identity is the PR author, continue to required Verification or `Approval / Ready / Human`; inability
+  to self-approve must not park the exact head in Review.
 
 A Dmitry-, Dependabot-, external-contributor-, or other independently authored PR may receive a formal `bedrin-gpt` review.
 A `bedrin-gpt`-authored PR cannot. That identity rule comes from the PR author, not the optional Project Implementer field.


### PR DESCRIPTION
## Problem
A completed technical Review could publish substantive blocking feedback but leave the canonical item at `Review / Ready / ChatGPT` when the active GitHub identity was also the PR author and could not submit formal `REQUEST_CHANGES`.

## Design
- Require both independent-review `REQUEST_CHANGES` and same-identity ordinary blocker-comment paths to complete a guarded durable lifecycle route in the same Review tick.
- Define defect routing to a deliberately selected Implementer, unresolved planning/architecture routing back to Planning, and true Dmitry-only blockers to Human.
- Require technically acceptable self-authored work to proceed to Verification or Approval rather than remaining parked in Review.
- Preserve the formal Request Changes return adapter as an idempotent recovery path for independently submitted reviews.
- Add focused policy assertions covering both reviewer identity paths and the terminal-state invariant.

## Develop reconciliation
Merged current `develop` into the existing branch without rebase or history rewriting. The sole content conflict in `docs/ai-delivery/review-return.md` was resolved by preserving both policies: the adapter remains recovery for independently submitted reviews, and formal maintainer Request Changes can return eligible work after Review has advanced it to Verification or Approval.

## Compatibility and dependencies
Documentation/prompt/test-only change. No runtime, public API, Java compatibility, dependency, workflow permission, or merge-authority changes.

## Tests and checks
- `node --check .github/scripts/delivery-policy.test.js`
- `node --test .github/scripts/delivery-policy.test.js` — 9/9 passed
- broader delivery-policy suite — 80/80 passed
- `git diff --check origin/develop`
- Exact-head Check Pull Request run [30719598784](https://github.com/sniffy/sniffy/actions/runs/30719598784) is successful across all 26 jobs. Attempt 1 had one macOS Intel JDK 25 `UnknownHostException: google.com` infrastructure failure after the other 25 jobs passed; isolated rerun job [91422549570](https://github.com/sniffy/sniffy/actions/runs/30719598784/job/91422549570) passed without a code change.
- Exact-head dependency submission, delivery status/control/review-return validation, and all four Codecov checks passed; CodeQL concluded neutral after the successful Analyze job.

## Limitations and remaining risks
This change makes the behavior enforceable in the authoritative ChatGPT prompt and policy regression suite; it does not make GitHub Project mutation transactional. Review/comment publication, guarded Project mutation, and assignment remain separately verified operations.

Exact published head: `b88a45041defb8a3c068af75dcbe6661e174b071`

Closes #787
