### PR TITLE
Refresh AI delivery status on demand

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -43,9 +43,16 @@ Do not create another Scheduled Task, child ChatGPT task, or promise future/back
 the current UTC timestamp as the dispatcher reference.
 
 ProjectV2 read protocol:
-- Prefer a complete direct organization ProjectV2 read when the connected tool actually succeeds. If direct ProjectV2 access is
-  unavailable, incomplete, or fails, apply .chatgpt/status-snapshot-instructions.md before intake, reconciliation, continuation,
-  or ordinary queue selection.
+- At the start of every tick, apply .chatgpt/status-snapshot-instructions.md as an on-demand refresh barrier. Discover the newest
+  open non-PR issue labeled ai-delivery-status, add exactly one `/ai-delivery-status refresh` comment, and wait up to the configured
+  120 seconds for the terminal +1 reaction on that exact comment. A -1 or missing terminal reaction blocks snapshot-dependent work;
+  do not retry in the same tick or fall back to the pointer that existed before the request.
+- After +1, rediscover and validate the pointer. Require `generatedAt` to be strictly later than the request comment's `createdAt`.
+  Normally require `source.workflowRun.refreshRequest.commentId` to equal the request comment ID; a pointer replaced by a later
+  serialized successful trigger is acceptable only when it is demonstrably newer than the request.
+- A complete direct organization ProjectV2 read may remain the selected read path when the connected tool actually succeeds, but
+  it does not skip the refresh barrier. If direct ProjectV2 access is unavailable, incomplete, or fails, use the acknowledged
+  snapshot for intake, reconciliation, continuation, or ordinary queue selection.
 - Discover the newest open non-PR issue labeled ai-delivery-status; never hardcode its issue number. Parse and validate its pure
   JSON pointer, require the configured protocol/repository/Project/artifact identity and freshness, then download the artifact by
   numeric artifact ID through the default GitHub connector and read project-2-status.json.
@@ -156,7 +163,8 @@ Perform this protocol:
 11. Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged
     repository/hosting operations without Dmitry's explicit instruction.
 12. If no eligible intake, head reconciliation, due continuation, control-log rotation, claimable turn, or meaningful
-    reconciliation exists, make no GitHub/source mutation and reply only NO_CHANGE. Otherwise finish with a compact summary
+    reconciliation exists, make no further GitHub or source mutation beyond the required status-refresh request and reply only
+    NO_CHANGE. Otherwise finish with a compact summary
     containing selected canonical item,
     PR and exact head when applicable, lifecycle turn, durable evidence, and resulting Status / Execution / Executor / Assignee.
 ```

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -1,25 +1,37 @@
 # Sniffy status-snapshot instructions for ChatGPT ticks
 
-Apply this supplement before Project intake, reconciliation, continuation, or ordinary queue selection when direct organization
-ProjectV2 reads are unavailable or fail.
+Apply this supplement at the start of every scheduled ChatGPT tick, before Project intake, reconciliation, continuation, or
+ordinary queue selection. A complete direct organization ProjectV2 read may remain the selected read path, but it does not skip
+this on-demand refresh barrier: the refreshed artifact is the deterministic fallback and durable read evidence for the tick.
 
 1. Search `sniffy/sniffy` for open issues labeled `ai-delivery-status`. Select the newest non-pull-request issue by issue number.
-   Never hardcode its number. Do not claim, assign, close, discuss work in, or add control commands to this technical issue.
-2. Parse the entire issue body as JSON. Require:
+   Never hardcode its number. Do not claim, assign, close, discuss work in, or add delivery-control commands to this technical
+   issue.
+2. Add exactly one comment whose entire body is `/ai-delivery-status refresh`. Record its comment ID and `createdAt`; do not add
+   prose, Markdown wrappers, or another request for the same tick. Wait no more than `statusSnapshot.refreshTimeoutSeconds` from
+   `docs/ai-delivery/profile.yml` for a terminal reaction on that exact comment:
+   - `+1` means the workflow published a new artifact and pointer, then acknowledged this request;
+   - `-1` means publication failed; report the refresh blocker and perform no snapshot-dependent claim or transition;
+   - no terminal reaction before the deadline is an unavailable refresh, not permission to use the pre-request pointer. Do not
+     retry in the same tick.
+3. After `+1`, rediscover the newest open status issue and parse its entire body as JSON. Require:
    - `schemaVersion = 1`;
    - `kind = ai-delivery-status/v1`;
    - `source.repository = sniffy/sniffy`;
    - `source.project.owner = sniffy` and `source.project.number = 2`;
    - `artifact.name = ai-delivery-status-project-2`;
    - a numeric `artifact.id` and file name `project-2-status.json`;
-   - `generatedAt` no older than `statusSnapshot.maxAgeMinutes` in `docs/ai-delivery/profile.yml`.
-3. Download that artifact by numeric ID with the default GitHub connector. Read `project-2-status.json` from the ZIP. Validate the
-   same schema/kind/repository/Project identity, require its `generatedAt` to match the pointer, and reject inconsistent counts or
-   an incomplete/malformed file.
-4. Use only the snapshot's explicit `fields`/`fieldValues` as ProjectV2 read state. An absent field value is represented as `null`;
+   - `generatedAt` strictly later than the refresh request's `createdAt` and no older than `statusSnapshot.maxAgeMinutes`;
+   - normally, `source.workflowRun.event = issue_comment` and `source.workflowRun.refreshRequest.commentId` equals the exact
+     request comment ID. Because publication is serialized, a pointer subsequently replaced by another successful trigger is also
+     acceptable when its `generatedAt` is strictly later than the request; it is necessarily at least as fresh.
+4. Download that artifact by numeric ID with the default GitHub connector. Read `project-2-status.json` from the ZIP. Validate the
+   same schema/kind/repository/Project identity, require its `generatedAt` and workflow-run provenance to match the pointer, and
+   reject inconsistent counts or an incomplete/malformed file.
+5. Use only the snapshot's explicit `fields`/`fieldValues` as ProjectV2 read state. An absent field value is represented as `null`;
    do not infer it from prose, authorship, prior chat state, or defaults. The file contains active Sniffy items only. The raw files
    are diagnostic and are not the ordinary queue.
-5. Before ordinary queue selection, inspect the snapshot's top-level `pullRequests` observations for `mergeable = CONFLICTING` or
+6. Before ordinary queue selection, inspect the snapshot's top-level `pullRequests` observations for `mergeable = CONFLICTING` or
    `mergeStateStatus = DIRTY`. This collection is independent of Project item type; use `closingIssueNumbers` to resolve the
    canonical issue-versus-PR identity before routing, without activating a duplicate PR lifecycle item. Treat each same-repository,
    non-Dependabot agent PR as a priority continuation/reconciliation obligation. Re-read the live PR first and require it still to
@@ -27,17 +39,18 @@ ProjectV2 reads are unavailable or fail.
    route conflict resolution to an eligible implementation executor, then start the normal 15-minute, second-15-minute, and hourly
    observation cycle. Fork PRs wait for their contributor, and Dependabot PRs use `@dependabot rebase`; never adopt or rewrite those
    branches through this rule.
-6. Re-read current issue/PR open/draft state, exact branch/head, formal closing links, assignment, reviews, threads, matching CI,
+7. Re-read current issue/PR open/draft state, exact branch/head, formal closing links, assignment, reviews, threads, matching CI,
    and mergeability through live GitHub operations before acting. Snapshot source metadata and mergeability are discovery hints,
    not mutation authority.
-7. Use snapshot values to construct guarded `delivery-control/v1` expected fields. A successful mutation still depends on the
+8. Use snapshot values to construct guarded `delivery-control/v1` expected fields. A successful mutation still depends on the
    control workflow's live serialized ProjectV2 comparison and verification.
-8. On `confused`, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run. On
+9. On `confused`, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run. On
    `+1`, the control workflow's internal final-state verification is authoritative for that command.
-9. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command. The status
-   workflow is triggered after delivery-control completion and also runs four times per hour. Do not chain dependent Project writes
-   from an older materialized view.
-10. If the status issue, pointer, artifact, or snapshot is missing, expired, inaccessible, malformed, mismatched, or stale, make no
-    snapshot-dependent Project claim or transition. Report the exact status-read blocker; do not guess.
-11. Exclude issues labeled `ai-delivery-control` or `ai-delivery-status` from canonical work selection even if Project automation
+10. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command. The status
+    workflow is triggered after delivery-control completion; request another on-demand refresh only when that event did not yield
+    a sufficiently new pointer. Do not chain dependent Project writes from an older materialized view.
+11. If the status issue, refresh acknowledgement, pointer, artifact, or snapshot is missing, expired, inaccessible, malformed,
+    mismatched, or stale, make no snapshot-dependent Project claim or transition. Report the exact status-read blocker; do not
+    guess.
+12. Exclude issues labeled `ai-delivery-control` or `ai-delivery-status` from canonical work selection even if Project automation
     materialized them.

--- a/.github/scripts/delivery-status-policy.test.js
+++ b/.github/scripts/delivery-status-policy.test.js
@@ -18,6 +18,9 @@ test('ChatGPT scheduled ticks require the labeled status artifact fallback', () 
   assert.match(prompt, /download the artifact by\s+numeric artifact ID/is);
   assert.match(prompt, /read project-2-status\.json/i);
   assert.match(prompt, /missing, expired, inaccessible, malformed, mismatched, or stale snapshot/i);
+  assert.match(prompt, /\/ai-delivery-status refresh/);
+  assert.match(prompt, /terminal \+1 reaction/i);
+  assert.match(prompt, /refreshRequest\.commentId/i);
 });
 
 test('snapshot-backed commands retain live compare-and-set semantics', () => {
@@ -36,6 +39,9 @@ test('profile fixes the status protocol, label, artifact and freshness contract'
   assert.match(profile, /artifactName:\s*"ai-delivery-status-project-2"/);
   assert.match(profile, /snapshotFile:\s*"project-2-status\.json"/);
   assert.match(profile, /maxAgeMinutes:\s*30/);
+  assert.match(profile, /refreshCommand:\s*"\/ai-delivery-status refresh"/);
+  assert.match(profile, /refreshTimeoutSeconds:\s*120/);
+  assert.match(profile, /refreshActors:\s*\[bedrin, bedrin-gpt\]/);
 });
 
 test('status documentation preserves the read-only mutation boundary', () => {
@@ -49,8 +55,15 @@ test('status documentation preserves the read-only mutation boundary', () => {
 test('workflow isolates validation and trusted status publication', () => {
   const workflow = read('.github/workflows/delivery-status.yml');
   assert.match(workflow, /permissions:\s*\{\}/);
-  assert.match(workflow, /cron:\s*'5,20,35,50 \* \* \* \*'/);
+  assert.match(workflow, /cron:\s*'5 \* \* \* \*'/);
   assert.match(workflow, /workflows:\s*\[AI delivery control\]/);
+  assert.match(workflow, /issue_comment:\s*\n\s+types:\s*\[created\]/);
+  assert.match(workflow, /github\.event\.comment\.body == '\/ai-delivery-status refresh'/);
+  assert.match(workflow, /contains\(github\.event\.issue\.labels\.\*\.name, 'ai-delivery-status'\)/);
+  assert.match(workflow, /fromJSON\('\["bedrin","bedrin-gpt"\]'\)/);
+  assert.match(workflow, /content:\s*'\+1'/);
+  assert.match(workflow, /content:\s*'-1'/);
+  assert.match(workflow, /refreshRequest:/);
   assert.match(workflow, /ref:\s*develop/);
   assert.match(workflow, /issues:\s*write/);
   assert.match(workflow, /pull-requests:\s*read/);

--- a/.github/scripts/delivery-status.js
+++ b/.github/scripts/delivery-status.js
@@ -311,6 +311,21 @@ function parseArguments(argv) {
   return result;
 }
 
+function refreshRequest(options) {
+  if (!options['request-comment-id']) return null;
+  const commentId = Number(options['request-comment-id']);
+  const issueNumber = Number(options['request-issue-number']);
+  const actor = options['request-actor'];
+  if (!Number.isSafeInteger(commentId) || commentId <= 0) {
+    throw new Error(`Invalid refresh request comment id: ${options['request-comment-id']}`);
+  }
+  if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error(`Invalid refresh request issue number: ${options['request-issue-number'] ?? '<missing>'}`);
+  }
+  if (!actor) throw new Error('Missing refresh request actor.');
+  return {commentId, issueNumber, actor};
+}
+
 function normalizeCommand(argv) {
   const options = parseArguments(argv);
   for (const required of ['fields', 'items', 'issues', 'pull-requests', 'output', 'generated-at', 'repository', 'project-owner', 'project-number', 'workflow-run-id']) {
@@ -334,7 +349,8 @@ function normalizeCommand(argv) {
       attempt: Number(options['workflow-run-attempt'] ?? 1),
       event: options.event ?? null,
       upstreamRunId: options['upstream-run-id'] ? Number(options['upstream-run-id']) : null,
-      headSha: options['head-sha'] ?? null
+      headSha: options['head-sha'] ?? null,
+      refreshRequest: refreshRequest(options)
     }
   });
   fs.writeFileSync(options.output, `${JSON.stringify(snapshot, null, 2)}\n`);
@@ -364,5 +380,6 @@ module.exports = {
   isActiveItem,
   normalizeItem,
   pointerPayload,
-  publishStatusPointer
+  publishStatusPointer,
+  refreshRequest
 };

--- a/.github/scripts/delivery-status.test.js
+++ b/.github/scripts/delivery-status.test.js
@@ -6,7 +6,8 @@ const {
   buildSnapshot,
   findOrCreateStatusIssue,
   pointerPayload,
-  publishStatusPointer
+  publishStatusPointer,
+  refreshRequest
 } = require('./delivery-status');
 
 const fieldsRaw = {
@@ -188,6 +189,47 @@ test('builds a machine-readable artifact pointer', () => {
   assert.equal(payload.artifact.snapshotFile, 'project-2-status.json');
   assert.equal(payload.artifact.rawIssuesFile, 'repository-issues.raw.json');
   assert.equal(payload.artifact.rawPullRequestsFile, 'repository-pull-requests.raw.json');
+});
+
+test('preserves the refresh request that produced a snapshot pointer', () => {
+  const request = refreshRequest({
+    'request-comment-id': '5152000000',
+    'request-issue-number': '778',
+    'request-actor': 'bedrin-gpt'
+  });
+  const payload = pointerPayload({
+    generatedAt: '2026-08-01T18:00:00Z',
+    repository: 'sniffy/sniffy',
+    projectOwner: 'sniffy',
+    projectNumber: 2,
+    workflowRun: {id: 102, event: 'issue_comment', refreshRequest: request},
+    artifact: {id: '56', retentionDays: '2'},
+    counts: {}
+  });
+  assert.deepEqual(payload.source.workflowRun.refreshRequest, {
+    commentId: 5152000000,
+    issueNumber: 778,
+    actor: 'bedrin-gpt'
+  });
+});
+
+test('rejects incomplete refresh request provenance', () => {
+  assert.equal(refreshRequest({'request-comment-id': ''}), null);
+  assert.throws(() => refreshRequest({
+    'request-comment-id': 'not-a-number',
+    'request-issue-number': '778',
+    'request-actor': 'bedrin-gpt'
+  }), /Invalid refresh request comment id/);
+  assert.throws(() => refreshRequest({
+    'request-comment-id': '5152000000',
+    'request-issue-number': '',
+    'request-actor': 'bedrin-gpt'
+  }), /Invalid refresh request issue number/);
+  assert.throws(() => refreshRequest({
+    'request-comment-id': '5152000000',
+    'request-issue-number': '778',
+    'request-actor': ''
+  }), /Missing refresh request actor/);
 });
 
 test('rejects a missing or nonnumeric artifact id before publishing a pointer', () => {

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -20,8 +20,10 @@ on:
   workflow_run:
     workflows: [AI delivery control]
     types: [completed]
+  issue_comment:
+    types: [created]
   schedule:
-    - cron: '5,20,35,50 * * * *'
+    - cron: '5 * * * *'
   workflow_dispatch:
 
 permissions: {}
@@ -66,6 +68,15 @@ jobs:
       (
         github.event_name != 'workflow_run' ||
         github.event.workflow_run.event != 'pull_request'
+      ) &&
+      (
+        github.event_name != 'issue_comment' ||
+        (
+          github.event.issue.pull_request == null &&
+          contains(github.event.issue.labels.*.name, 'ai-delivery-status') &&
+          github.event.comment.body == '/ai-delivery-status refresh' &&
+          contains(fromJSON('["bedrin","bedrin-gpt"]'), github.actor)
+        )
       )
     runs-on: ubuntu-slim
     timeout-minutes: 10
@@ -91,6 +102,9 @@ jobs:
           PROJECT_NUMBER: '2'
           STATUS_REPOSITORY: sniffy/sniffy
           UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id || '' }}
+          REFRESH_REQUEST_COMMENT_ID: ${{ github.event.comment.id || '' }}
+          REFRESH_REQUEST_ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          REFRESH_REQUEST_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
           mkdir -p status-artifact
@@ -158,7 +172,10 @@ jobs:
             --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
             --event "$GITHUB_EVENT_NAME" \
             --upstream-run-id "$UPSTREAM_RUN_ID" \
-            --head-sha "$source_sha"
+            --head-sha "$source_sha" \
+            --request-comment-id "$REFRESH_REQUEST_COMMENT_ID" \
+            --request-issue-number "$REFRESH_REQUEST_ISSUE_NUMBER" \
+            --request-actor "$REFRESH_REQUEST_ACTOR"
 
           node .github/scripts/delivery-status-mergeability.js \
             status-artifact/project-2-status.json \
@@ -190,6 +207,9 @@ jobs:
           ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
           UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id || '' }}
           SOURCE_SHA: ${{ steps.export.outputs.source_sha }}
+          REFRESH_REQUEST_COMMENT_ID: ${{ github.event.comment.id || '' }}
+          REFRESH_REQUEST_ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          REFRESH_REQUEST_ACTOR: ${{ github.actor }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -199,7 +219,12 @@ jobs:
               attempt: Number(process.env.GITHUB_RUN_ATTEMPT),
               event: process.env.GITHUB_EVENT_NAME,
               upstreamRunId: process.env.UPSTREAM_RUN_ID ? Number(process.env.UPSTREAM_RUN_ID) : null,
-              headSha: process.env.SOURCE_SHA
+              headSha: process.env.SOURCE_SHA,
+              refreshRequest: process.env.REFRESH_REQUEST_COMMENT_ID ? {
+                commentId: Number(process.env.REFRESH_REQUEST_COMMENT_ID),
+                issueNumber: Number(process.env.REFRESH_REQUEST_ISSUE_NUMBER),
+                actor: process.env.REFRESH_REQUEST_ACTOR
+              } : null
             };
             const payload = status.pointerPayload({
               generatedAt: process.env.GENERATED_AT,
@@ -222,3 +247,34 @@ jobs:
               counts: JSON.parse(process.env.COUNTS_JSON)
             });
             await status.publishStatusPointer({github, context, core, payload});
+
+      - name: Acknowledge successful refresh request
+        if: success() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+      - name: Reject failed refresh request
+        if: failure() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const reactions = await github.paginate(github.rest.reactions.listForIssueComment, {
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              per_page: 100
+            });
+            if (!reactions.some(reaction => reaction.content === '+1')) {
+              await github.rest.reactions.createForIssueComment({
+                ...context.repo,
+                comment_id: context.payload.comment.id,
+                content: '-1'
+              });
+            }

--- a/docs/ai-delivery/README.md
+++ b/docs/ai-delivery/README.md
@@ -89,11 +89,11 @@ All configured executors use the same central control-issue protocol for Project
 is reserved for human-useful plans, reviews, evidence, blockers, and handoffs. Omitted Project fields remain unchanged, and an empty
 optional field is valid state rather than a reason to invent a new select option. See [`control-plane.md`](control-plane.md).
 
-Clients without reliable direct organization ProjectV2 reads use the repository-owned status snapshot in
-[`status-snapshot.md`](status-snapshot.md). The snapshot is a read-only, eventually consistent selection aid. It never authorizes a
-mutation: every claim and handoff still goes through `delivery-control/v1`, whose workflow re-reads and verifies live ProjectV2
-state. A stale or unavailable snapshot blocks snapshot-dependent autonomous selection rather than permitting remembered or guessed
-field values.
+Scheduled ChatGPT ticks request the repository-owned status snapshot in [`status-snapshot.md`](status-snapshot.md) before queue
+selection and use it when a complete direct organization ProjectV2 read is unavailable. The snapshot is a read-only selection aid.
+It never authorizes a mutation: every claim and handoff still goes through `delivery-control/v1`, whose workflow re-reads and
+verifies live ProjectV2 state. A failed refresh, stale, or unavailable snapshot blocks snapshot-dependent autonomous selection
+rather than permitting remembered or guessed field values.
 
 Dmitry owns product decisions, accepted risk, privileged repository/hosting operations, final acceptance, and merge authorization.
 ChatGPT owns issue refinement, universal PR intake/canonicalization, routing proposals, supervision, code review, verification
@@ -152,13 +152,14 @@ append to each task's defining chat rather than reliably creating a new chat. Ev
 instruction and re-read GitHub/repository state, while the four defining chats are retained and periodically replaced as a
 maintenance action. No Scheduled Task may rely on previous chat turns as state.
 
-A no-op tick creates no GitHub mutation. A productive tick performs at most one canonicalization/reconciliation or lifecycle turn
-directly, or makes one supported external dispatch. Scheduled ChatGPT ticks cannot create child Scheduled Tasks.
+A no-op tick creates no work-item, Project, source, or worker mutation; the required status-refresh request and its reaction are
+read-path telemetry. A productive tick performs at most one canonicalization/reconciliation or lifecycle turn directly, or makes
+one supported external dispatch. Scheduled ChatGPT ticks cannot create child Scheduled Tasks.
 
-When direct ProjectV2 reads are unavailable, each tick must apply the configured status-snapshot supplement before queue selection:
-find the newest open issue labeled `ai-delivery-status`, validate its JSON pointer and freshness, download the artifact by numeric
-ID through the default GitHub connector, and read the explicit normalized fields. Technical `ai-delivery-control` and
-`ai-delivery-status` issues are never canonical work. See [`status-snapshot.md`](status-snapshot.md).
+At the start of each tick, the configured status-snapshot supplement creates an on-demand read barrier: find the newest open issue
+labeled `ai-delivery-status`, post the exact refresh command, wait for its terminal reaction, then validate the newer JSON pointer
+and artifact. When direct ProjectV2 reads are unavailable, the tick uses those explicit normalized fields. Technical
+`ai-delivery-control` and `ai-delivery-status` issues are never canonical work. See [`status-snapshot.md`](status-snapshot.md).
 
 Every open PR targeting `develop` is scanned. A single linked issue remains canonical; a standalone PR becomes the Project item;
 a multi-issue PR enters Planning. Same-repository corrections can be adopted by ChatGPT or Local Codex on the exact existing

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -25,8 +25,9 @@ Some adapters split dispatch and work into separate processes or conversations. 
 execute the claimed lifecycle turn directly in the same scheduled occurrence. Child-worker spawning is optional, not a
 requirement of the generic protocol.
 
-A no-op tick creates no GitHub mutation, source branch, worktree, control command, or worker claim. A provider may still append a
-compact execution transcript to its own scheduler conversation.
+A no-op tick creates no work-item, Project, source branch, worktree, control command, or worker claim. A read adapter may still
+emit its configured refresh request/reaction, and a provider may append a compact execution transcript to its scheduler
+conversation.
 
 ## Desired cadence
 
@@ -61,15 +62,16 @@ Treat each occurrence as logically stateless even though the transcript is persi
 
 1. ignore prior-run conclusions and mutable conversational context;
 2. read current GitHub state, repository policy, and [`profile.yml`](profile.yml) from scratch;
-3. reconcile every open PR targeting the configured base branch and choose one canonical issue/PR item;
-4. reconcile a canonical issue/PR whose current head no longer matches the exact head supporting its downstream lifecycle state;
-5. continue one due owned worker/PR operation or select at most one eligible lifecycle turn;
-6. submit one guarded control command to claim it;
-7. verify the successful reaction and resulting Project state before doing work;
-8. perform the lifecycle turn directly or make one supported external dispatch;
-9. publish human-useful evidence on the canonical target item;
-10. submit one guarded control command for the lifecycle handoff and verify the result;
-11. return `NO_CHANGE` when no intake, head reconciliation, continuation, rotation, or eligible work exists.
+3. request and validate the on-demand status snapshot barrier;
+4. reconcile every open PR targeting the configured base branch and choose one canonical issue/PR item;
+5. reconcile a canonical issue/PR whose current head no longer matches the exact head supporting its downstream lifecycle state;
+6. continue one due owned worker/PR operation or select at most one eligible lifecycle turn;
+7. submit one guarded control command to claim it;
+8. verify the successful reaction and resulting Project state before doing work;
+9. perform the lifecycle turn directly or make one supported external dispatch;
+10. publish human-useful evidence on the canonical target item;
+11. submit one guarded control command for the lifecycle handoff and verify the result;
+12. return `NO_CHANGE` when no intake, head reconciliation, continuation, rotation, or eligible work exists.
 
 A tick must never claim work it cannot reasonably complete or hand off durably during that occurrence. Route long
 implementation, dependency-heavy builds, persistent services, existing-PR continuation, and environment-specific verification to

--- a/docs/ai-delivery/executors/chatgpt.md
+++ b/docs/ai-delivery/executors/chatgpt.md
@@ -127,9 +127,10 @@ occurrence must therefore be stateless by procedure:
 
 - ignore previous-run conclusions;
 - read current GitHub and repository-owned policy from scratch;
+- request and validate the configured status-snapshot read barrier;
 - canonicalize arbitrary PRs before queue selection;
 - perform at most one reconciliation, lifecycle turn, or supported dispatch;
-- make no GitHub mutation for `NO_CHANGE`;
+- make no work-item, Project, source, or worker mutation for `NO_CHANGE`; the status-refresh request is read telemetry;
 - keep durable state outside the chat.
 
 The four persistent transcripts are telemetry. Replace a long defining chat deliberately using

--- a/docs/ai-delivery/profile.yml
+++ b/docs/ai-delivery/profile.yml
@@ -30,7 +30,10 @@ statusSnapshot:
   rawPullRequestsFile: "repository-pull-requests.raw.json"
   maxAgeMinutes: 30
   retentionDays: 2
-  scheduleMinutes: [5, 20, 35, 50]
+  scheduleMinutes: [5]
+  refreshCommand: "/ai-delivery-status refresh"
+  refreshActors: [bedrin, bedrin-gpt]
+  refreshTimeoutSeconds: 120
 
 fields:
   status: Status

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -8,12 +8,14 @@ replaces, the guarded mutation protocol in [`control-plane.md`](control-plane.md
 
 ```text
 Project 2
+  -> scheduled tick posts /ai-delivery-status refresh
   -> AI delivery status workflow
       -> raw field and item exports
       -> normalized active-item JSON
       -> short-retention Actions artifact
       -> newest open issue labeled ai-delivery-status
            contains the latest artifact pointer as JSON
+      -> terminal reaction on the exact request comment
 ```
 
 The status issue is discovered by label. Its number is intentionally not configuration. The workflow creates the label and issue
@@ -21,24 +23,37 @@ when no open labeled issue exists and otherwise updates the newest open labeled 
 the workflow warns in its summary and readers still choose the newest open issue by number.
 
 The status issue is technical control-plane metadata. It is not a delivery work item, must not be claimed, and is excluded from the
-normalized active queue together with issues labeled `ai-delivery-control`.
+normalized active queue together with issues labeled `ai-delivery-control`. Its discussion is a narrow refresh-request audit log;
+delivery-control commands and ordinary work discussion do not belong there.
 
 ## Workflow triggers and freshness
 
 [`.github/workflows/delivery-status.yml`](../../.github/workflows/delivery-status.yml) runs:
 
-- at minute `5`, `20`, `35`, and `50` of every hour, ahead of the four ChatGPT event-loop slots;
+- at minute `5` of every hour as a best-effort dashboard and recovery fallback;
 - after non-PR completions of the `AI delivery control` workflow, so guarded mutations are materialized promptly;
+- on an exact `/ai-delivery-status refresh` issue comment on an `ai-delivery-status` issue from an actor allowlisted in
+  [`profile.yml`](profile.yml);
 - through `workflow_dispatch` for maintainer-authorized diagnosis or recovery;
 - in validation-only mode for pull requests changing this adapter.
 
 The publish job is serialized with `cancel-in-progress: false`. It always checks out trusted `develop`, including for
-`workflow_run`, so a completed pull-request validation run cannot inject untrusted code into the secret-bearing publication job.
+`workflow_run` and `issue_comment`, so neither a completed pull-request validation run nor comment content can inject untrusted
+code into the secret-bearing publication job. The comment trigger accepts only the exact configured command, status label, and
+actors `bedrin` or `bedrin-gpt`; all other issue comments produce a skipped publication job.
 
-A ChatGPT tick accepts only the protocol, repository, Project number, artifact name, and files configured in
-[`profile.yml`](profile.yml). The pointer and snapshot `generatedAt` timestamps must be no older than the configured maximum age.
-A stale, missing, malformed, expired, or inaccessible snapshot blocks snapshot-dependent autonomous Project selection. It does not
-justify guessing Project fields from prior chats, issue prose, or remembered state.
+After the artifact and latest pointer are published, the workflow adds `+1` to the exact request comment. A publication failure
+adds `-1` when the runner can still execute the failure step. The reaction is deliberately last: `+1` is a read barrier proving
+that this request produced a usable pointer, while `-1` or no terminal reaction tells the tick to stop. The request comment ID,
+issue number, and actor are preserved as `source.workflowRun.refreshRequest` in both pointer and normalized snapshot.
+
+A scheduled ChatGPT tick first requests a snapshot and waits up to the configured timeout for the terminal reaction. It then
+accepts only the protocol, repository, Project number, artifact name, and files configured in [`profile.yml`](profile.yml). The
+pointer and snapshot `generatedAt` timestamps must be strictly later than the request comment's creation time and no older than the
+configured maximum age. Normally the pointer names the exact request comment; a later serialized successful trigger may replace
+it and is necessarily at least as fresh. A failed request or stale, missing, malformed, expired, or inaccessible snapshot blocks
+snapshot-dependent autonomous Project selection. It does not justify guessing Project fields from prior chats, issue prose, or
+remembered state.
 
 ## Artifact contents
 
@@ -102,7 +117,8 @@ The status issue body is one JSON object:
       "attempt": 1,
       "event": "schedule",
       "upstreamRunId": null,
-      "headSha": "..."
+      "headSha": "...",
+      "refreshRequest": null
     }
   },
   "artifact": {
@@ -125,6 +141,16 @@ The status issue body is one JSON object:
 }
 ```
 
+For a comment-driven publication, `source.workflowRun.event` is `issue_comment` and `refreshRequest` is populated:
+
+```json
+{
+  "commentId": 5152000000,
+  "issueNumber": 778,
+  "actor": "bedrin-gpt"
+}
+```
+
 Readers parse the body as JSON, reject unknown `kind` or `schemaVersion`, validate repository and Project identity, and use the
 numeric artifact ID with the default GitHub connector's artifact download operation. The artifact URL is diagnostic; it is not a
 credential and is not the primary download mechanism.
@@ -135,11 +161,13 @@ The exact Scheduled Task supplement lives in
 [`.chatgpt/status-snapshot-instructions.md`](../../.chatgpt/status-snapshot-instructions.md). In summary, every stateless tick:
 
 1. searches open `sniffy/sniffy` issues with label `ai-delivery-status` and selects the newest issue by number;
-2. parses and validates the pointer body and freshness;
-3. downloads the artifact by `artifact.id` through the default GitHub connector;
-4. reads `project-2-status.json`, validates its identity, timestamp, and counts, and then uses its explicit fields for Project
+2. posts exactly one `/ai-delivery-status refresh` comment, records its ID/time, and waits at most 120 seconds for `+1`;
+3. after `+1`, rediscovers the newest status issue and validates that its pointer is newer than the request and normally names the
+   exact request comment in `source.workflowRun.refreshRequest`;
+4. downloads the artifact by `artifact.id` through the default GitHub connector;
+5. reads `project-2-status.json`, validates its identity, timestamp, provenance, and counts, and then uses its explicit fields for Project
    selection and guarded expected values;
-5. re-reads live issue/PR, branch, head, review, assignment, and CI state from GitHub before any claim or source mutation.
+6. re-reads live issue/PR, branch, head, review, assignment, and CI state from GitHub before any claim or source mutation.
 
 The snapshot is not a lease and does not prove current ownership. A candidate may have changed after generation.
 
@@ -155,13 +183,14 @@ For a snapshot-backed client:
 - `-1` means an unexpected control failure; inspect the control run and do not infer final state;
 - `+1` means the control workflow applied or observed the requested final values and verified them internally.
 
-After `+1`, a later dependent Project transition must use a status snapshot generated after that command. Work that does not require
-another immediate Project write may proceed from the verified claim reaction plus live source state. The `workflow_run` trigger
-normally refreshes the pointer promptly after control completion, while the scheduled runs provide bounded recovery if that event is
-missed.
+After a control-command `+1`, a later dependent Project transition must use a status snapshot generated after that command. Work
+that does not require another immediate Project write may proceed from the verified claim reaction plus live source state. The
+`workflow_run` trigger normally refreshes the pointer promptly after control completion; if it does not, the tick uses the same
+on-demand comment barrier rather than waiting for best-effort cron. Scheduled runs remain a non-deterministic dashboard/recovery
+signal and are not the freshness guarantee for a tick.
 
-No client may mutate Project fields directly from the snapshot, treat the status issue as a command channel, or bypass exact-head
-and expected-field guards.
+No client may mutate Project fields directly from the snapshot, treat the status issue as a delivery-control/Project-mutation
+channel, or bypass exact-head and expected-field guards. Its only accepted command is the configured read-only refresh request.
 
 ## Permissions and failure response
 
@@ -178,10 +207,11 @@ On repeated failure, inspect:
 - GitHub CLI Project output/schema changes;
 - pagination/truncation failures;
 - artifact upload failure;
-- repository issue or label write failure.
+- repository issue, label, pointer, or reaction write failure.
 
 The snapshot workflow is a non-required operational signal, not source CI. A failed run prevents snapshot-dependent autonomous
-selection until a fresh pointer exists; maintainers may use `workflow_dispatch` after correcting the cause.
+selection until a fresh pointer exists. A scheduled tick reports `-1` or an unacknowledged request and stops; maintainers may use
+`workflow_dispatch` after correcting the cause.
 
 ## Removal condition
 


### PR DESCRIPTION
## Problem

The AI delivery tick requires a Project status snapshot no older than 30 minutes, but GitHub's `schedule` trigger is best-effort and has skipped most configured runs. A healthy publisher therefore still leaves scheduled ticks blocked on stale state.

## Design

- add an allowlisted, exact `/ai-delivery-status refresh` command on the labeled status issue;
- run the existing serialized publisher from trusted `develop`; never execute comment or PR content;
- preserve the request comment ID, issue number, and actor in pointer/artifact provenance;
- react `+1` only after the artifact and pointer are published, and `-1` after a recoverable publication failure;
- require scheduled ticks to wait up to 120 seconds for their exact terminal reaction and reject pre-request snapshots;
- reduce cron to one hourly best-effort dashboard/recovery run instead of treating it as a freshness SLA;
- update the canonical Scheduled Task prompt, read supplement, profile, event-loop docs, and ChatGPT runbook.

The workflow keeps its existing least-privilege job permissions (`contents: read`, `issues: write`, `pull-requests: read`). GitHub still creates a skipped workflow record for unrelated issue comments, but no runner or `PROJECT_TOKEN` work is started unless the label, actor, and exact command all match.

## Validation

- `node --check` for all delivery-status scripts/tests
- 36 Node policy/status tests
- YAML parse for the workflow and profile
- `git diff --check`
- exact-head [AI delivery status run 30711705093](https://github.com/sniffy/sniffy/actions/runs/30711705093): tests, YAML parse, and actionlint all passed
- exact-head `Check Pull Request` matrix is running; all completed jobs are green

## Compatibility, limitations, and rollout

The status schema remains v1; `source.workflowRun.refreshRequest` is additive and `null` for non-comment triggers. Existing Scheduled Tasks already re-read the repository supplement, while their stored prompt should be replaced with the updated canonical text after merge.

GitHub only executes an `issue_comment` workflow definition from the default branch. PR validation therefore proves syntax and contracts but cannot execute the new privileged publication path. After merge, perform one live smoke request in the newest `ai-delivery-status` issue and verify:

1. the request comment receives only terminal `+1`;
2. the pointer and downloaded artifact both name the exact request in `source.workflowRun.refreshRequest`;
3. `generatedAt` is later than the comment's `createdAt`;
4. an unrelated or non-allowlisted comment produces no publish job.

The status issue will receive four small refresh comments per hour. They are read-path audit telemetry and may require deliberate issue rotation if discussion size becomes operationally inconvenient.

Exact published head: `bd0dd75a7f455e0123eb1dc834afbd89d4e88152`