### PR TITLE
Dispatch ready Codex Cloud work from ChatGPT

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -114,26 +114,39 @@ Perform this protocol:
    it. Verify the terminal reaction, PR draft/head, and canonical Project state directly or through the required post-command
    status snapshot. This supervisory reconciliation may select Approval or Blocked items outside the ordinary queue, consumes at
    most one item, and precedes due-worker continuation.
-3. Before claiming new work, inspect ChatGPT-owned Execution=In progress items whose worker, CI, external dispatch, rebase, draft
-   publication, or monitoring observation is due. Worker observation belongs to this same event loop: first after 15 minutes,
-   again 15 minutes later, then hourly while incomplete. Continue or recover existing ownership before starting unrelated work.
+3. Before claiming new work, reconcile one unclaimable `Execution = Ready` route when its non-Human `Executor` is configured but
+   its Assignee belongs to a different executor pool. Never silently filter out that mismatch. Re-read the authoritative route and
+   either assign the configured executor identity when the route is still valid, or use one guarded transition to the correct
+   lifecycle/executor; use `Blocked / Human / bedrin` only when Dmitry actually must decide or act. This reconciliation consumes
+   the tick. Otherwise inspect both ChatGPT-owned and ChatGPT-supervised Codex Cloud `Execution = In progress` items whose worker,
+   CI, external dispatch, rebase, draft publication, or monitoring observation is due. Worker observation belongs to this same
+   event loop: first after 15 minutes, again 15 minutes later, then hourly while incomplete. Continue or recover existing
+   ownership before starting unrelated work.
 4. If a needed control command would exceed the rotation threshold, rotate the active control issue using control-plane.md, then
    continue this tick. Do not create a separate cleanup scheduler.
-5. Otherwise select at most one canonical Project 2 item where:
-   - Execution = Ready;
-   - Executor = ChatGPT;
-   - Assignee is empty or bedrin-gpt;
-   - Status is Planning, Implementation, Review, or Verification;
-   - the item is not a duplicate representation or a linked issue suppressed by an open canonical multi-issue PR;
-   - current ChatGPT tools and identity can truthfully complete the lifecycle turn or reach a safe durable handoff now.
-   Eligibility must not require Implementer to be populated.
+5. Otherwise select at most one canonical Project 2 item from either eligible class:
+   - **supervised Codex Cloud dispatch:** `Status = Implementation`, `Execution = Ready`, `Executor = Codex Cloud`, and Assignee
+     is empty or `bedrin-codex-cloud`. Codex Cloud does not poll Project 2, so ChatGPT is the configured dispatch owner and must not
+     leave this route waiting for a nonexistent Cloud dispatcher. Require bounded fresh work or an explicitly recoverable existing
+     Cloud branch. Route an arbitrary same-repository existing-PR continuation to Local Codex instead of dispatching Cloud;
+   - **ChatGPT lifecycle turn:** `Execution = Ready`, `Executor = ChatGPT`, Assignee is empty or `bedrin-gpt`, and Status is
+     Planning, Implementation, Review, or Verification.
+   In either class the item must not be a duplicate representation or a linked issue suppressed by an open canonical multi-issue
+   PR, and current ChatGPT tools and identity must be able to reach a safe durable handoff now. Eligibility must not require
+   Implementer to be populated outside a routed Implementation turn.
 6. Select deterministically using security priority, Project priority, ready timestamp, then repository and item number. Never
    create a duplicate Project item, worker, branch, or pull request.
-7. Claim with one guarded delivery-control/v1 command. Set Execution=In progress plus the concrete tick/worker reference and
-   lease, inspect the terminal reaction, and verify ownership through direct ProjectV2 or the control workflow's internal +1
-   verification before work. If execution or external dispatch cannot start, release to Ready. Set Blocked only when Dmitry must
-   decide or act. Require a post-command status snapshot before a later dependent Project handoff.
-8. Perform exactly one lifecycle turn:
+7. Claim with one guarded delivery-control/v1 command. Preserve the selected Executor and set `Execution = In progress` plus the
+   concrete tick/provisional worker reference and lease, inspect the terminal reaction, and verify ownership through direct
+   ProjectV2 or the control workflow's internal +1 verification before work. For a supervised Codex Cloud route, then post one
+   exact implementation trigger, require its connector reaction, task link, or equivalent durable acknowledgement, and replace
+   the provisional reference with that concrete dispatch evidence and the first 15-minute observation point. If the trigger was
+   not submitted or was definitively rejected, release to Ready. If submission succeeded but acknowledgement is uncertain, retain
+   the exact trigger comment/task-generation reference as provisional `In progress` recovery evidence, schedule the first
+   15-minute observation, and never redispatch that generation until recovery resolves it. Set Blocked only when Dmitry must decide
+   or act. Require a post-command status snapshot before a later dependent Project handoff.
+8. A supervised Codex Cloud dispatch is the one productive outcome for that tick: after durable acknowledgement, stop and let the
+   normal 15-minute, second-15-minute, then hourly supervision cadence observe it. Otherwise perform exactly one lifecycle turn:
    - Planning: resolve outcome, canonical item, linked issues, decisions, non-goals, risk axes, Implementer when a future
      Implementation turn is actually needed, Verifier, and proof obligations. Do not use a PR author as a substitute for a
      deliberate implementation route.

--- a/.github/scripts/delivery-policy.test.js
+++ b/.github/scripts/delivery-policy.test.js
@@ -37,6 +37,33 @@ test('profile makes universal intake and existing-PR routing explicit', () => {
   assert.match(profile, /Local Codex:[\s\S]*maxConcurrentWorkers:\s*1/);
 });
 
+test('ChatGPT supervises Ready Codex Cloud dispatch instead of stranding it', () => {
+  const prompt = read('.chatgpt/scheduled-task-prompt.md');
+  const profile = read('docs/ai-delivery/profile.yml');
+  const eventLoop = read('docs/ai-delivery/event-loop.md');
+  const supervision = read('docs/ai-delivery/supervision.md');
+
+  assert.match(profile, /Codex Cloud:[\s\S]*dispatchMode:\s*supervised[\s\S]*dispatchOwner:\s*ChatGPT/);
+  assert.match(prompt, /supervised Codex Cloud dispatch:[\s\S]*Status = Implementation[\s\S]*Execution = Ready[\s\S]*Executor = Codex Cloud/i);
+  assert.match(prompt, /Codex Cloud does not poll Project 2/i);
+  assert.match(prompt, /post one\s+exact implementation trigger[\s\S]*durable acknowledgement/i);
+  assert.match(prompt, /If the trigger was\s+not submitted or was definitively rejected, release to Ready/i);
+  assert.match(prompt, /submission succeeded but acknowledgement is uncertain[\s\S]*never redispatch that generation/i);
+  assert.match(prompt, /first 15-minute observation point/i);
+  assert.match(prompt, /ChatGPT-supervised Codex Cloud `Execution = In progress` items/i);
+  assert.match(eventLoop, /dispatchMode: supervised[\s\S]*ChatGPT as\s+its dispatch owner/i);
+  assert.match(supervision, /claim while\s+preserving Executor[\s\S]*release the provisional claim to Ready/i);
+});
+
+test('configured Ready routes with the wrong assignee require reconciliation', () => {
+  const prompt = read('.chatgpt/scheduled-task-prompt.md');
+  const eventLoop = read('docs/ai-delivery/event-loop.md');
+
+  assert.match(prompt, /unclaimable `Execution = Ready` route[\s\S]*Assignee belongs to a different executor pool/i);
+  assert.match(prompt, /Never silently filter out that mismatch/i);
+  assert.match(eventLoop, /Ready route whose Assignee belongs to another executor pool is a supervisory reconciliation obligation/i);
+});
+
 test('Local Codex can adopt an explicitly routed same-repository PR without duplication', () => {
   const worker = read('.codex/local/worker-task-prompt.md');
   const dispatcher = read('.codex/local/scheduled-task-prompt.md');

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -65,10 +65,11 @@ Treat each occurrence as logically stateless even though the transcript is persi
 3. request and validate the on-demand status snapshot barrier;
 4. reconcile every open PR targeting the configured base branch and choose one canonical issue/PR item;
 5. reconcile a canonical issue/PR whose current head no longer matches the exact head supporting its downstream lifecycle state;
-6. continue one due owned worker/PR operation or select at most one eligible lifecycle turn;
+6. reconcile one invalid Ready route/assignee, continue one due owned worker/PR operation, dispatch one configured non-polling
+   executor, or select at most one eligible lifecycle turn;
 7. submit one guarded control command to claim it;
 8. verify the successful reaction and resulting Project state before doing work;
-9. perform the lifecycle turn directly or make one supported external dispatch;
+9. perform the lifecycle turn directly or make one supported external dispatch with durable acknowledgement;
 10. publish human-useful evidence on the canonical target item;
 11. submit one guarded control command for the lifecycle handoff and verify the result;
 12. return `NO_CHANGE` when no intake, head reconciliation, continuation, rotation, or eligible work exists.
@@ -94,6 +95,24 @@ create another Scheduled Task. All durable context therefore lives in GitHub and
 
 The four tasks may scan several repositories because queue state is external. Repository-specific filters and executor settings
 belong in explicit profiles, not in prior chat history.
+
+### Supervisor-dispatched executors
+
+Not every executor polls Project state. The current Sniffy profile marks Codex Cloud as `dispatchMode: supervised` with ChatGPT as
+its dispatch owner. A `Ready / Codex Cloud` route is therefore eligible work for a ChatGPT tick even though ChatGPT is not the
+implementation executor. The tick claims the routed turn without changing Executor, starts exactly one supported Cloud task,
+requires durable acknowledgement, records the task/trigger and first observation point, and then stops.
+
+If the external trigger was never submitted or was definitively rejected, the tick releases the provisional claim back to Ready.
+If submission succeeded but acknowledgement is uncertain, the exact trigger comment or task-generation reference remains
+provisional `In progress` recovery evidence; the next observation performs targeted recovery and must not submit a duplicate
+generation. The tick must not invent a worker or wait for Cloud to discover Project 2 on its own. Arbitrary existing-PR
+continuation is routed to Local Codex rather than converted into duplicate fresh Cloud work; only an explicitly recoverable
+existing Cloud branch may be continued through Cloud.
+
+A configured non-Human Ready route whose Assignee belongs to another executor pool is a supervisory reconciliation obligation,
+not an invisible queue item. Re-read the authoritative route, correct the assignment when the route remains valid, or route the
+item deliberately to the correct lifecycle/executor. Do not infer a human blocker solely from stale assignment.
 
 ## Universal pull-request intake adapter
 
@@ -213,13 +232,21 @@ group; neither replaces the other.
 
 ## Eligible work
 
-A dispatcher queries the materialized current route, not planned roles alone:
+A polling dispatcher normally queries the materialized current route, not planned roles alone:
 
 ```text
 Execution = Ready
 Executor = <dispatcher executor type>
 Assignee is empty OR Assignee belongs to this dispatcher pool
 ```
+
+A supervisor may also select `Execution = Ready` work for a configured `dispatchMode: supervised` executor whose
+`dispatchOwner` is that supervisor. This is dispatch ownership, not implementation ownership: the claim preserves the routed
+Executor and becomes durable only after the external worker acknowledgement is recorded. Sniffy's current instance is ChatGPT
+dispatching Codex Cloud. Local Codex remains a polling pool and Human remains a directed route.
+
+Before applying either selector, reconcile a configured non-Human Ready item whose Assignee belongs to a different executor pool.
+Silently excluding it would create a permanently unclaimable state even though its lifecycle fields say Ready.
 
 The canonical work item may be an issue or pull request. The dispatcher also checks lifecycle compatibility, required access,
 worker-pool capacity, existing branch/PR ownership, and absence of a valid current worker. It excludes duplicate representations

--- a/docs/ai-delivery/executors/chatgpt.md
+++ b/docs/ai-delivery/executors/chatgpt.md
@@ -129,7 +129,9 @@ occurrence must therefore be stateless by procedure:
 - read current GitHub and repository-owned policy from scratch;
 - request and validate the configured status-snapshot read barrier;
 - canonicalize arbitrary PRs before queue selection;
-- perform at most one reconciliation, lifecycle turn, or supported dispatch;
+- reconcile configured Ready routes that are unclaimable because their Assignee belongs to another executor pool;
+- perform at most one reconciliation, lifecycle turn, or supported dispatch, including a Ready Codex Cloud route for which
+  ChatGPT is the configured dispatch owner;
 - make no work-item, Project, source, or worker mutation for `NO_CHANGE`; the status-refresh request is read telemetry;
 - keep durable state outside the chat.
 
@@ -138,6 +140,15 @@ The four persistent transcripts are telemetry. Replace a long defining chat deli
 
 Worker and PR-operation monitoring is not another Scheduled Task. Due 15-minute, second-15-minute, and hourly observations are
 selected by these same event-loop ticks before new work.
+
+Codex Cloud has no Project polling loop. When the current profile routes bounded fresh Implementation to
+`Implementation / Ready / Codex Cloud`, a ChatGPT tick must claim that route without changing Executor, post exactly one supported
+Cloud trigger, require durable acknowledgement, and record the first 15-minute observation point. If acknowledgement is absent,
+release the provisional claim to Ready only when the trigger was not submitted or was definitively rejected. A submitted trigger
+with uncertain acknowledgement remains one provisional generation for targeted recovery and must not be dispatched again. The
+same ChatGPT loop monitors acknowledged or provisional Cloud `In progress` routes after 15 minutes, again after 15 minutes, then
+hourly. Do not wait for Cloud to discover the Project item. Do not use this bridge for arbitrary existing-PR adoption; route that
+continuation to Local Codex unless the existing Cloud branch is explicitly recoverable.
 
 ## ChatGPT Project bootstrap
 

--- a/docs/ai-delivery/profile.yml
+++ b/docs/ai-delivery/profile.yml
@@ -48,18 +48,24 @@ executors:
   ChatGPT:
     assignee: bedrin-gpt
     model: provider-managed
+    dispatchMode: direct
   Codex Cloud:
     assignee: bedrin-codex-cloud
     model: provider-managed
+    # Cloud has no Project polling loop. ChatGPT must claim and trigger each routed Cloud turn.
+    dispatchMode: supervised
+    dispatchOwner: ChatGPT
   Local Codex:
     assignee: bedrin-codex-local
     model: Sol
     reasoning: extra-high
+    dispatchMode: polling
     # App-native dispatch derives this scheduling limit from the retained Project snapshot.
     # Provider-wide Codex project/task inventory is recovery evidence, not a normal capacity source.
     maxConcurrentWorkers: 1
   Human:
     assignee: bedrin
+    dispatchMode: directed
 
 routing:
   supervisor: ChatGPT

--- a/docs/ai-delivery/supervision.md
+++ b/docs/ai-delivery/supervision.md
@@ -79,6 +79,10 @@ control reaction.
 
 - A Cloud implementation is dispatched only after the proven trigger has a connector reaction, task link, or equivalent durable
   acknowledgement. A review mention alone is not implementation dispatch.
+- Codex Cloud does not poll Project 2. ChatGPT owns dispatch for a valid `Implementation / Ready / Codex Cloud` route: claim while
+  preserving Executor, issue exactly one supported trigger, record durable acknowledgement and the first observation point, or
+  release the provisional claim to Ready when the trigger was not submitted or was definitively rejected. A submitted trigger
+  with uncertain acknowledgement remains one provisional generation for targeted recovery; never redispatch it blindly.
 - An app-native Local Codex item is dispatched only after a verified claim plus a concrete worker task/chat/worktree.
 - A headless Local Codex item is dispatched only after a verified claim plus process/worktree/branch record.
 - An adopted existing PR is dispatched only after the canonical Project item explicitly routes the exact same-repository PR,
@@ -98,8 +102,13 @@ Queue polling and worker follow-up are responsibilities of the same event loop:
 - **Universal PR intake** scans every open PR targeting `develop`, canonicalizes issue versus PR, and materializes reviewable work
   before ordinary queue selection.
 - **Queue polling** finds canonical `Ready` work and claims it. Desired logical cadence is every 15 minutes.
+- **Supervised external dispatch** lets the ChatGPT loop select configured `Ready / Codex Cloud` work even though ChatGPT is not
+  the Implementer. The acknowledged dispatch, not the Ready route alone, starts worker monitoring.
+- **Ready-route reconciliation** repairs a non-Human Ready item whose Assignee belongs to a different executor pool; such an item
+  must not disappear from every dispatcher's eligibility filter.
 - **Worker/operation monitoring** observes an existing implementation, correction, CI wait, contributor update, bot rebase, or
-  draft publication after 15 minutes, again 15 minutes later, then hourly while incomplete.
+  draft publication after 15 minutes, again 15 minutes later, then hourly while incomplete. It includes ChatGPT-supervised Codex
+  Cloud `In progress` routes even though their Executor field remains Codex Cloud.
 - **Control-log maintenance** rotates the active technical issue when a needed command would exceed the documented threshold.
 
 Do not create an additional monitoring Scheduled Task. A normal dispatcher tick first checks whether an existing owned worker or


### PR DESCRIPTION
## Problem

Project 2 currently has no consumer for `Implementation / Ready / Codex Cloud`. The ChatGPT scheduled prompt only selects `Executor = ChatGPT`, Local Codex has its own polling loop, and Codex Cloud does not poll Project state. This stranded canonical issues #770 and #772 and the correction route for #753. A second blind spot silently filters Ready routes whose Assignee belongs to another executor pool, as seen on #746.

## Design

- Declare executor dispatch modes in the Sniffy profile and make ChatGPT the dispatch owner for Codex Cloud.
- Let one ChatGPT tick select a valid Ready Cloud route while preserving Codex Cloud as the implementation Executor.
- Require a guarded provisional claim, one exact Cloud trigger, durable acknowledgement, and the existing 15-minute, second-15-minute, then hourly supervision cadence.
- Preserve one submitted-but-unacknowledged generation for targeted recovery instead of blindly redispatching it.
- Reconcile configured non-Human Ready routes with a mismatched Assignee instead of filtering them out forever.
- Keep arbitrary existing-PR continuation on Local Codex unless an existing Cloud branch is explicitly recoverable.

## Compatibility and safety

This is a prompt/profile/policy-test change only. It does not change runtime code, Project fields, workflow permissions, GitHub settings, merge authority, or executor concurrency. Every Project mutation still uses `delivery-control/v1`.

## Validation

- `node --check .github/scripts/delivery-policy.test.js`
- `node --test .github/scripts/delivery-policy.test.js` — 10/10 passed
- `node --test .github/scripts/delivery-*.test.js .github/scripts/review-return*.test.js` — 81/81 passed
- `git diff --check`

Exact published head: `d098c558c2b8cf17d03969e4d500d6186ca1c67f`

No merge or auto-merge is authorized.