### PR TITLE
Avoid status snapshot rate-limit amplification

### DIFF
--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -47,8 +47,9 @@ this on-demand refresh barrier: the refreshed artifact is the deterministic fall
 9. On `confused`, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run. On
    `+1`, the control workflow's internal final-state verification is authoritative for that command.
 10. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command. The status
-    workflow is triggered after delivery-control completion; request another on-demand refresh only when that event did not yield
-    a sufficiently new pointer. Do not chain dependent Project writes from an older materialized view.
+    workflow deliberately does not run after every delivery-control completion because that fan-out exhausts the shared Project
+    GraphQL rate limit during active reconciliation. Request exactly one on-demand refresh before the dependent transition. Do not
+    chain dependent Project writes from an older materialized view or add speculative refreshes between transitions.
 11. If the status issue, refresh acknowledgement, pointer, artifact, or snapshot is missing, expired, inaccessible, malformed,
     mismatched, or stale, make no snapshot-dependent Project claim or transition. Report the exact status-read blocker; do not
     guess.

--- a/.github/scripts/delivery-status-policy.test.js
+++ b/.github/scripts/delivery-status-policy.test.js
@@ -56,7 +56,8 @@ test('workflow isolates validation and trusted status publication', () => {
   const workflow = read('.github/workflows/delivery-status.yml');
   assert.match(workflow, /permissions:\s*\{\}/);
   assert.match(workflow, /cron:\s*'5 \* \* \* \*'/);
-  assert.match(workflow, /workflows:\s*\[AI delivery control\]/);
+  assert.doesNotMatch(workflow, /workflow_run:/);
+  assert.doesNotMatch(workflow, /github\.event\.workflow_run/);
   assert.match(workflow, /issue_comment:\s*\n\s+types:\s*\[created\]/);
   assert.match(workflow, /github\.event\.comment\.body == '\/ai-delivery-status refresh'/);
   assert.match(workflow, /contains\(github\.event\.issue\.labels\.\*\.name, 'ai-delivery-status'\)/);

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -19,9 +19,6 @@ on:
       - docs/ai-delivery/status-workflow-optimization.md
       - docs/ai-delivery/ubuntu-slim-capability-experiment.md
       - docs/ai-delivery/merge-conflict-reconciliation.md
-  workflow_run:
-    workflows: [AI delivery control]
-    types: [completed]
   issue_comment:
     types: [created]
   schedule:
@@ -93,10 +90,6 @@ jobs:
     if: >-
       github.event_name != 'pull_request' &&
       (
-        github.event_name != 'workflow_run' ||
-        github.event.workflow_run.event != 'pull_request'
-      ) &&
-      (
         github.event_name != 'issue_comment' ||
         (
           github.event.issue.pull_request == null &&
@@ -135,7 +128,6 @@ jobs:
           PROJECT_OWNER: sniffy
           PROJECT_NUMBER: '2'
           STATUS_REPOSITORY: sniffy/sniffy
-          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id || '' }}
           REFRESH_REQUEST_COMMENT_ID: ${{ github.event.comment.id || '' }}
           REFRESH_REQUEST_ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
           REFRESH_REQUEST_ACTOR: ${{ github.actor }}
@@ -205,7 +197,6 @@ jobs:
             --workflow-run-id "$GITHUB_RUN_ID" \
             --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
             --event "$GITHUB_EVENT_NAME" \
-            --upstream-run-id "$UPSTREAM_RUN_ID" \
             --head-sha "$source_sha" \
             --request-comment-id "$REFRESH_REQUEST_COMMENT_ID" \
             --request-issue-number "$REFRESH_REQUEST_ISSUE_NUMBER" \
@@ -239,7 +230,6 @@ jobs:
           ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
           ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
-          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id || '' }}
           SOURCE_SHA: ${{ steps.export.outputs.source_sha }}
           REFRESH_REQUEST_COMMENT_ID: ${{ github.event.comment.id || '' }}
           REFRESH_REQUEST_ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
@@ -252,7 +242,7 @@ jobs:
               id: Number(process.env.GITHUB_RUN_ID),
               attempt: Number(process.env.GITHUB_RUN_ATTEMPT),
               event: process.env.GITHUB_EVENT_NAME,
-              upstreamRunId: process.env.UPSTREAM_RUN_ID ? Number(process.env.UPSTREAM_RUN_ID) : null,
+              upstreamRunId: null,
               headSha: process.env.SOURCE_SHA,
               refreshRequest: process.env.REFRESH_REQUEST_COMMENT_ID ? {
                 commentId: Number(process.env.REFRESH_REQUEST_COMMENT_ID),

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -31,17 +31,20 @@ delivery-control commands and ordinary work discussion do not belong there.
 [`.github/workflows/delivery-status.yml`](../../.github/workflows/delivery-status.yml) runs:
 
 - at minute `5` of every hour as a best-effort dashboard and recovery fallback;
-- after non-PR completions of the `AI delivery control` workflow, so guarded mutations are materialized promptly;
 - on an exact `/ai-delivery-status refresh` issue comment on an `ai-delivery-status` issue from an actor allowlisted in
   [`profile.yml`](profile.yml);
 - through `workflow_dispatch` for maintainer-authorized diagnosis or recovery;
 - in validation-only mode for pull requests changing this adapter.
 
+The workflow deliberately does not publish after every delivery-control completion. A busy lifecycle turn may use several guarded
+commands, and exporting the complete Project after each one amplifies GraphQL cost until the shared token is rate-limited. A later
+dependent transition requests one explicit on-demand barrier instead. The hourly run remains a dashboard and recovery fallback.
+
 The publish job is serialized with `queue: max` and `cancel-in-progress: false`. GitHub may keep up to 100 pending publications in
 FIFO order instead of replacing an older pending request when another trigger arrives. This preserves each on-demand request until
 it can reach a terminal reaction while still keeping pointer updates sequential. The job always checks out trusted `develop`,
-including for `workflow_run` and `issue_comment`, so neither a completed pull-request validation run nor comment content can inject
-untrusted code into the secret-bearing publication job. The comment trigger accepts only the exact configured command, status
+including for `issue_comment`, so comment content cannot inject untrusted code into the secret-bearing publication job. The
+comment trigger accepts only the exact configured command, status
 label, and actors `bedrin` or `bedrin-gpt`; all other issue comments produce a skipped publication job.
 
 After the artifact and latest pointer are published, the workflow adds `+1` to the exact request comment. A publication failure
@@ -187,9 +190,9 @@ For a snapshot-backed client:
 
 After a control-command `+1`, a later dependent Project transition must use a status snapshot generated after that command. Work
 that does not require another immediate Project write may proceed from the verified claim reaction plus live source state. The
-`workflow_run` trigger normally refreshes the pointer promptly after control completion; if it does not, the tick uses the same
-on-demand comment barrier rather than waiting for best-effort cron. Scheduled runs remain a non-deterministic dashboard/recovery
-signal and are not the freshness guarantee for a tick.
+tick requests one on-demand comment barrier before the dependent transition rather than exporting after every control completion
+or waiting for best-effort cron. Scheduled runs remain a non-deterministic dashboard/recovery signal and are not the freshness
+guarantee for a tick.
 
 No client may mutate Project fields directly from the snapshot, treat the status issue as a delivery-control/Project-mutation
 channel, or bypass exact-head and expected-field guards. Its only accepted command is the configured read-only refresh request.

--- a/docs/ai-delivery/status-workflow-optimization.md
+++ b/docs/ai-delivery/status-workflow-optimization.md
@@ -9,7 +9,7 @@ runners, Project queries, artifact schema, permissions, or scheduling semantics.
 - use non-cone sparse checkout for the exact files consumed by each job;
 - keep `fetch-depth: 1`;
 - set `persist-credentials: false` because later steps authenticate explicitly through `GH_TOKEN` or action inputs;
-- preserve trusted `ref: develop` for secret-bearing publication triggered by `workflow_run`;
+- preserve trusted `ref: develop` for secret-bearing scheduled, on-demand, and manual publication;
 - preserve the current runner split: validation on `ubuntu-24.04` and publication on `ubuntu-slim`.
 
 Do not combine `filter` with `sparse-checkout`: `actions/checkout` documents that the partial-clone filter overrides sparse checkout.
@@ -34,7 +34,7 @@ future test reads another file, add that path in the same change that introduces
 
 - PR validation runs the existing focused tests, YAML parse, actionlint, and embedded shellcheck;
 - inspect checkout logs for the expected sparse-checkout configuration;
-- after merge, inspect one scheduled and one `workflow_run` publication;
+- after merge, inspect one scheduled and one on-demand publication;
 - verify pointer digest, artifact contents, source SHA, and counts remain unchanged in meaning.
 
 ## Removal condition


### PR DESCRIPTION
## Summary

Stop the status workflow from exporting a full ProjectV2 snapshot after every completed `AI delivery control` run.

The control burst used to fan out into one GraphQL-heavy status export per mutation. During the recovery dispatch on 2026-08-02 this produced roughly twenty status runs within minutes and exhausted the shared Project GraphQL quota. Status runs [30752565932](https://github.com/sniffy/sniffy/actions/runs/30752565932) and [30752834585](https://github.com/sniffy/sniffy/actions/runs/30752834585) failed with `API rate limit exceeded for user ID 4654384`.

## Design

- remove the redundant `workflow_run` trigger from `delivery-status.yml`;
- keep the exact on-demand refresh barrier for transitions that need a fresh snapshot;
- keep hourly fallback and manual dispatch;
- document that callers should request one barrier after their dependent control transition, not speculative refreshes;
- leave permissions, trusted checkout, snapshot schema, canonicalization and publication unchanged.

## Verification

- delivery/status/control/review policy suite: **84/84**
- focused delivery-status policy suite: **31/31**
- YAML parse: passed
- actionlint 1.7.12: passed
- `git diff --check`: passed

Published as one commit at exact head `1f65c94433352801e869308a6534808f7fabdd7b`. No merge or auto-merge requested.