### PR TITLE
Speed up Local Codex claim fast path

### DIFF
--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -35,15 +35,23 @@ the worker's PR, merge, or enable auto-merge.
    connector, combine stale snapshots, or infer eligibility from issue/PR state alone. Report `RATE_LIMITED: no claim made` in this
    dispatcher conversation and stop.
 4. Inspect `ownedInProgress` from the retained snapshot first. Continue only an item whose worker or monitoring observation is due
-   under the 15-minute, second-15-minute, then hourly cadence. Do not create another monitor.
+   under the 15-minute, second-15-minute, then hourly cadence. Do not create another monitor. A provider-wide Codex project/task
+   inventory is allowed only to recover one selected `In progress` item whose provisional Worker reference leaves child creation
+   uncertain; scope the result to that claim token and generation.
 5. Otherwise use the already sorted `readyCandidates` array and choose at most its first candidate, subject to canonical duplicate
-   suppression and current capacity. Eligible work has Execution=Ready, Executor=Local Codex, Status=Implementation or
-   Verification, and an empty or local-worker Assignee.
+   suppression and available capacity. Compute available capacity from `executors.Local Codex.maxConcurrentWorkers` in the loaded
+   profile minus the length of `ownedInProgress` in the retained snapshot. Treat this as the single-dispatcher scheduling limit,
+   not a distributed semaphore. Do not call `List projects`, list tasks/conversations, or use any other provider-wide inventory on
+   the normal `Ready` claim path. Eligible work has Execution=Ready, Executor=Local Codex, Status=Implementation or Verification,
+   and an empty or local-worker Assignee.
 6. If neither a due owned item nor a ready candidate exists, create no task, worktree, branch, target comment, control command, or
    Project mutation. Reply only NO_CHANGE.
-7. Only after one candidate is selected, perform targeted deep reads for that canonical issue or PR: formal closing links, routing,
-   proof matrix, exact branch/PR/head, worker reference, review state, CI, and duplicate-worker evidence. Use targeted `gh issue
-   view`, `gh pr view`, Actions, and control-issue reads; never refetch the full Project snapshot for this inspection.
+7. Only after one candidate is selected, perform the minimum targeted live reads needed to construct the guarded claim and render
+   its worker: canonical item type/open state, formal closing links, exact existing PR branch/head and repository ownership when
+   applicable, plus the newest active control issue. Do not read the complete discussion, proof matrix, review submissions,
+   review threads, or CI before claim; the lifecycle worker owns those reads. Never refetch the full Project snapshot or query
+   provider-wide Codex inventory for duplicate-worker evidence. Per-target guarded claim serialization is the duplicate-generation
+   authority.
 8. An existing same-repository PR may be an adopted continuation even when Dmitry, ChatGPT, an IDE agent, or another configured
    worker created it. Adoption is valid only when the retained snapshot and targeted reads show the canonical Project route sets
    Implementer/Executor=Local Codex. Reuse the exact branch and PR. Do not adopt fork or Dependabot branches for direct correction.
@@ -61,7 +69,9 @@ the worker's PR, merge, or enable auto-merge.
 13. Do not use shell UI automation, Python observers, codex app-server, codex exec, or .codex/local/run-issue.sh for this
     app-native adapter.
 14. After confirming the child task exists, publish one guarded control command updating the final worker reference, then verify
-    it. If child creation fails, release to Ready through the same protocol. Set Blocked only when Dmitry must decide or act.
+    it. If child creation definitively fails, release to Ready through the same protocol. If the creation result is ambiguous, keep
+    the provisional `In progress` ownership for targeted recovery under step 4; never release and redispatch speculatively. Set
+    Blocked only when Dmitry must decide or act.
 
 Never dispatch the same lifecycle generation twice. Never merge or enable auto-merge.
 ```
@@ -71,6 +81,10 @@ Never dispatch the same lifecycle generation twice. Never merge or enable auto-m
 Before enabling or replacing the recurring dispatcher, prove with disposable/read-only items that:
 
 - one tick invokes `project-queue-snapshot.sh` once and never invokes `gh project item-list` directly;
+- a normal `Ready` claim derives capacity from `ownedInProgress` plus `maxConcurrentWorkers` and performs no provider-wide Codex
+  project/task inventory;
+- recovery may inspect provider inventory only for one provisional `In progress` claim token/generation after ambiguous child
+  creation;
 - an empty snapshot stays in this conversation and creates no worktree;
 - a rate-limited snapshot creates no claim and does not switch data sources;
 - one eligible issue item creates exactly one standalone worker conversation and isolated WSL worktree;

--- a/.github/scripts/delivery-policy.test.js
+++ b/.github/scripts/delivery-policy.test.js
@@ -34,6 +34,7 @@ test('profile makes universal intake and existing-PR routing explicit', () => {
   assert.match(profile, /noClosingIssue:\s*pullRequest/);
   assert.match(profile, /multipleClosingIssues:\s*pullRequestPlanning/);
   assert.match(profile, /existingPullRequestContinuationExecutor:\s*Local Codex/);
+  assert.match(profile, /Local Codex:[\s\S]*maxConcurrentWorkers:\s*1/);
 });
 
 test('Local Codex can adopt an explicitly routed same-repository PR without duplication', () => {
@@ -110,6 +111,10 @@ test('Local Codex uses one bounded normalized Project snapshot per tick', () => 
   assert.match(dispatcher, /only normal full-Project query/i);
   assert.match(dispatcher, /Do not run `gh project item-list`/i);
   assert.match(dispatcher, /Do not switch to another\s+connector, combine stale snapshots/i);
+  assert.match(dispatcher, /Compute available capacity from `executors\.Local Codex\.maxConcurrentWorkers`[\s\S]*`ownedInProgress`/i);
+  assert.match(dispatcher, /Do not call `List projects`[\s\S]*provider-wide inventory on\s+the normal `Ready` claim path/i);
+  assert.match(dispatcher, /inventory is allowed only to recover one selected `In progress` item[\s\S]*claim token and generation/i);
+  assert.match(dispatcher, /Do not read the complete discussion, proof matrix, review submissions,[\s\S]*the lifecycle worker owns those reads/i);
   assert.equal((helper.match(/^\s*if ! gh project item-list\b/gm) || []).length, 1);
   assert.match(helper, /exit 75/);
 

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -223,6 +223,13 @@ The canonical work item may be an issue or pull request. The dispatcher also che
 worker-pool capacity, existing branch/PR ownership, and absence of a valid current worker. It excludes duplicate representations
 and linked issues suppressed by an open canonical multi-issue PR.
 
+When a profile defines a worker limit, the normal dispatcher derives used capacity from owned `In progress` items in the same
+retained authoritative queue snapshot used for selection. Provider project/task/conversation inventory is not a normal pre-claim
+capacity or duplicate-worker check: it is slower, can be stale, and cannot make `inventory -> claim` atomic. Use provider inventory
+only for targeted recovery of an already claimed `In progress` generation when provisional worker evidence leaves child creation
+uncertain. Per-target duplicate-generation exclusion comes from the guarded claim. A strict cross-target global pool limit across
+several concurrent dispatchers requires a separately serialized semaphore; provider inventory is not that semaphore.
+
 Eligibility must not require `Implementer` or `Verifier` to be populated when the current status does not use them. A blank
 `Implementer` means unknown/not deliberately selected, while `Executor` remains the authoritative current route. Entering
 Implementation requires a non-empty deliberately selected Implementer; Review, PR monitoring, Verification, Approval, and closure

--- a/docs/ai-delivery/executors/codex-local.md
+++ b/docs/ai-delivery/executors/codex-local.md
@@ -32,6 +32,9 @@ The local scheduled automation selects its model and reasoning for the automatio
 workers therefore use Sol / extra-high consistently. Do not label Codex Cloud as Terra and do not pretend the local dispatcher can
 switch models per item unless a future product capability is explicitly smoke-tested and the profile is changed.
 
+The app-native dispatcher currently permits one concurrent Local Codex worker. It derives used capacity from `ownedInProgress` in
+the one retained Project snapshot. This is a scheduling policy for the single persistent dispatcher, not a distributed semaphore.
+
 ## App-native topology
 
 ```text
@@ -101,6 +104,9 @@ Both adapters:
 - accept issue and PR Project items;
 - respect directed Assignee or empty pool ownership;
 - inspect canonicalization, lifecycle, profile, access, capacity, exact branch/PR/head, current worker, and due monitoring;
+- derive normal capacity and duplicate-generation decisions from the retained Project snapshot plus the guarded claim, without a
+  provider-wide Codex project/task inventory before claiming `Ready` work;
+- use provider inventory only for targeted recovery of one provisional `In progress` claim after ambiguous child creation;
 - exclude duplicate representations and linked issues suppressed by an open canonical multi-issue PR;
 - use the one active technical control issue and one guarded `delivery-control/v1` command per claim/transition;
 - inspect the reaction and re-read Project state before spawning;

--- a/docs/ai-delivery/profile.yml
+++ b/docs/ai-delivery/profile.yml
@@ -52,6 +52,9 @@ executors:
     assignee: bedrin-codex-local
     model: Sol
     reasoning: extra-high
+    # App-native dispatch derives this scheduling limit from the retained Project snapshot.
+    # Provider-wide Codex project/task inventory is recovery evidence, not a normal capacity source.
+    maxConcurrentWorkers: 1
   Human:
     assignee: bedrin
 


### PR DESCRIPTION
## Problem

The Local Codex dispatcher already selects candidates from one normalized Project snapshot, but the prompt still requires unspecified capacity and duplicate-worker evidence before claim. In practice this can trigger a slow provider-wide `List projects` inventory plus duplicate reads of discussion, reviews, and CI that the lifecycle worker performs again.

## Design

- define the app-native Local Codex scheduling capacity as one worker;
- derive used capacity from `ownedInProgress` in the retained Project snapshot;
- keep normal pre-claim reads to canonical identity, formal links, exact continuation PR identity, and the active control issue;
- make the guarded per-target CAS claim authoritative for duplicate-generation exclusion;
- reserve provider-wide Codex inventory for targeted recovery of an ambiguous provisional `In progress` claim;
- preserve ambiguous child-creation ownership instead of speculatively releasing and redispatching it;
- add policy tests that fail if app-wide inventory or duplicated worker-owned reads return to the normal Ready path.

## Impact and compatibility

This changes only AI delivery prompts, profile configuration, documentation, and policy tests. It does not change Sniffy runtime code, public APIs, dependencies, GitHub workflow permissions, or the delivery-control implementation.

The configured one-worker limit is a scheduling policy for the single persistent app-native dispatcher. It is intentionally not presented as a distributed cross-target semaphore.

## Validation

- `bash -n .codex/local/project-queue-snapshot.sh`
- Node syntax checks for delivery-control and policy test sources
- `node --test .github/scripts/delivery-control.test.js .github/scripts/delivery-control-post-mutation.test.js .github/scripts/delivery-policy.test.js` — 34 passed
- `python -c "import yaml; yaml.safe_load(open('docs/ai-delivery/profile.yml'))"`
- `git diff --check`

The workflow's Ruby YAML parser was not available locally; the profile was parsed with PyYAML and will also be parsed by the PR validation job.

## Remaining risk

If several independent dispatchers are later enabled and a strict cross-target global worker cap is required, that cap will need a separately serialized semaphore. A provider inventory read cannot provide that guarantee.

Exact published head: `77b91d77c99f0a12e0f0eb6539ce4ba5a4d03536`