### PR TITLE
Finish Codecov OIDC PR verification flow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,21 +53,6 @@ jobs:
         run: npm run typecheck
       - name: Unit and Storybook interaction tests with coverage
         run: npm run test:coverage
-      - name: Install Codecov uploader dependencies
-        run: |
-          apt-get update
-          apt-get install --no-install-recommends --yes ca-certificates curl git gnupg
-          rm -rf /var/lib/apt/lists/*
-      - name: Upload frontend coverage
-        uses: codecov/codecov-action@v7
-        with:
-          files: ./sniffy-ui/coverage/lcov.info
-          flags: frontend
-          disable_search: true
-          use_oidc: true
-          fail_ci_if_error: true
-          version: v11.3.1
-          name: frontend
       - name: Build Storybook
         run: npm run storybook:build
       - name: Build production assets
@@ -85,6 +70,21 @@ jobs:
           path: |
             sniffy-ui/playwright-report/
             sniffy-ui/test-results/
+      - name: Install Codecov uploader dependencies
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends --yes ca-certificates curl git gnupg
+          rm -rf /var/lib/apt/lists/*
+      - name: Upload frontend coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./sniffy-ui/coverage/lcov.info
+          flags: frontend
+          disable_search: true
+          use_oidc: true
+          fail_ci_if_error: true
+          version: v11.3.1
+          name: frontend
   website:
     name: Website
     runs-on: ubuntu-24.04
@@ -247,7 +247,6 @@ jobs:
         with:
           flags: backend
           use_oidc: true
-          fail_ci_if_error: true
   arch-matrix:
     runs-on: ubuntu-26.04
     timeout-minutes: 90
@@ -352,7 +351,6 @@ jobs:
         with:
           flags: backend
           use_oidc: true
-          fail_ci_if_error: true
   test-matrix:
     needs:
       - smoke-test
@@ -428,7 +426,6 @@ jobs:
         with:
           flags: backend
           use_oidc: true
-          fail_ci_if_error: true
   analyze:
     needs:
       - smoke-test


### PR DESCRIPTION
Closes #746.

## Problem

The earlier OIDC migration removed the stored Codecov token dependency, but the frontend upload still ran before Storybook/build/generated/bundle/Playwright verification, so an external Codecov failure could mask deterministic checks. It also made the three backend uploads blocking even though #746 explicitly preserves their existing non-blocking semantics.

Codex Cloud completed and validated the bounded fix, but GitHub rejected publication through its PAT because that credential lacks the `workflow` scope. This PR publishes the recovered one-file fix through the repository GitHub App without changing secrets, settings, triggers, matrices, check names, or permissions.

## Design

- move frontend Codecov dependency setup and upload after every deterministic frontend check and the always-running browser artifact step;
- keep frontend `fail_ci_if_error: true`;
- remove `fail_ci_if_error: true` from the three backend uploads so the official action's default non-blocking behavior is restored;
- retain the existing job-level `contents: read` / `id-token: write`, `use_oidc: true`, and tokenless fork path.

## Verification

Published recovery checks:

- YAML parse: passed
- Prettier 3.9.6: passed
- actionlint 1.7.12: passed after filtering only the pre-existing `ubuntu-26.04` label and undefined `matrix.language` diagnostics
- explicit Codecov order/permission/token/failure-policy contract: passed
- `git diff --check`: passed

The preceding Cloud run of the same bounded issue also reported lint, typecheck, 185 coverage tests, Storybook/build/generated/bundle checks and 60 functional browser tests passing. Its full Maven run hit the unrelated `SniffySocketChannelOrderingTest` concurrency failure, and three existing visual baselines differed in the Cloud environment; no retry, timeout, snapshot or unrelated code change is included here.

Exact published head: `dc51a6b21b0bff8c4feb27d1078c1fcf50690b64`. The new GitHub Actions run is the authoritative exact-head runtime proof. No merge or auto-merge is requested.