### PR TITLE
Preserve pending delivery status refresh requests

### DIFF
--- a/.github/scripts/delivery-status-policy.test.js
+++ b/.github/scripts/delivery-status-policy.test.js
@@ -69,3 +69,9 @@ test('workflow isolates validation and trusted status publication', () => {
   assert.match(workflow, /pull-requests:\s*read/);
   assert.doesNotMatch(workflow, /contents:\s*write/);
 });
+
+test('status publication preserves every pending refresh request', () => {
+  const workflow = read('.github/workflows/delivery-status.yml');
+  assert.match(workflow, /concurrency:\s*\n\s+group:\s*ai-delivery-status-\$\{\{ github\.repository \}\}\s*\n\s+queue:\s*max\s*\n\s+cancel-in-progress:\s*false/);
+  assert.match(workflow, /-ignore 'unexpected key "queue" for "concurrency" section'/);
+});

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -60,7 +60,11 @@ jobs:
           YAML.load_file(".github/workflows/delivery-status.yml");
           YAML.load_file("docs/ai-delivery/profile.yml")'
       - name: Lint GitHub Actions workflow
-        run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/delivery-status.yml
+        # actionlint 1.7.12 predates GitHub's queue concurrency key. Keep every other diagnostic active.
+        run: >-
+          docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12
+          -ignore 'unexpected key "queue" for "concurrency" section'
+          .github/workflows/delivery-status.yml
 
   publish:
     if: >-
@@ -86,6 +90,7 @@ jobs:
       pull-requests: read
     concurrency:
       group: ai-delivery-status-${{ github.repository }}
+      queue: max
       cancel-in-progress: false
 
     steps:

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -37,10 +37,12 @@ delivery-control commands and ordinary work discussion do not belong there.
 - through `workflow_dispatch` for maintainer-authorized diagnosis or recovery;
 - in validation-only mode for pull requests changing this adapter.
 
-The publish job is serialized with `cancel-in-progress: false`. It always checks out trusted `develop`, including for
-`workflow_run` and `issue_comment`, so neither a completed pull-request validation run nor comment content can inject untrusted
-code into the secret-bearing publication job. The comment trigger accepts only the exact configured command, status label, and
-actors `bedrin` or `bedrin-gpt`; all other issue comments produce a skipped publication job.
+The publish job is serialized with `queue: max` and `cancel-in-progress: false`. GitHub may keep up to 100 pending publications in
+FIFO order instead of replacing an older pending request when another trigger arrives. This preserves each on-demand request until
+it can reach a terminal reaction while still keeping pointer updates sequential. The job always checks out trusted `develop`,
+including for `workflow_run` and `issue_comment`, so neither a completed pull-request validation run nor comment content can inject
+untrusted code into the secret-bearing publication job. The comment trigger accepts only the exact configured command, status
+label, and actors `bedrin` or `bedrin-gpt`; all other issue comments produce a skipped publication job.
 
 After the artifact and latest pointer are published, the workflow adds `+1` to the exact request comment. A publication failure
 adds `-1` when the runner can still execute the failure step. The reaction is deliberately last: `+1` is a read barrier proving


### PR DESCRIPTION
## Problem

The on-demand status refresh request https://github.com/sniffy/sniffy/issues/778#issuecomment-5153141873 received neither `+1` nor `-1`.

Actions evidence shows that request created run [30715717034](https://github.com/sniffy/sniffy/actions/runs/30715717034), but its `publish` job never received a runner and was cancelled after four seconds. Run 30715664778 already occupied the shared concurrency group; later `workflow_run` triggers 30715718698 and 30715721044 replaced pending runs. With the default concurrency queue, `cancel-in-progress: false` protects the running job but still allows only one pending job, so a newer trigger silently cancels the older pending refresh before either terminal reaction step can run.

This is the exact pending-run replacement risk previously identified during review of #791.

## Fix

- set `queue: max` on the existing `ai-delivery-status-${{ github.repository }}` concurrency group;
- retain `cancel-in-progress: false`, keeping artifact and pointer publication sequential;
- add a policy contract that requires the full queue configuration;
- document the FIFO queue, 100-run limit, and terminal-reaction guarantee.

GitHub documents that `queue: max` retains up to 100 pending jobs/runs instead of replacing the existing pending entry: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

The pinned actionlint 1.7.12 schema predates this GitHub key. Validation therefore ignores only its exact unknown-`queue` diagnostic; all other actionlint diagnostics remain active, and the exception is covered by the policy test.

## Validation

- Node syntax checks for all delivery-status scripts and tests
- 29 focused delivery-status tests
- workflow/profile YAML parse
- actionlint 1.7.12 with the exact temporary `queue` diagnostic ignored
- `git diff --check`
- remote comparison: one commit, three intended files, no unrelated changes

## Compatibility and remaining risk

The status schema, permissions, trigger allowlist, runner, and pointer format are unchanged. The production queue path can only be smoke-tested after this workflow reaches the default branch. A concurrency group can retain at most 100 pending jobs; requests beyond that GitHub limit may still be rejected.

The separate second-resolution `generatedAt > createdAt` boundary noted on #791 is not involved in this incident and is unchanged.

Exact published head: `84b899180f756f316439e6c0d717152dee9e27f1`
