### PR TITLE
Reduce pull request CI matrix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -363,22 +363,16 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # Keep every supported JDK in PR CI; deploy.yml retains the exhaustive release matrix.
-        java: [8, 11, 17, 21, 25]
-        # Intel macOS remains covered post-merge and for releases.
-        os: [ubuntu-26.04, windows-2025, macos-26]
-        exclude:
+        # smoke-test covers JDK 8/11/17/25 across Linux, Windows, and macOS.
+        # Keep a representative complement here; deploy.yml retains the exhaustive release matrix.
+        include:
           - java: 8
-            os: ubuntu-26.04
-          - java: 11
             os: windows-2025
-          - java: 17
-            os: macos-26
-          - java: 25
+          - java: 21
             os: ubuntu-26.04
-          - java: 8
-            os: macos-26
-          - java: 11
+          - java: 25
+            os: windows-2025
+          - java: 25
             os: macos-26
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -363,10 +363,10 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # test against LTS versions of JDK up to 21:
-        #        java: [ 8, 11, 17, 21 ]
+        # Keep every supported JDK in PR CI; deploy.yml retains the exhaustive release matrix.
         java: [8, 11, 17, 21, 25]
-        os: [ubuntu-26.04, windows-2025, macos-26, macos-26-intel]
+        # Intel macOS remains covered post-merge and for releases.
+        os: [ubuntu-26.04, windows-2025, macos-26]
         exclude:
           - java: 8
             os: ubuntu-26.04


### PR DESCRIPTION
## Problem

The pull-request workflow expands backend validation into 18 full Maven builds. Five use `macos-26-intel`, and most of the remaining jobs repeat the same reactor on every JDK/OS combination.

Actions evidence from the 20 most recent completed PR runs shows that runner demand can turn these short builds into long workflows. In run [30693954417](https://github.com/sniffy/sniffy/actions/runs/30693954417), the five Intel jobs waited 16–22 minutes before starting. During a larger concurrent burst earlier that day, runner waits stretched several PR workflows to roughly three or four hours.

The first exact-head run of this PR confirmed the second bottleneck: after removing Intel macOS, 15 second-stage jobs still competed for limited runner slots and the otherwise-green workflow took 23 minutes.

## Change

Use a representative PR matrix instead of the near-Cartesian JDK/OS product:

- the existing smoke jobs keep JDK 8 on Linux, JDK 11 on Windows, JDK 17 on Apple Silicon macOS, and JDK 25 on Linux;
- the complementary matrix adds JDK 8 on Windows, JDK 21 on Linux, and JDK 25 on Windows and Apple Silicon macOS;
- no PR job uses Intel macOS;
- `deploy.yml` remains unchanged and retains the exhaustive JDK/OS matrix, including Intel macOS, after merge and for releases.

Every configured JDK (8, 11, 17, 21, and 25) and every retained PR runner OS remains covered. The oldest baseline runs on Linux and Windows; the current JDK runs on Linux, Windows, and macOS.

This reduces the PR workflow from 26 to 16 jobs and full backend Maven builds from 18 to 8.

## Compatibility and impact

No Sniffy runtime, public API, dependency, permission, trigger, artifact, Codecov, or deployment behavior changes. PR feedback uses representative compatibility coverage; the unchanged post-merge/release workflow remains the exhaustive publication gate.

## Validation

- YAML parse with PyYAML
- Prettier 3.9.6 check
- actionlint 1.7.12 with only the workflow's two pre-existing diagnostics ignored (the future `ubuntu-26.04` runner label and existing undefined `matrix.language`)
- explicit matrix contract: 16 total PR jobs, all five JDKs, all three retained OS runners, Java 8 on Linux/Windows, and Java 25 on Linux/Windows/macOS
- `git diff --check`
- complete one-file diff inspection
- exact-head [Check Pull Request run 30718116385](https://github.com/sniffy/sniffy/actions/runs/30718116385): 16/16 jobs passed on attempt 2; attempt 1 hit an unrelated Maven Central HTTP 429 in `setup-maven` before build/test, and all four QEMU jobs passed on retry

## Remaining risk

A regression specific to a JDK/OS combination omitted from the representative PR matrix will be detected after merge rather than during PR review. The unchanged exhaustive `deploy.yml` matrix prevents such a regression from passing the publication gate.

Exact published head: `28651c70d46f8d55b84226f8d38f2c85573c9b23`
