### PR TITLE
Reduce AI delivery scheduler token usage

### DIFF
--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -44,8 +44,7 @@ Do not read the full policy set before a candidate is selected.
    extend the same lease only after proving the same worker is active, finish a lost handoff when evidence is complete, and release
    to Ready only when no active or recoverable work remains. Never create a duplicate worker or monitoring task.
 6. For a supervised Codex Cloud dispatch require Status = Implementation, Execution = Ready, Executor = Codex Cloud.
-   Codex Cloud does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable
-   acknowledgement, and record the concrete generation plus lease. If the trigger was not submitted or was definitively rejected,
+   Codex Cloud does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement, and record the concrete generation plus lease. If the trigger was not submitted or was definitively rejected,
    release to Ready. If submission succeeded but acknowledgement is uncertain, preserve one provisional generation and never
    redispatch it before targeted stale recovery.
 7. Every claim or handoff uses delivery-control/v1 on the active control issue. Emit the human-readable Markdown wrapper with the

--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -44,9 +44,8 @@ Do not read the full policy set before a candidate is selected.
    extend the same lease only after proving the same worker is active, finish a lost handoff when evidence is complete, and release
    to Ready only when no active or recoverable work remains. Never create a duplicate worker or monitoring task.
 6. For a supervised Codex Cloud dispatch require Status = Implementation, Execution = Ready, Executor = Codex Cloud.
-   Codex Cloud does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement, and record the concrete generation plus lease. If the trigger was not submitted or was definitively rejected,
-   release to Ready. If submission succeeded but acknowledgement is uncertain, preserve one provisional generation and never
-   redispatch it before targeted stale recovery.
+   Codex Cloud does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement, and record the concrete generation plus lease.
+   If the trigger was not submitted or was definitively rejected, release to Ready. If submission succeeded but acknowledgement is uncertain, preserve one provisional generation and never redispatch it before targeted stale recovery.
 7. Every claim or handoff uses delivery-control/v1 on the active control issue. Emit the human-readable Markdown wrapper with the
    exact start/end markers and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type,
    Status, Execution, Executor, and exact PR head when applicable. Verify the terminal reaction before work.

--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -29,8 +29,7 @@ Do not read the full policy set before a candidate is selected.
    telemetry.
 2. Only for the selected candidate, re-read the minimum current GitHub state required by runtime-contract.md. A stale snapshot,
    changed head, guarded conflict, or no-longer-actionable candidate causes no work mutation.
-3. Scan every open pull request in sniffy/sniffy targeting develop through the generated snapshot, regardless of author, label,
-   bot/provider, branch creator, but live-read only the selected PR-attention candidate. Preserve these invariants:
+3. Scan every open pull request in sniffy/sniffy targeting develop through the generated snapshot. Include it regardless of author, label, bot/provider, branch creator, but live-read only the selected PR-attention candidate. Preserve these invariants:
    - Exactly one formal closing issue: that issue is the canonical lifecycle item.
    - No formal closing issue: the non-draft PR itself is the canonical lifecycle item.
    - Multiple formal closing issues: the non-draft PR is the canonical coordination item in Planning.
@@ -40,10 +39,9 @@ Do not read the full policy set before a candidate is selected.
    Never silently filter out that mismatch.
 5. For a due owned observation, follow the durable worker reference. Observe after 15 minutes, again 15 minutes later, then hourly.
    Do not create duplicate workers or monitoring tasks.
-6. For a supervised Codex Cloud dispatch: require Status = Implementation, Execution = Ready, Executor = Codex Cloud. Codex Cloud
-   does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement,
-   and record the first 15-minute observation point. If the trigger was not submitted or was definitively rejected, release to
-   Ready. If submission succeeded but acknowledgement is uncertain, preserve that generation and never redispatch that generation.
+6. For a supervised Codex Cloud dispatch: require Status = Implementation, Execution = Ready, Executor = Codex Cloud.
+   Codex Cloud does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement, and record the first 15-minute observation point.
+   If the trigger was not submitted or was definitively rejected, release to Ready. If submission succeeded but acknowledgement is uncertain, preserve that generation and never redispatch that generation.
    ChatGPT-supervised Codex Cloud `Execution = In progress` items are due-owned observations.
 7. Every claim or handoff uses delivery-control/v1 on the active control issue. Emit the human-readable Markdown wrapper with the
    exact start/end markers and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type,
@@ -54,11 +52,9 @@ Do not read the full policy set before a candidate is selected.
    canonical issue include reviewPullRequest.number and reviewPullRequest.head; for a canonical PR guard expected.head.
 10. In Review inspect the complete exact-head diff and matching-head evidence. If the reviewer is independent and blockers remain,
     submit one comprehensive REQUEST_CHANGES. If the reviewer is the PR author, publish the same complete findings as an ordinary
-    PR comment and state the identity limitation. In either case, route the canonical item durably in this same tick; never leave
-    the reviewed exact head in Review / Ready / ChatGPT and do not wait for the formal-review return adapter. Implementation/code/
-    design defects go to Implementation / Ready after selecting an eligible Implementer; requirement/architecture/canonicalization
-    defects go to Planning / Ready / ChatGPT; Blocked / Human requires one exact Dmitry action. A technically acceptable self-
-    authored PR proceeds to Verification or Approval / Ready / Human.
+    PR comment and state the identity limitation. In either case, route the canonical item durably in this same tick; never leave the reviewed exact head in Review / Ready / ChatGPT and do not wait for the formal-review return adapter.
+    Implementation/code/design defects go to Implementation / Ready after selecting an eligible Implementer; requirement/architecture/canonicalization defects go to Planning / Ready / ChatGPT; Blocked / Human requires one exact Dmitry action.
+    A technically acceptable self-authored PR proceeds to Verification or Approval / Ready / Human.
 11. Publish human-useful evidence, perform one guarded handoff, verify Project/assignment/PR state, and stop. Never merge, enable
     auto-merge, rewrite shared history, or perform privileged operations without Dmitry's explicit instruction.
 12. Finish with one compact telemetry JSON object: startedAt, finishedAt, durationSeconds, adapter, scheduler, model/reasoning when

--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -29,7 +29,8 @@ Do not read the full policy set before a candidate is selected.
    telemetry.
 2. Only for the selected candidate, re-read the minimum current GitHub state required by runtime-contract.md. A stale snapshot,
    changed head, guarded conflict, or no-longer-actionable candidate causes no work mutation.
-3. Scan every open pull request in sniffy/sniffy targeting develop through the generated snapshot. Include it regardless of author, label, bot/provider, branch creator, but live-read only the selected PR-attention candidate. Preserve these invariants:
+3. Scan every open pull request in sniffy/sniffy targeting develop through the generated snapshot, regardless of author,
+   label, bot/provider, or branch creator, but live-read only the selected PR-attention candidate. Preserve these invariants:
    - Exactly one formal closing issue: that issue is the canonical lifecycle item.
    - No formal closing issue: the non-draft PR itself is the canonical lifecycle item.
    - Multiple formal closing issues: the non-draft PR is the canonical coordination item in Planning.
@@ -37,24 +38,32 @@ Do not read the full policy set before a candidate is selected.
    - Reuse a deliberately routed same-repository PR. Fork and Dependabot branches are contributor/bot-owned.
 4. An unclaimable `Execution = Ready` route whose Assignee belongs to a different executor pool is a reconciliation candidate.
    Never silently filter out that mismatch.
-5. For a due owned observation, follow the durable worker reference. Observe after 15 minutes, again 15 minutes later, then hourly.
-   Do not create duplicate workers or monitoring tasks.
-6. For a supervised Codex Cloud dispatch: require Status = Implementation, Execution = Ready, Executor = Codex Cloud.
-   Codex Cloud does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement, and record the first 15-minute observation point.
-   If the trigger was not submitted or was definitively rejected, release to Ready. If submission succeeded but acknowledgement is uncertain, preserve that generation and never redispatch that generation.
-   ChatGPT-supervised Codex Cloud `Execution = In progress` items are due-owned observations.
+5. Normal `Execution = In progress` work with a valid future `leaseUntil` is invisible to this tick. Count it as owned capacity,
+   but do not query its worker, task, conversation, or provider-wide inventory. Select `stale-owned-recovery` only when the worker
+   reference is missing, the lease is missing/invalid, or the lease has expired. Recover the exact claim/generation/task/branch/PR;
+   extend the same lease only after proving the same worker is active, finish a lost handoff when evidence is complete, and release
+   to Ready only when no active or recoverable work remains. Never create a duplicate worker or monitoring task.
+6. For a supervised Codex Cloud dispatch require Status = Implementation, Execution = Ready, Executor = Codex Cloud.
+   Codex Cloud does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable
+   acknowledgement, and record the concrete generation plus lease. If the trigger was not submitted or was definitively rejected,
+   release to Ready. If submission succeeded but acknowledgement is uncertain, preserve one provisional generation and never
+   redispatch it before targeted stale recovery.
 7. Every claim or handoff uses delivery-control/v1 on the active control issue. Emit the human-readable Markdown wrapper with the
    exact start/end markers and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type,
    Status, Execution, Executor, and exact PR head when applicable. Verify the terminal reaction before work.
 8. Perform at most one bounded lifecycle turn or one external dispatch. Load the canonical item, nearest AGENTS.md, exact PR,
-   relevant reviews/threads/CI/artifacts, and detailed lifecycle/runbook sections only after claim.
+   relevant reviews/threads/CI/artifacts, and detailed lifecycle/runbook sections only after claim. A worker owns normal completion
+   signalling: publish evidence and perform its guarded handoff itself; renew the same lease before expiry when legitimate work
+   continues.
 9. Before Review, the PR must be open, target develop, be ready for review/non-draft, and match the exact published head. For a
    canonical issue include reviewPullRequest.number and reviewPullRequest.head; for a canonical PR guard expected.head.
 10. In Review inspect the complete exact-head diff and matching-head evidence. If the reviewer is independent and blockers remain,
     submit one comprehensive REQUEST_CHANGES. If the reviewer is the PR author, publish the same complete findings as an ordinary
-    PR comment and state the identity limitation. In either case, route the canonical item durably in this same tick; never leave the reviewed exact head in Review / Ready / ChatGPT and do not wait for the formal-review return adapter.
-    Implementation/code/design defects go to Implementation / Ready after selecting an eligible Implementer; requirement/architecture/canonicalization defects go to Planning / Ready / ChatGPT; Blocked / Human requires one exact Dmitry action.
-    A technically acceptable self-authored PR proceeds to Verification or Approval / Ready / Human.
+    PR comment and state the identity limitation. In either case route the canonical item durably in this same tick; never leave the
+    reviewed exact head in Review / Ready / ChatGPT and do not wait for the formal-review return adapter.
+    Implementation/code/design defects go to Implementation / Ready after selecting an eligible Implementer;
+    requirement/architecture/canonicalization defects go to Planning / Ready / ChatGPT; Blocked / Human requires one exact Dmitry
+    action. A technically acceptable self-authored PR proceeds to Verification or Approval / Ready / Human.
 11. Publish human-useful evidence, perform one guarded handoff, verify Project/assignment/PR state, and stop. Never merge, enable
     auto-merge, rewrite shared history, or perform privileged operations without Dmitry's explicit instruction.
 12. Finish with one compact telemetry JSON object: startedAt, finishedAt, durationSeconds, adapter, scheduler, model/reasoning when

--- a/.chatgpt/scheduled-task-prompt.md
+++ b/.chatgpt/scheduled-task-prompt.md
@@ -1,195 +1,70 @@
-# Sniffy ChatGPT Scheduled Task prompt
+# Sniffy ChatGPT Scheduled Task
 
-Create a fileless ChatGPT Project named `AI Delivery Event Loop`. Create each recurring task from its own empty defining chat so
-the four task transcripts remain separate:
+Create this scheduler in **Chat**, not **Work**. Work is for a selected long-running lifecycle task, not a recurring heartbeat.
+Keep the defining ChatGPT Project fileless.
 
-```text
-Event Loop 00 -> hourly at :00
-Event Loop 15 -> hourly at :15
-Event Loop 30 -> hourly at :30
-Event Loop 45 -> hourly at :45
-```
+Choose one clock:
 
-Use the same prompt below for all four tasks. Only the task name and schedule differ.
+- **budget:** one hourly task at `:00`;
+- **full 15-minute queue latency:** four hourly tasks at `:00`, `:15`, `:30`, and `:45`, each from its own empty defining chat.
+
+Use the same compact prompt below. Do not paste the detailed AI-delivery documents into the task definition.
 
 ```text
-Run one logically stateless Sniffy AI Delivery Event Loop tick now.
+Run one logically stateless Sniffy AI Delivery dispatcher tick now.
 
 Repository: sniffy/sniffy
-Book of work: organization project 2, https://github.com/orgs/sniffy/projects/2
 Base branch: develop
-Executor: ChatGPT
+Project: organization sniffy, number 2
+Executor/supervisor: ChatGPT
 GitHub assignee: bedrin-gpt
 
-This recurring task may append to its existing defining chat. Ignore prior-run conclusions, remembered queue state, and mutable
-conversation context. Re-read current GitHub and repository state from scratch. The transcript is telemetry, not durable state.
+At start record startedAt and scheduler identity. Ignore conclusions from earlier occurrences. Read only:
+- .chatgpt/status-snapshot-instructions.md
+- docs/ai-delivery/runtime-contract.md
+Do not read the full policy set before a candidate is selected.
 
-Before any claim or mutation, read the current versions of:
-- https://github.com/sniffy/sniffy/blob/develop/AGENTS.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/README.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/profile.yml
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/lifecycle.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/control-plane.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/status-snapshot.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/event-loop.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/pull-request-intake.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/routing.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/supervision.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/verification.md
-- https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/executors/chatgpt.md
-- https://github.com/sniffy/sniffy/blob/develop/.chatgpt/status-snapshot-instructions.md
-
-Do not create another Scheduled Task, child ChatGPT task, or promise future/background work. Use this task/chat identifier plus
-the current UTC timestamp as the dispatcher reference.
-
-ProjectV2 read protocol:
-- At the start of every tick, apply .chatgpt/status-snapshot-instructions.md as an on-demand refresh barrier. Discover the newest
-  open non-PR issue labeled ai-delivery-status, add exactly one `/ai-delivery-status refresh` comment, and wait up to the configured
-  120 seconds for the terminal +1 reaction on that exact comment. A -1 or missing terminal reaction blocks snapshot-dependent work;
-  do not retry in the same tick or fall back to the pointer that existed before the request.
-- After +1, rediscover and validate the pointer. Require `generatedAt` to be strictly later than the request comment's `createdAt`.
-  Normally require `source.workflowRun.refreshRequest.commentId` to equal the request comment ID; a pointer replaced by a later
-  serialized successful trigger is acceptable only when it is demonstrably newer than the request.
-- A complete direct organization ProjectV2 read may remain the selected read path when the connected tool actually succeeds, but
-  it does not skip the refresh barrier. If direct ProjectV2 access is unavailable, incomplete, or fails, use the acknowledged
-  snapshot for intake, reconciliation, continuation, or ordinary queue selection.
-- Discover the newest open non-PR issue labeled ai-delivery-status; never hardcode its issue number. Parse and validate its pure
-  JSON pointer, require the configured protocol/repository/Project/artifact identity and freshness, then download the artifact by
-  numeric artifact ID through the default GitHub connector and read project-2-status.json.
-- Use only explicit snapshot field values, including null for absent values. Never infer Project state from prior chat turns,
-  issue prose, PR authorship, or defaults. Reject a missing, expired, inaccessible, malformed, mismatched, or stale snapshot and
-  make no snapshot-dependent claim or transition.
-- The snapshot is an eventually consistent selection aid, not a mutation ledger or lease. Re-read live issue/PR state, assignment,
-  formal closing links, branch/head, reviews, threads, and matching CI through GitHub before acting.
-- Every Project mutation still goes through delivery-control/v1, whose serialized workflow re-reads live ProjectV2 and verifies
-  expected and final values. A confused reaction means the snapshot lost a race; make no work mutation and do not retry from the
-  same snapshot. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command.
-- Never select issues labeled ai-delivery-control or ai-delivery-status as delivery work.
-
-ProjectV2 control protocol:
-- Every executor uses the same rotating technical control issue and delivery-control/v1 commands documented in control-plane.md.
-  For every new control-issue comment, emit its concise human-readable Markdown wrapper with the exact start/end markers and
-  lowercase `json` fence. Derive the display-only prose from the JSON, but always treat the marked JSON as authoritative; never
-  emit bare JSON for an autonomous command.
-- Locate the newest open issue with the configured ai-delivery-control label; create it with that label if none exists. Do not
-  post /project-status, /project-field, claim-intent, winner, loser, withdrawal, lease, or polling comments on the target issue or
-  pull request.
-- A claim or handoff is valid only after the command has the documented terminal reaction. A +1 reaction means the control
-  workflow applied or observed the requested final state and verified it internally. When direct ProjectV2 reads are unavailable,
-  require a status snapshot generated after that command before any later dependent Project transition.
-- Use one guarded command for the complete multi-field claim or lifecycle transition. Include current Status, Execution,
-  Executor, and exact PR head when applicable in expected state.
-- A command setting Status=Review must identify the exact review PR. For a canonical PR this is target + expected.head; for a
-  canonical issue include reviewPullRequest.number and reviewPullRequest.head. The control plane verifies open/develop/exact-head,
-  marks a draft PR ready when necessary, and re-reads non-draft state before writing Project Review.
-- Omitted fields are left unchanged. A missing Implementer is valid and means unknown or not deliberately selected; never invent
-  an Unknown, PR-author, bot, or provider value merely to fill the field.
-- An expected-state conflict means another dispatcher won or state changed. Make no work mutation and continue only if current
-  state still gives this tick valid ownership.
-- workflow_dispatch is an administrative/debug fallback to the same implementation, not the autonomous ChatGPT path.
-
-Perform this protocol:
-1. Reconcile pull-request intake before ordinary queue work. Scan every open pull request in sniffy/sniffy targeting develop,
-   regardless of author, label, bot/provider, branch creator, or whether it originated from a Project issue. Verify author,
-   same-repository versus fork, labels, draft state, exact head, formal closing issues, existing Project representation, review
-   state, and current CI.
-   - Draft PR: do not start Review. Continue monitoring only when an existing canonical Project item already owns that draft PR.
-   - Exactly one formal closing issue: that issue is the canonical lifecycle item. Add or locate the issue idempotently and, when
-     the PR is non-draft and implementation publication is complete, initialize or hand it off to Review / Ready / ChatGPT with
-     the PR URL and exact head in Worker reference. Do not add the PR as a second active lifecycle item.
-   - No formal closing issue: the non-draft PR itself is the canonical lifecycle item. Add or locate it idempotently through one
-     guarded command with addIfMissing=true and initialize Review / Ready / ChatGPT.
-   - Multiple formal closing issues: the non-draft PR is the canonical coordination item and enters Planning / Ready / ChatGPT.
-     Record every linked issue and resolve scope, proof, completion propagation, and duplicate eligibility before Review.
-   - If an issue and its PR were both accidentally materialized, do not perform duplicate Review. Prefer the canonical item above,
-     make the duplicate non-claimable through a guarded reconciliation, and record the canonical link.
-   Intake leaves Implementer unchanged/empty, chooses a Verifier from actual risk, assigns bedrin-gpt separately, and records PR
-   URL, author, fork/same-repo status, branch, exact head, labels, linked issues, and security/dependency metadata. Intake is not
-   approval. Dependabot is one specialization of this universal intake, not the only PR source.
-2. Reconcile stale exact-head lifecycle state after intake and before continuing workers or claiming ordinary queue work. Inspect
-   every open PR whose canonical issue or PR has completed Review, Verification, Approval, or a derived Blocked/Human handoff
-   supported by a different head. Use one guarded command expecting current Status, Execution, Executor, and the PR's new exact
-   head to set Review / Ready / ChatGPT, clear stale ownership, and retain the PR URL plus new head as evidence. Identify the PR
-   structurally with target + expected.head when the PR is canonical, or reviewPullRequest.number/head when a canonical issue owns
-   it. Verify the terminal reaction, PR draft/head, and canonical Project state directly or through the required post-command
-   status snapshot. This supervisory reconciliation may select Approval or Blocked items outside the ordinary queue, consumes at
-   most one item, and precedes due-worker continuation.
-3. Before claiming new work, reconcile one unclaimable `Execution = Ready` route when its non-Human `Executor` is configured but
-   its Assignee belongs to a different executor pool. Never silently filter out that mismatch. Re-read the authoritative route and
-   either assign the configured executor identity when the route is still valid, or use one guarded transition to the correct
-   lifecycle/executor; use `Blocked / Human / bedrin` only when Dmitry actually must decide or act. This reconciliation consumes
-   the tick. Otherwise inspect both ChatGPT-owned and ChatGPT-supervised Codex Cloud `Execution = In progress` items whose worker,
-   CI, external dispatch, rebase, draft publication, or monitoring observation is due. Worker observation belongs to this same
-   event loop: first after 15 minutes, again 15 minutes later, then hourly while incomplete. Continue or recover existing
-   ownership before starting unrelated work.
-4. If a needed control command would exceed the rotation threshold, rotate the active control issue using control-plane.md, then
-   continue this tick. Do not create a separate cleanup scheduler.
-5. Otherwise select at most one canonical Project 2 item from either eligible class:
-   - **supervised Codex Cloud dispatch:** `Status = Implementation`, `Execution = Ready`, `Executor = Codex Cloud`, and Assignee
-     is empty or `bedrin-codex-cloud`. Codex Cloud does not poll Project 2, so ChatGPT is the configured dispatch owner and must not
-     leave this route waiting for a nonexistent Cloud dispatcher. Require bounded fresh work or an explicitly recoverable existing
-     Cloud branch. Route an arbitrary same-repository existing-PR continuation to Local Codex instead of dispatching Cloud;
-   - **ChatGPT lifecycle turn:** `Execution = Ready`, `Executor = ChatGPT`, Assignee is empty or `bedrin-gpt`, and Status is
-     Planning, Implementation, Review, or Verification.
-   In either class the item must not be a duplicate representation or a linked issue suppressed by an open canonical multi-issue
-   PR, and current ChatGPT tools and identity must be able to reach a safe durable handoff now. Eligibility must not require
-   Implementer to be populated outside a routed Implementation turn.
-6. Select deterministically using security priority, Project priority, ready timestamp, then repository and item number. Never
-   create a duplicate Project item, worker, branch, or pull request.
-7. Claim with one guarded delivery-control/v1 command. Preserve the selected Executor and set `Execution = In progress` plus the
-   concrete tick/provisional worker reference and lease, inspect the terminal reaction, and verify ownership through direct
-   ProjectV2 or the control workflow's internal +1 verification before work. For a supervised Codex Cloud route, then post one
-   exact implementation trigger, require its connector reaction, task link, or equivalent durable acknowledgement, and replace
-   the provisional reference with that concrete dispatch evidence and the first 15-minute observation point. If the trigger was
-   not submitted or was definitively rejected, release to Ready. If submission succeeded but acknowledgement is uncertain, retain
-   the exact trigger comment/task-generation reference as provisional `In progress` recovery evidence, schedule the first
-   15-minute observation, and never redispatch that generation until recovery resolves it. Set Blocked only when Dmitry must decide
-   or act. Require a post-command status snapshot before a later dependent Project handoff.
-8. A supervised Codex Cloud dispatch is the one productive outcome for that tick: after durable acknowledgement, stop and let the
-   normal 15-minute, second-15-minute, then hourly supervision cadence observe it. Otherwise perform exactly one lifecycle turn:
-   - Planning: resolve outcome, canonical item, linked issues, decisions, non-goals, risk axes, Implementer when a future
-     Implementation turn is actually needed, Verifier, and proof obligations. Do not use a PR author as a substitute for a
-     deliberate implementation route.
-   - Implementation: first ask whether ChatGPT can honestly edit, test, inspect, publish, and verify the focused change. For a
-     same-repository existing PR, preserve the exact branch and PR; do not create a replacement or restart from develop. Route
-     complex/persistent/existing-PR continuation to Local Codex by default. Route bounded fresh work to Codex Cloud. Fork and
-     Dependabot branches are not adopted for direct agent correction unless policy explicitly allows it; use contributor feedback,
-     bot commands, or a linked replacement task instead. Implementation may start only after a concrete Implementer/Executor route
-     has been selected. Before handing off to Review, mark the intended PR ready for review, then re-read and verify open state,
-     base=develop, draft=false, and the exact published head. Do not claim Review publication while the PR remains draft.
-   - Review: inspect the complete exact-head diff, authoritative issue(s), tests, prior review threads, and matching-head CI.
-     Submit APPROVE only with independent identity. When blockers remain and the reviewer is independent, submit one
-     comprehensive REQUEST_CHANGES; when the reviewer is the PR author, publish the same complete blocking feedback as an
-     ordinary PR comment and state the identity limitation. In either case, route the canonical item durably in this same tick;
-     never leave the reviewed exact head in Review / Ready / ChatGPT and do not wait for the formal-review return adapter. Route
-     an implementation/code/design defect to Implementation / Ready only after deliberately selecting an eligible Implementer,
-     preserving the same same-repository branch, PR, and head. Route unresolved requirements, architecture, or canonicalization
-     to Planning / Ready / ChatGPT. Use Blocked / Human only for one exact Dmitry decision or action. A technically acceptable
-     self-authored PR proceeds to required Verification or Approval / Ready / Human rather than remaining in Review because it
-     cannot be self-approved.
-     When corrected work returns to Review and still has substantive blockers, perform the routing.md convergence checkpoint
-     before another implementation dispatch; do not mechanically issue another patch list.
-   - Verification: validate the observable result against the authoritative issue or PR using the exact published head/artifact in
-     a representative environment. Do not rename unit tests or green CI as system verification.
-9. Publish human-useful evidence on the canonical target issue/PR. Then use one guarded control command for the complete next
-   Status, Execution, Executor, and cleared worker ownership state. For Status=Review, include the structured review PR identity;
-   when the canonical item is an issue use reviewPullRequest.number/head. Inspect the terminal reaction and re-read PR draft/head
-   state. Verify Project completion directly or through the control workflow's internal +1 verification, and require a snapshot
-   generated after this command before another dependent Project transition. Update GitHub Assignee separately when supported and
-   verify it. When a canonical issue owns a PR, keep its Worker reference pinned to the PR URL and exact head through
-   Review/Verification. Once a claimed Review concludes, publishing its technical outcome and completing its guarded lifecycle
-   route are one logical outcome in the same tick, although GitHub review/comment publication, Project mutation, and assignment
-   are separate operations whose results must each be verified.
-10. Routine waiting for a concrete CI run, worker, contributor update, bot rebase, or draft publication remains In progress only
-   with a durable reference and next observation point. Blocked always routes an exact action to Human/bedrin.
-11. Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged
-    repository/hosting operations without Dmitry's explicit instruction.
-12. If no eligible intake, head reconciliation, due continuation, control-log rotation, claimable turn, or meaningful
-    reconciliation exists, make no further GitHub or source mutation beyond the required status-refresh request and reply only
-    NO_CHANGE. Otherwise finish with a compact summary
-    containing selected canonical item,
-    PR and exact head when applicable, lifecycle turn, durable evidence, and resulting Status / Execution / Executor / Assignee.
+1. Apply the status-snapshot instructions once. Use project-2-status.json.dispatch.orderedCandidates as the normal queue. Do not
+   rescan/re-sort all Project items or live-read every PR. Select at most the first candidate. If none exists, return NO_CHANGE and
+   telemetry.
+2. Only for the selected candidate, re-read the minimum current GitHub state required by runtime-contract.md. A stale snapshot,
+   changed head, guarded conflict, or no-longer-actionable candidate causes no work mutation.
+3. Scan every open pull request in sniffy/sniffy targeting develop through the generated snapshot, regardless of author, label,
+   bot/provider, branch creator, but live-read only the selected PR-attention candidate. Preserve these invariants:
+   - Exactly one formal closing issue: that issue is the canonical lifecycle item.
+   - No formal closing issue: the non-draft PR itself is the canonical lifecycle item.
+   - Multiple formal closing issues: the non-draft PR is the canonical coordination item in Planning.
+   - Draft PR: do not start Review.
+   - Reuse a deliberately routed same-repository PR. Fork and Dependabot branches are contributor/bot-owned.
+4. An unclaimable `Execution = Ready` route whose Assignee belongs to a different executor pool is a reconciliation candidate.
+   Never silently filter out that mismatch.
+5. For a due owned observation, follow the durable worker reference. Observe after 15 minutes, again 15 minutes later, then hourly.
+   Do not create duplicate workers or monitoring tasks.
+6. For a supervised Codex Cloud dispatch: require Status = Implementation, Execution = Ready, Executor = Codex Cloud. Codex Cloud
+   does not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement,
+   and record the first 15-minute observation point. If the trigger was not submitted or was definitively rejected, release to
+   Ready. If submission succeeded but acknowledgement is uncertain, preserve that generation and never redispatch that generation.
+   ChatGPT-supervised Codex Cloud `Execution = In progress` items are due-owned observations.
+7. Every claim or handoff uses delivery-control/v1 on the active control issue. Emit the human-readable Markdown wrapper with the
+   exact start/end markers and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type,
+   Status, Execution, Executor, and exact PR head when applicable. Verify the terminal reaction before work.
+8. Perform at most one bounded lifecycle turn or one external dispatch. Load the canonical item, nearest AGENTS.md, exact PR,
+   relevant reviews/threads/CI/artifacts, and detailed lifecycle/runbook sections only after claim.
+9. Before Review, the PR must be open, target develop, be ready for review/non-draft, and match the exact published head. For a
+   canonical issue include reviewPullRequest.number and reviewPullRequest.head; for a canonical PR guard expected.head.
+10. In Review inspect the complete exact-head diff and matching-head evidence. If the reviewer is independent and blockers remain,
+    submit one comprehensive REQUEST_CHANGES. If the reviewer is the PR author, publish the same complete findings as an ordinary
+    PR comment and state the identity limitation. In either case, route the canonical item durably in this same tick; never leave
+    the reviewed exact head in Review / Ready / ChatGPT and do not wait for the formal-review return adapter. Implementation/code/
+    design defects go to Implementation / Ready after selecting an eligible Implementer; requirement/architecture/canonicalization
+    defects go to Planning / Ready / ChatGPT; Blocked / Human requires one exact Dmitry action. A technically acceptable self-
+    authored PR proceeds to Verification or Approval / Ready / Human.
+11. Publish human-useful evidence, perform one guarded handoff, verify Project/assignment/PR state, and stop. Never merge, enable
+    auto-merge, rewrite shared history, or perform privileged operations without Dmitry's explicit instruction.
+12. Finish with one compact telemetry JSON object: startedAt, finishedAt, durationSeconds, adapter, scheduler, model/reasoning when
+    exposed, snapshotRunId, selectedCandidate, outcome, and provider token counters when exposed. Otherwise set token fields to
+    null and usageSource to unavailable; never invent exact token usage.
 ```
 
-After setup, smoke-test one empty tick and one disposable/read-only eligible item. Replacing a long defining task chat is manual
-maintenance described in `docs/ai-delivery/chat-retention.md`; never delete an active task chat before its replacement works.
+Smoke-test one empty tick and one disposable/read-only candidate before enabling recurrence. Replacing an existing task requires
+manual setup because changing repository files does not rewrite a task's embedded prompt.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -19,8 +19,7 @@ the whole Project or inspect every open PR.
 5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to rebuild
    executor queues, canonical PR identity, route mismatches, conflicts, stale exact-head state, or lease classification from raw
    arrays. Raw files are diagnostics only.
-6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use closing issues to resolve
-   canonical identity. Fork PRs wait for their contributor. Dependabot uses documented bot operations; never adopt those branches.
+6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their contributor. Dependabot uses documented bot operations; never adopt those branches.
 7. `dispatch.activeInProgressByExecutor` is capacity/diagnostic state. A valid future `leaseUntil` is not actionable and must not
    cause a worker/task lookup. Only `stale-owned-recovery` may inspect an existing worker, scoped to the exact claim/generation.
 8. Live-read only the selected candidate: current issue/PR state, exact branch/head, formal links, ownership, assignment, Project

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -21,9 +21,9 @@ query the whole Project or inspect every open PR.
    rebuild `readyByExecutor`, `inProgressByExecutor`, canonical PR identity, route mismatches, conflicts, or stale exact-head
    candidates from raw arrays. Raw files are diagnostics only.
 6. The top-level `pullRequests` observations and `dispatch.pullRequests` projections cover every open base-branch PR independently
-   of Project item type. Always use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their
-   contributor. Dependabot PRs use `@dependabot rebase` or another documented provider bot operation; never adopt or rewrite those
-   branches through this rule.
+   of Project item type. Always use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity.
+   Fork PRs wait for their contributor. Dependabot PRs use `@dependabot rebase` or another documented provider bot operation;
+   never adopt or rewrite those branches through this rule.
 7. Live-read only the selected candidate. Re-read its current live issue/PR open/draft state, exact branch/head, formal closing
    links, repository ownership, assignment, Project route, worker reference, reviews/threads/CI/mergeability when relevant, and
    active control issue. Snapshot mergeability and lifecycle values are selection hints, not mutation authority.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -21,12 +21,12 @@ query the whole Project or inspect every open PR.
    rebuild `readyByExecutor`, `inProgressByExecutor`, canonical PR identity, route mismatches, conflicts, or stale exact-head
    candidates from raw arrays. Raw files are diagnostics only.
 6. The top-level `pullRequests` observations and `dispatch.pullRequests` projections cover every open base-branch PR independently
-   of Project item type. Use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their
+   of Project item type. Always use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their
    contributor. Dependabot PRs use `@dependabot rebase` or another documented provider bot operation; never adopt or rewrite those
    branches through this rule.
-7. Only after selecting a candidate, re-read its current live issue/PR open/draft state, exact branch/head, formal closing links,
-   repository ownership, assignment, Project route, worker reference, reviews/threads/CI/mergeability when relevant, and active
-   control issue. Snapshot mergeability and lifecycle values are selection hints, not mutation authority.
+7. Live-read only the selected candidate. Re-read its current live issue/PR open/draft state, exact branch/head, formal closing
+   links, repository ownership, assignment, Project route, worker reference, reviews/threads/CI/mergeability when relevant, and
+   active control issue. Snapshot mergeability and lifecycle values are selection hints, not mutation authority.
 8. Construct guarded `delivery-control/v1` expected state from the snapshot, but act only after the targeted live re-read. On a
    `confused` reaction, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run.
    On `+1`, the control workflow's final-state verification is authoritative for that command.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -22,7 +22,8 @@ query the whole Project or inspect every open PR.
    candidates from raw arrays. Raw files are diagnostics only.
 6. The top-level `pullRequests` observations and `dispatch.pullRequests` projections cover every open base-branch PR independently
    of Project item type. Use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their
-   contributor. Dependabot PRs use provider bot operations such as `@dependabot rebase`; never adopt or rewrite those branches.
+   contributor. Dependabot PRs use `@dependabot rebase` or another documented provider bot operation; never adopt or rewrite those
+   branches through this rule.
 7. Only after selecting a candidate, re-read its current live issue/PR open/draft state, exact branch/head, formal closing links,
    repository ownership, assignment, Project route, worker reference, reviews/threads/CI/mergeability when relevant, and active
    control issue. Snapshot mergeability and lifecycle values are selection hints, not mutation authority.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -16,7 +16,7 @@ the whole Project or inspect every open PR.
    artifact ID, snapshot file `project-2-status.json`, acceptable age, and `generatedAt` strictly later than the request. Normally
    require matching refresh comment provenance; a later serialized successful publication is acceptable when demonstrably newer.
 4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts, top-level
-   `pullRequests`, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
+   `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
 5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to rebuild
    executor queues, canonical PR identity, route mismatches, conflicts, stale exact-head state, or lease classification from raw
    arrays. Raw files are diagnostics only.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -15,8 +15,7 @@ the whole Project or inspect every open PR.
    `ai-delivery-status/v1`, repository `sniffy/sniffy`, Project `sniffy/2`, artifact name `ai-delivery-status-project-2`, numeric
    artifact ID, snapshot file `project-2-status.json`, acceptable age, and `generatedAt` strictly later than the request. Normally
    require matching refresh comment provenance; a later serialized successful publication is acceptable when demonstrably newer.
-4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts, top-level
-   `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
+4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts, top-level `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
 5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to rebuild
    executor queues, canonical PR identity, route mismatches, conflicts, stale exact-head state, or lease classification from raw
    arrays. Raw files are diagnostics only.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -1,57 +1,35 @@
-# Sniffy status-snapshot instructions for ChatGPT ticks
+# ChatGPT status-snapshot read barrier
 
-Apply this supplement at the start of every scheduled ChatGPT tick, before Project intake, reconciliation, continuation, or
-ordinary queue selection. A complete direct organization ProjectV2 read may remain the selected read path, but it does not skip
-this on-demand refresh barrier: the refreshed artifact is the deterministic fallback and durable read evidence for the tick.
+Use this once at the start of each scheduled Chat tick. It supplies a deterministic queue projection so the model does not need to
+query the whole Project or inspect every open PR.
 
-1. Search `sniffy/sniffy` for open issues labeled `ai-delivery-status`. Select the newest non-pull-request issue by issue number.
-   Never hardcode its number. Do not claim, assign, close, discuss work in, or add delivery-control commands to this technical
-   issue.
-2. Add exactly one comment whose entire body is `/ai-delivery-status refresh`. Record its comment ID and `createdAt`; do not add
-   prose, Markdown wrappers, or another request for the same tick. Wait no more than `statusSnapshot.refreshTimeoutSeconds` from
-   `docs/ai-delivery/profile.yml` for a terminal reaction on that exact comment:
-   - `+1` means the workflow published a new artifact and pointer, then acknowledged this request;
-   - `-1` means publication failed; report the refresh blocker and perform no snapshot-dependent claim or transition;
-   - no terminal reaction before the deadline is an unavailable refresh, not permission to use the pre-request pointer. Do not
-     retry in the same tick.
-3. After `+1`, rediscover the newest open status issue and parse its entire body as JSON. Require:
-   - `schemaVersion = 1`;
-   - `kind = ai-delivery-status/v1`;
-   - `source.repository = sniffy/sniffy`;
-   - `source.project.owner = sniffy` and `source.project.number = 2`;
-   - `artifact.name = ai-delivery-status-project-2`;
-   - a numeric `artifact.id` and file name `project-2-status.json`;
-   - `generatedAt` strictly later than the refresh request's `createdAt` and no older than `statusSnapshot.maxAgeMinutes`;
-   - normally, `source.workflowRun.event = issue_comment` and `source.workflowRun.refreshRequest.commentId` equals the exact
-     request comment ID. Because publication is serialized, a pointer subsequently replaced by another successful trigger is also
-     acceptable when its `generatedAt` is strictly later than the request; it is necessarily at least as fresh.
-4. Download that artifact by numeric ID with the default GitHub connector. Read `project-2-status.json` from the ZIP. Validate the
-   same schema/kind/repository/Project identity, require its `generatedAt` and workflow-run provenance to match the pointer, and
-   reject inconsistent counts or an incomplete/malformed file.
-5. Use only the snapshot's explicit `fields`/`fieldValues` as ProjectV2 read state. An absent field value is represented as `null`;
-   do not infer it from prose, authorship, prior chat state, or defaults. The file contains active Sniffy items only. The raw files
-   are diagnostic and are not the ordinary queue.
-6. Before ordinary queue selection, inspect the snapshot's top-level `pullRequests` observations for `mergeable = CONFLICTING` or
-   `mergeStateStatus = DIRTY`. This collection is independent of Project item type; use `closingIssueNumbers` to resolve the
-   canonical issue-versus-PR identity before routing, without activating a duplicate PR lifecycle item. Treat each same-repository,
-   non-Dependabot agent PR as a priority continuation/reconciliation obligation. Re-read the live PR first and require it still to
-   be open, target `develop`, have the same exact head, and remain conflicted. Preserve the existing branch and PR; deliberately
-   route conflict resolution to an eligible implementation executor, then start the normal 15-minute, second-15-minute, and hourly
-   observation cycle. Fork PRs wait for their contributor, and Dependabot PRs use `@dependabot rebase`; never adopt or rewrite those
-   branches through this rule.
-7. Re-read current issue/PR open/draft state, exact branch/head, formal closing links, assignment, reviews, threads, matching CI,
-   and mergeability through live GitHub operations before acting. Snapshot source metadata and mergeability are discovery hints,
-   not mutation authority.
-8. Use snapshot values to construct guarded `delivery-control/v1` expected fields. A successful mutation still depends on the
-   control workflow's live serialized ProjectV2 comparison and verification.
-9. On `confused`, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run. On
-   `+1`, the control workflow's internal final-state verification is authoritative for that command.
-10. Before a later dependent Project transition, obtain a snapshot generated after the preceding successful command. The status
-    workflow deliberately does not run after every delivery-control completion because that fan-out exhausts the shared Project
-    GraphQL rate limit during active reconciliation. Request exactly one on-demand refresh before the dependent transition. Do not
-    chain dependent Project writes from an older materialized view or add speculative refreshes between transitions.
-11. If the status issue, refresh acknowledgement, pointer, artifact, or snapshot is missing, expired, inaccessible, malformed,
-    mismatched, or stale, make no snapshot-dependent Project claim or transition. Report the exact status-read blocker; do not
-    guess.
-12. Exclude issues labeled `ai-delivery-control` or `ai-delivery-status` from canonical work selection even if Project automation
-    materialized them.
+1. Find the newest open non-PR issue in `sniffy/sniffy` labelled `ai-delivery-status`. Never hardcode its number. Exclude technical
+   `ai-delivery-control` and `ai-delivery-status` issues from work selection.
+2. Add exactly one comment whose entire body is `/ai-delivery-status refresh`. Record its comment ID and `createdAt`. Wait at most
+   `statusSnapshot.refreshTimeoutSeconds` from `docs/ai-delivery/profile.yml` for a terminal reaction on that exact comment:
+   - `+1`: a newer pointer/artifact was published;
+   - `-1`: publication failed;
+   - timeout: refresh unavailable.
+   On `-1` or timeout, make no snapshot-dependent claim or transition. Do not retry or use the pre-request pointer.
+3. After `+1`, rediscover the newest open status issue and parse its body as JSON. Require schema 1, kind
+   `ai-delivery-status/v1`, repository `sniffy/sniffy`, Project `sniffy/2`, artifact name `ai-delivery-status-project-2`, numeric
+   artifact ID, snapshot file `project-2-status.json`, acceptable age, and `generatedAt` strictly later than the request. Normally
+   require matching refresh comment provenance; a later serialized successful publication is acceptable when demonstrably newer.
+4. Download that artifact by numeric ID and validate the snapshot has matching identity, generation, provenance, complete counts,
+   top-level `pullRequests`, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
+5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to
+   rebuild `readyByExecutor`, `inProgressByExecutor`, canonical PR identity, route mismatches, conflicts, or stale exact-head
+   candidates from raw arrays. Raw files are diagnostics only.
+6. The top-level `pullRequests` observations and `dispatch.pullRequests` projections cover every open base-branch PR independently
+   of Project item type. Use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their
+   contributor. Dependabot PRs use provider bot operations such as `@dependabot rebase`; never adopt or rewrite those branches.
+7. Only after selecting a candidate, re-read its current live issue/PR open/draft state, exact branch/head, formal closing links,
+   repository ownership, assignment, Project route, worker reference, reviews/threads/CI/mergeability when relevant, and active
+   control issue. Snapshot mergeability and lifecycle values are selection hints, not mutation authority.
+8. Construct guarded `delivery-control/v1` expected state from the snapshot, but act only after the targeted live re-read. On a
+   `confused` reaction, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run.
+   On `+1`, the control workflow's final-state verification is authoritative for that command.
+9. Before a later dependent Project transition, request one snapshot generated after the preceding successful command. Do not add
+   speculative refreshes between independent reads or chain Project writes from an older materialized view.
+10. If no candidate remains actionable after the live re-read, return `NO_CHANGE` plus telemetry without a target, source, worker,
+    or control mutation.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -1,7 +1,7 @@
 # ChatGPT status-snapshot read barrier
 
-Use this once at the start of each scheduled Chat tick. It supplies a deterministic queue projection so the model does not need to
-query the whole Project or inspect every open PR.
+Use this once at the start of each scheduled Chat tick. It supplies a deterministic queue projection so the model does not query
+the whole Project or inspect every open PR.
 
 1. Find the newest open non-PR issue in `sniffy/sniffy` labelled `ai-delivery-status`. Never hardcode its number. Exclude technical
    `ai-delivery-control` and `ai-delivery-status` issues from work selection.
@@ -15,22 +15,22 @@ query the whole Project or inspect every open PR.
    `ai-delivery-status/v1`, repository `sniffy/sniffy`, Project `sniffy/2`, artifact name `ai-delivery-status-project-2`, numeric
    artifact ID, snapshot file `project-2-status.json`, acceptable age, and `generatedAt` strictly later than the request. Normally
    require matching refresh comment provenance; a later serialized successful publication is acceptable when demonstrably newer.
-4. Download that artifact by numeric ID and validate the snapshot has matching identity, generation, provenance, complete counts,
-   top-level `pullRequests`, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
-5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to
-   rebuild `readyByExecutor`, `inProgressByExecutor`, canonical PR identity, route mismatches, conflicts, or stale exact-head
-   candidates from raw arrays. Raw files are diagnostics only.
-6. The top-level `pullRequests` observations and `dispatch.pullRequests` projections cover every open base-branch PR independently
-   of Project item type. Always use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity.
-   Fork PRs wait for their contributor. Dependabot PRs use `@dependabot rebase` or another documented provider bot operation;
-   never adopt or rewrite those branches through this rule.
-7. Live-read only the selected candidate. Re-read its current live issue/PR open/draft state, exact branch/head, formal closing
-   links, repository ownership, assignment, Project route, worker reference, reviews/threads/CI/mergeability when relevant, and
-   active control issue. Snapshot mergeability and lifecycle values are selection hints, not mutation authority.
-8. Construct guarded `delivery-control/v1` expected state from the snapshot, but act only after the targeted live re-read. On a
-   `confused` reaction, perform no work mutation and do not retry from the same snapshot. On `-1`, inspect the failed control run.
-   On `+1`, the control workflow's final-state verification is authoritative for that command.
-9. Before a later dependent Project transition, request one snapshot generated after the preceding successful command. Do not add
-   speculative refreshes between independent reads or chain Project writes from an older materialized view.
-10. If no candidate remains actionable after the live re-read, return `NO_CHANGE` plus telemetry without a target, source, worker,
-    or control mutation.
+4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts, top-level
+   `pullRequests`, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
+5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to rebuild
+   executor queues, canonical PR identity, route mismatches, conflicts, stale exact-head state, or lease classification from raw
+   arrays. Raw files are diagnostics only.
+6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use closing issues to resolve
+   canonical identity. Fork PRs wait for their contributor. Dependabot uses documented bot operations; never adopt those branches.
+7. `dispatch.activeInProgressByExecutor` is capacity/diagnostic state. A valid future `leaseUntil` is not actionable and must not
+   cause a worker/task lookup. Only `stale-owned-recovery` may inspect an existing worker, scoped to the exact claim/generation.
+8. Live-read only the selected candidate: current issue/PR state, exact branch/head, formal links, ownership, assignment, Project
+   route, worker reference/lease, reviews/threads/CI/mergeability when relevant, and active control issue. Snapshot values are
+   selection hints, not mutation authority.
+9. Construct guarded `delivery-control/v1` expected state from the snapshot, but act only after targeted live re-read. On
+   `confused`, make no work mutation or retry from the same snapshot. On `-1`, inspect the failed control run. On `+1`, the control
+   workflow's final verification is authoritative.
+10. Before a later dependent Project transition, request one snapshot generated after the preceding successful command. Do not add
+    speculative refreshes or chain dependent Project writes from an older materialized view.
+11. If no candidate remains actionable after live re-read, return `NO_CHANGE` plus telemetry without target/source/worker/control
+    mutation.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -19,7 +19,7 @@ the whole Project or inspect every open PR.
 5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to rebuild
    executor queues, canonical PR identity, route mismatches, conflicts, stale exact-head state, or lease classification from raw
    arrays. Raw files are diagnostics only.
-6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their contributor. Dependabot uses documented bot operations; never adopt those branches.
+6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their contributor. Dependabot PRs use `@dependabot rebase`; never adopt or rewrite those branches through this rule.
 7. `dispatch.activeInProgressByExecutor` is capacity/diagnostic state. A valid future `leaseUntil` is not actionable and must not
    cause a worker/task lookup. Only `stale-owned-recovery` may inspect an existing worker, scoped to the exact claim/generation.
 8. Live-read only the selected candidate: current issue/PR state, exact branch/head, formal links, ownership, assignment, Project

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,44 +1,40 @@
 # Codex executor files
 
-This directory contains Codex-specific environment scripts and launch prompts. It is not a second repository policy.
+This directory contains Codex-specific adapters, not a second repository policy. Every selected worker follows the canonical item,
+nearest `AGENTS.md`, and `docs/ai-delivery/runtime-contract.md`; it loads detailed lifecycle/runbook sections only after selection.
 
-Every Codex task must follow:
+## Model profiles
 
-- the current GitHub issue or pull request;
-- the nearest applicable `AGENTS.md`;
-- [`docs/ai-delivery/`](../docs/ai-delivery/README.md) for lifecycle, routing, event-loop, supervision, and verification.
+- dispatcher heartbeat: `gpt-5.6-luna` / low;
+- normal lifecycle worker: `gpt-5.6-terra` / medium;
+- explicit difficult-task escalation: `gpt-5.6-sol` / high;
+- xhigh only with a recorded exceptional reason.
 
 ## Cloud
 
-- `cloud/setup.sh` — one-time environment bootstrap and GitHub CLI authentication.
-- `cloud/maintenance.sh` — refresh a cached environment after branch or dependency changes.
-- `cloud/use-jdk.sh` — select a supported JDK.
-- `cloud/warm-maven-cache.sh` — repository dependency warm-up helper.
-- [`docs/ai-delivery/executors/codex-cloud.md`](../docs/ai-delivery/executors/codex-cloud.md) — canonical Cloud runbook.
+- `cloud/setup.sh`, `maintenance.sh`, `use-jdk.sh`, `warm-maven-cache.sh` — Cloud environment helpers.
+- `docs/ai-delivery/executors/codex-cloud.md` — Cloud runbook.
 
-## Local app adapter
+## Local app
 
-- `local/scheduled-task-prompt.md` — persistent app-native dispatcher prompt.
-- `local/project-queue-snapshot.sh` — one bounded full-Project read that normalizes Local Codex ownership and ready candidates.
-- `local/worker-task-prompt.md` — rendered canonical-item app worker template.
-- [`docs/local-codex-worker.md`](../docs/local-codex-worker.md) — detailed Windows/WSL/VM setup.
+- `local/scheduled-task-prompt.md` — persistent Luna/low dispatcher prompt;
+- `local/project-queue-snapshot.sh` — one bounded full-Project query and normalized Local Codex queue;
+- `local/worker-task-prompt.md` — rendered Terra/medium lifecycle worker;
+- `docs/local-codex-worker.md` — Windows/WSL/VM setup.
 
-The dispatcher must use the snapshot helper exactly once per tick and perform all candidate filtering against its retained JSON.
-Do not repeatedly invoke `gh project item-list`, probe the raw schema through successive `jq` commands, or combine a rate-limited
-snapshot with another or stale data source. A guarded claim performs the authoritative current-state recheck after one candidate
-has been selected.
+The dispatcher runs the snapshot helper exactly once per tick, selects from retained normalized JSON, and live-reads only one
+candidate before the guarded claim. Do not repeatedly query ProjectV2 or enumerate all provider tasks on the normal Ready path.
+Provider inventory is only targeted recovery for one ambiguous already-claimed generation.
 
-The prompt filenames remain stable because configured automations may reference them. A repository merge does **not** replace the
-prompt text embedded in an existing Codex automation; copy the updated canonical prompt into the automation and smoke-test it after
-every material dispatcher change.
+Repository merges do not replace prompt text embedded in existing Codex automations. Copy the updated prompt, select the documented
+model/reasoning profile, and repeat the smoke test.
 
-## Headless local adapter
+## Headless
 
-- `local/run-issue.sh` — current one-issue CLI launch helper.
-- A reusable unattended dispatcher should use systemd/cron, host-local `flock`, the GitHub claim protocol, isolated worktrees,
-  and `codex exec` as described in
-  [`docs/ai-delivery/event-loop.md`](../docs/ai-delivery/event-loop.md).
-- [`docs/ai-delivery/executors/codex-local.md`](../docs/ai-delivery/executors/codex-local.md) — app-native versus headless topology,
-  capabilities, and security boundaries.
+- `local/run-issue.sh` — focused CLI worker, Terra/medium by default with explicit environment-variable escalation;
+- reusable unattended dispatch uses cron/systemd, `flock`, one normalized snapshot, guarded claims, isolated worktrees, and
+  `codex exec`;
+- `docs/ai-delivery/executors/codex-local.md` — topology, continuity, monitoring, telemetry, and security.
 
-Do not duplicate lifecycle, build, compatibility, review, verification, or merge rules here; link to canonical policy instead.
+Do not duplicate lifecycle, compatibility, review, verification, or merge rules here. Never merge or enable auto-merge without
+Dmitry's explicit instruction.

--- a/.codex/local/project-queue-snapshot.sh
+++ b/.codex/local/project-queue-snapshot.sh
@@ -8,13 +8,13 @@ LOCAL_ASSIGNEE="${AI_DELIVERY_LOCAL_ASSIGNEE:-bedrin-codex-local}"
 INPUT_FILE=""
 
 usage() {
-  cat <<'EOF'
+  cat <<'USAGE'
 Usage: project-queue-snapshot.sh [--input FILE]
 
 Without --input, fetches the GitHub Project exactly once through
 `gh project item-list`, then emits one normalized JSON snapshot for Local Codex
 dispatch. --input normalizes an existing raw snapshot for tests or inspection.
-EOF
+USAGE
 }
 
 while (($#)); do
@@ -56,9 +56,14 @@ fi
 
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
 
+generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+generated_epoch="$(date -u +%s)"
+
 jq -ce \
   --arg repository "$REPOSITORY" \
-  --arg localAssignee "$LOCAL_ASSIGNEE" '
+  --arg localAssignee "$LOCAL_ASSIGNEE" \
+  --arg generatedAt "$generated_at" \
+  --argjson generatedEpoch "$generated_epoch" '
   def repository_name:
     if (.content.repository | type) == "string" then .content.repository
     elif (.content.repository | type) == "object" then
@@ -73,38 +78,65 @@ jq -ce \
       else empty
       end];
 
+  def lease_until($reference):
+    if ($reference | type) != "string" then null
+    else ((try (
+      $reference
+      | capture("(?i)(^|[^A-Za-z0-9_])\\\"?leaseUntil\\\"?\\s*[=:]\\s*\\\"?(?<lease>[^\\\"\\s;,}]+)")
+      | .lease
+    ) catch null) // null)
+    end;
+
   def normalized:
-    {
-      id,
-      type: (.content.type // .type // null),
-      number: (.content.number // .number // null),
-      title: (.title // .content.title // null),
-      url: (.content.url // .url // null),
-      repository: repository_name,
-      status: (.status // null),
-      execution: (.execution // null),
-      executor: (.executor // null),
-      implementer: (.implementer // null),
-      verifier: (.verifier // null),
-      priority: (.priority // null),
-      readyTimestamp: (."ready timestamp" // .readyAt // null),
-      assignees: assignee_logins,
-      workerReference: (."worker reference" // null),
-      linkedPullRequests: (."linked pull requests" // [])
-    };
+    (."worker reference" // null) as $workerReference
+    | {
+        id,
+        type: (.content.type // .type // null),
+        number: (.content.number // .number // null),
+        title: (.title // .content.title // null),
+        url: (.content.url // .url // null),
+        repository: repository_name,
+        status: (.status // null),
+        execution: (.execution // null),
+        executor: (.executor // null),
+        implementer: (.implementer // null),
+        verifier: (.verifier // null),
+        priority: (.priority // null),
+        readyTimestamp: (."ready timestamp" // .readyAt // null),
+        assignees: assignee_logins,
+        workerReference: $workerReference,
+        leaseUntil: lease_until($workerReference),
+        linkedPullRequests: (."linked pull requests" // [])
+      };
 
   def pool_eligible:
     (.assignees | length == 0) or (.assignees | index($localAssignee) != null);
 
+  def with_stale_reason:
+    . as $item
+    | if (($item.workerReference | type) != "string" or ($item.workerReference | length) == 0) then
+        $item + {staleReason: "missing-worker-reference"}
+      elif $item.leaseUntil == null then
+        $item + {staleReason: "missing-lease"}
+      else
+        (try ($item.leaseUntil | fromdateiso8601) catch null) as $leaseEpoch
+        | if $leaseEpoch == null then $item + {staleReason: "invalid-lease"}
+          elif $leaseEpoch <= $generatedEpoch then $item + {staleReason: "lease-expired"}
+          else $item + {staleReason: null}
+          end
+      end;
+
   if (.items | type) != "array" then error("Project snapshot has no items array") else . end
   | ([.items[] | normalized | select(.repository == $repository)]) as $items
+  | ([$items[] | select(.execution == "In progress" and .executor == "Local Codex") | with_stale_reason]
+      | sort_by(.number, .type)) as $owned
   | {
+      generatedAt: $generatedAt,
       totalCount: (.totalCount // (.items | length)),
       repositoryItemCount: ($items | length),
-      ownedInProgress: [
-        $items[]
-        | select(.execution == "In progress" and .executor == "Local Codex")
-      ] | sort_by(.number, .type),
+      ownedInProgress: $owned,
+      activeOwnedInProgress: [$owned[] | select(.staleReason == null)],
+      staleOwnedInProgress: [$owned[] | select(.staleReason != null)],
       readyCandidates: [
         $items[]
         | select(

--- a/.codex/local/run-issue.sh
+++ b/.codex/local/run-issue.sh
@@ -46,9 +46,14 @@ fi
 
 issue_markdown="$(gh issue view "${issue_number}" --repo "${repo}" --json title,body,url --template '{{.title}}\n\n{{.body}}\n\nIssue: {{.url}}')"
 
-model="${CODEX_MODEL:-gpt-5.6-sol}"
-reasoning="${CODEX_REASONING_EFFORT:-xhigh}"
+# Normal workers use the balanced profile. Override explicitly for an exceptional task, e.g.:
+# CODEX_MODEL=gpt-5.6-sol CODEX_REASONING_EFFORT=high bash .codex/local/run-issue.sh 123
+model="${CODEX_MODEL:-gpt-5.6-terra}"
+reasoning="${CODEX_REASONING_EFFORT:-medium}"
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+started_epoch="$(date +%s)"
 
+set +e
 codex \
   --model "${model}" \
   --config "model_reasoning_effort=\"${reasoning}\"" \
@@ -58,9 +63,31 @@ codex \
   exec - <<PROMPT
 Work autonomously on the GitHub issue below in repository ${repo}.
 
-Read AGENTS.md and inspect the repository before editing. The issue is authoritative. Implement the task end to end, add or update tests and documentation, run all locally applicable checks, review the final diff, commit, push ${branch_name} without force-pushing, and create or update a draft pull request linked to the issue. Do not ask for routine decisions or approval. Make conservative maintainable implementation decisions yourself. Do not merge the pull request. Stop only for a genuine blocker and report it precisely.
+Read AGENTS.md, the nearest nested AGENTS.md files, and docs/ai-delivery/runtime-contract.md before editing. The canonical issue is
+authoritative. Implement the smallest coherent solution end to end, add or update tests and documentation, run all locally
+applicable checks, inspect the complete final diff, commit, push ${branch_name} without force-pushing, and create or update the
+intended draft pull request linked to the issue. Mark it ready for review only after implementation and locally available proof are
+complete, then verify open/non-draft/exact-head publication. Never merge or enable auto-merge. Stop only for a genuine blocker and
+report it precisely.
 
 ${issue_markdown}
 PROMPT
+codex_status=$?
+set -e
+
+finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+finished_epoch="$(date +%s)"
+duration_seconds=$((finished_epoch - started_epoch))
+if ((codex_status == 0)); then
+  outcome="HANDOFF"
+else
+  outcome="FAILED"
+fi
+
+printf '%s\n' "{\"startedAt\":\"${started_at}\",\"finishedAt\":\"${finished_at}\",\"durationSeconds\":${duration_seconds},\"adapter\":\"codex-cli-worker\",\"model\":\"${model}\",\"reasoning\":\"${reasoning}\",\"repository\":\"${repo}\",\"issue\":${issue_number},\"branch\":\"${branch_name}\",\"outcome\":\"${outcome}\",\"usageSource\":\"unavailable\",\"inputTokens\":null,\"cachedInputTokens\":null,\"outputTokens\":null,\"reasoningTokens\":null}"
+
+if ((codex_status != 0)); then
+  exit "${codex_status}"
+fi
 
 printf 'Codex run finished for %s on branch %s.\n' "${issue_url}" "${branch_name}"

--- a/.codex/local/run-issue.sh
+++ b/.codex/local/run-issue.sh
@@ -84,6 +84,7 @@ else
   outcome="FAILED"
 fi
 
+# Exact provider token counters are unavailable in this wrapper; never fabricate them.
 printf '%s\n' "{\"startedAt\":\"${started_at}\",\"finishedAt\":\"${finished_at}\",\"durationSeconds\":${duration_seconds},\"adapter\":\"codex-cli-worker\",\"model\":\"${model}\",\"reasoning\":\"${reasoning}\",\"repository\":\"${repo}\",\"issue\":${issue_number},\"branch\":\"${branch_name}\",\"outcome\":\"${outcome}\",\"usageSource\":\"unavailable\",\"inputTokens\":null,\"cachedInputTokens\":null,\"outputTokens\":null,\"reasoningTokens\":null}"
 
 if ((codex_status != 0)); then

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -23,42 +23,49 @@ Record startedAt. This conversation coordinates only: never edit source, create 
 worker PR, merge, or enable auto-merge.
 
 1. Fetch current origin/develop. In one batched local command read this prompt, runtime-contract.md, profile.yml, and the worker
-   template exactly once. Do not load the detailed lifecycle/control/routing/supervision/verification documents before selection.
+   template exactly once. Do not load detailed lifecycle/control/routing/supervision/verification documents before selection.
 2. Run `.codex/local/project-queue-snapshot.sh` exactly once. It is the only normal full-Project query. Retain that JSON for the
    whole selection phase. Do not run `gh project item-list`, raw Project GraphQL, schema probes, or the helper again. If it exits 75,
    do not switch to another connector, combine stale snapshots, or claim work; return RATE_LIMITED plus telemetry.
-3. Inspect `ownedInProgress` first. Continue only an item whose durable next observation is due after 15 minutes, another 15
-   minutes, then hourly. Provider inventory is allowed only to recover one selected `In progress` item whose provisional reference
-   leaves child creation uncertain, scoped to its claim token and generation.
-4. Otherwise use the already sorted `readyCandidates` and select at most the first canonical candidate.
-   Compute available capacity from `executors.Local Codex.maxConcurrentWorkers` in profile.yml minus `ownedInProgress`. Do not call `List projects`, list all tasks/conversations, or use provider-wide inventory on the normal `Ready` claim path.
-5. If no candidate is due or ready, create no target comment, control command, task, worktree, branch, or Project mutation. Return
-   NO_CHANGE plus telemetry.
+3. Inspect `ownedInProgress` without querying any worker. An item with a valid future `leaseUntil` consumes capacity and is ignored.
+   Select at most one stale owned item only when its worker reference or lease is missing/invalid, or the lease has expired.
+   Targeted provider inventory is allowed only for that selected recovery and only for its claim token/generation.
+4. Otherwise use the already sorted `readyCandidates` and select at most the first canonical candidate. Compute available capacity
+   from `executors.Local Codex.maxConcurrentWorkers` minus all `ownedInProgress`, including stale ownership until recovery resolves
+   it. Do not call `List projects`, list all tasks/conversations, or use provider-wide inventory on the normal Ready path.
+5. If no stale recovery or Ready candidate exists, create no target comment, control command, task, worktree, branch, or Project
+   mutation. Return NO_CHANGE plus telemetry.
 6. Only after selection, perform minimum targeted live reads: canonical item type/open state, formal closing links, exact existing
-   PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue.
-   Do not read the complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker owns those reads.
-7. An existing same-repository PR may be an adopted continuation only when the verified canonical Project route selects Local
+   PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue. Do not read the
+   complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker owns those reads.
+7. For stale recovery, preserve the exact generation/branch/task. If the same worker is demonstrably active, extend its lease by a
+   guarded update and stop. If completion evidence exists but handoff was lost, finish the deterministic handoff. If the worker
+   failed or disappeared, recover the same workspace/branch when possible. Release to Ready only when no active or recoverable work
+   remains. Never spawn a duplicate generation.
+8. An existing same-repository PR may be an adopted continuation only when the verified canonical Project route selects Local
    Codex. Reuse the exact branch and PR. Do not adopt fork or Dependabot branches for direct correction.
-8. Claim with one guarded `delivery-control/v1` command. Use the human-readable Markdown wrapper, exact start/end markers, and
-   lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type, Status, Execution=Ready,
-   Executor=Local Codex, and exact PR head when applicable; set In progress with token, owner, lease, provisional worker reference,
-   and first observation point. Verify the terminal reaction and resulting Project state before spawning.
-9. Render every worker placeholder. Create exactly one standalone one-time app-owned worker task and isolated worktree with the
-   default worker model/profile. Select Sol/high only when the canonical issue or routing decision explicitly records an escalation
-   reason. Never create the worker inside this dispatcher conversation.
-10. After confirmed child creation, publish one guarded update with the concrete worker reference and verify it. If creation
-    definitively fails, release to Ready. If ambiguous, preserve the one provisional generation for targeted recovery; never
-    redispatch speculatively. Block only for an exact Dmitry decision/action.
-11. Finish with one telemetry JSON object containing startedAt, finishedAt, durationSeconds, adapter, scheduler, model, reasoning,
+9. Claim Ready work with one guarded `delivery-control/v1` command. Use the human-readable Markdown wrapper, exact start/end markers,
+   and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type, Status,
+   Execution=Ready, Executor=Local Codex, and exact PR head when applicable; set In progress with token, owner, claimedAt,
+   leaseUntil, and provisional worker reference. Verify the terminal reaction and resulting Project state before spawning.
+10. Render every worker placeholder. Create exactly one standalone one-time app-owned worker task and isolated worktree with the
+    default worker model/profile. Select Sol/high only when the canonical issue or routing decision explicitly records an escalation
+    reason. Never create the worker inside this dispatcher conversation.
+11. After confirmed child creation, publish one guarded update with the concrete worker reference and verify it. If creation
+    definitively fails, release to Ready. If ambiguous, preserve the one provisional generation with the configured provisional
+    lease for targeted recovery; never redispatch speculatively. Block only for an exact Dmitry decision/action.
+12. Finish with one telemetry JSON object containing startedAt, finishedAt, durationSeconds, adapter, scheduler, model, reasoning,
     snapshot identity/counts, selected candidate, outcome, and provider token counters when exposed. Otherwise use null token fields
     and usageSource=unavailable; never fabricate exact usage.
 
-Never dispatch the same lifecycle generation twice. Never merge or enable auto-merge.
+A worker must perform its own guarded lifecycle handoff when complete and may renew its lease before expiry. Never poll active
+workers. Never dispatch the same lifecycle generation twice. Never merge or enable auto-merge.
 ```
 
 ## Smoke test
 
 Before enabling recurrence, prove that the snapshot helper runs once; an empty tick creates no worker/worktree; a rate-limited tick
-claims nothing; normal Ready selection performs no provider-wide inventory; one issue creates one worker; a routed same-repository
-PR reuses its exact branch/PR; fork and Dependabot PRs are rejected for adoption; concurrent guarded claims have one winner; failed
-creation releases; and a completed worker performs a guarded lifecycle handoff rather than spawning a reviewer.
+claims nothing; active leased workers are not queried; only expired/malformed ownership triggers targeted recovery; normal Ready
+selection performs no provider-wide inventory; one issue creates one worker; a routed same-repository PR reuses its exact branch/PR;
+fork and Dependabot PRs are rejected for adoption; concurrent guarded claims have one winner; failed creation releases; and a
+completed worker performs a guarded lifecycle handoff rather than spawning a reviewer.

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -30,9 +30,8 @@ worker PR, merge, or enable auto-merge.
 3. Inspect `ownedInProgress` first. Continue only an item whose durable next observation is due after 15 minutes, another 15
    minutes, then hourly. Provider inventory is allowed only to recover one selected `In progress` item whose provisional reference
    leaves child creation uncertain, scoped to its claim token and generation.
-4. Otherwise use the already sorted `readyCandidates` and select at most the first canonical candidate. Compute available capacity
-   from `executors.Local Codex.maxConcurrentWorkers` in profile.yml minus `ownedInProgress`. Do not call `List projects`, list all
-   tasks/conversations, or use provider-wide inventory on the normal `Ready` claim path.
+4. Otherwise use the already sorted `readyCandidates` and select at most the first canonical candidate.
+   Compute available capacity from `executors.Local Codex.maxConcurrentWorkers` in profile.yml minus `ownedInProgress`. Do not call `List projects`, list all tasks/conversations, or use provider-wide inventory on the normal `Ready` claim path.
 5. If no candidate is due or ready, create no target comment, control command, task, worktree, branch, or Project mutation. Return
    NO_CHANGE plus telemetry.
 6. Only after selection, perform minimum targeted live reads: canonical item type/open state, formal closing links, exact existing

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -1,102 +1,65 @@
-# Sniffy app-native Local Codex dispatcher prompt
+# Token-efficient Local Codex dispatcher
 
-Configure the Codex automation and its worker tasks with the current Sniffy Local Codex profile: **Sol** model and
-**extra-high** reasoning. The scheduler-level model is fixed; the dispatcher does not dynamically substitute Terra or another
-model for individual items.
+Configure the persistent app automation with **`gpt-5.6-luna` / low reasoning**. The dispatcher coordinates only. A selected
+normal worker uses **`gpt-5.6-terra` / medium reasoning**. Use `gpt-5.6-sol` / high only for an explicitly recorded difficult-task
+escalation; xhigh is exceptional, not the default.
 
-Copy the text block below into one automation attached to a persistent dispatcher conversation in the Codex app. Repository
-merges do not update the text embedded in an existing automation: replace that text manually whenever this canonical prompt
-changes, then repeat the smoke test below.
-
-This is one adapter for the generic lifecycle and control protocol in `docs/ai-delivery/`; it is not a second policy.
+Repository merges do not rewrite an existing Codex automation. Replace the embedded prompt manually and smoke-test it.
 
 ```text
-Run one Sniffy app-native Local Codex dispatcher tick in this existing dispatcher conversation.
+Run one logically stateless Sniffy Local Codex dispatcher tick in this persistent dispatcher conversation.
 
 Repository: sniffy/sniffy
-Book of work: organization project 2, https://github.com/orgs/sniffy/projects/2
 Base branch: develop
+Project: organization sniffy, number 2
 Executor: Local Codex
-Queue snapshot helper: .codex/local/project-queue-snapshot.sh
+Queue helper: .codex/local/project-queue-snapshot.sh
+Runtime contract: docs/ai-delivery/runtime-contract.md
 Worker template: .codex/local/worker-task-prompt.md
-Model/profile: Sol / extra-high reasoning
+Dispatcher model/profile: gpt-5.6-luna / low
+Default worker model/profile: gpt-5.6-terra / medium
 
-This conversation coordinates only. Never edit source, create a work branch, run implementation/verification commands, review
-the worker's PR, merge, or enable auto-merge.
+Record startedAt. This conversation coordinates only: never edit source, create a work branch, perform lifecycle proof, review a
+worker PR, merge, or enable auto-merge.
 
-1. Fetch current origin/develop. Read AGENTS.md,
-   docs/ai-delivery/{README,profile,lifecycle,control-plane,event-loop,pull-request-intake,routing,supervision,verification}.md,
-   this prompt, and the worker template exactly once from that revision. Use one batched local command. Do not probe file lengths,
-   search for a nonexistent profile.md, or re-read whole documents unless one named section is genuinely missing.
-2. Run `.codex/local/project-queue-snapshot.sh` exactly once and retain its normalized JSON for the entire selection phase. This
-   helper is the only normal full-Project query. Do not run `gh project item-list`, raw Project GraphQL, schema-discovery jq probes,
-   or the helper again in the same tick.
-3. If the helper exits 75 because GitHub GraphQL is rate-limited, make no claim or Project/source mutation. Do not switch to another
-   connector, combine stale snapshots, or infer eligibility from issue/PR state alone. Report `RATE_LIMITED: no claim made` in this
-   dispatcher conversation and stop.
-4. Inspect `ownedInProgress` from the retained snapshot first. Continue only an item whose worker or monitoring observation is due
-   under the 15-minute, second-15-minute, then hourly cadence. Do not create another monitor. A provider-wide Codex project/task
-   inventory is allowed only to recover one selected `In progress` item whose provisional Worker reference leaves child creation
-   uncertain; scope the result to that claim token and generation.
-5. Otherwise use the already sorted `readyCandidates` array and choose at most its first candidate, subject to canonical duplicate
-   suppression and available capacity. Compute available capacity from `executors.Local Codex.maxConcurrentWorkers` in the loaded
-   profile minus the length of `ownedInProgress` in the retained snapshot. Treat this as the single-dispatcher scheduling limit,
-   not a distributed semaphore. Do not call `List projects`, list tasks/conversations, or use any other provider-wide inventory on
-   the normal `Ready` claim path. Eligible work has Execution=Ready, Executor=Local Codex, Status=Implementation or Verification,
-   and an empty or local-worker Assignee.
-6. If neither a due owned item nor a ready candidate exists, create no task, worktree, branch, target comment, control command, or
-   Project mutation. Reply only NO_CHANGE.
-7. Only after one candidate is selected, perform the minimum targeted live reads needed to construct the guarded claim and render
-   its worker: canonical item type/open state, formal closing links, exact existing PR branch/head and repository ownership when
-   applicable, plus the newest active control issue. Do not read the complete discussion, proof matrix, review submissions,
-   review threads, or CI before claim; the lifecycle worker owns those reads. Never refetch the full Project snapshot or query
-   provider-wide Codex inventory for duplicate-worker evidence. Per-target guarded claim serialization is the duplicate-generation
-   authority.
-8. An existing same-repository PR may be an adopted continuation even when Dmitry, ChatGPT, an IDE agent, or another configured
-   worker created it. Adoption is valid only when the retained snapshot and targeted reads show the canonical Project route sets
-   Implementer/Executor=Local Codex. Reuse the exact branch and PR. Do not adopt fork or Dependabot branches for direct correction.
-9. Select deterministically by Project priority, ready timestamp, repository, item type, then item number. The helper has already
-   normalized and sorted candidates; do not create an alternative ordering from raw Project data.
-10. Claim through the one active technical control issue using one guarded delivery-control/v1 command. Post every new command
-    with the concise human-readable Markdown wrapper from control-plane.md, including its exact start/end markers and lowercase
-    `json` fence. Derive the display-only prose from the JSON, treat the marked JSON as authoritative, and never emit bare JSON.
-    Guard current Status,
-    Execution=Ready, Executor=Local Codex, and exact PR head when the canonical item is a PR; set Execution=In progress plus
-    claim token/lease inside the provisional Worker reference. The guarded transition is the authoritative current-state recheck.
-    Inspect the reaction and re-read the resulting target Project state before spawning.
-11. Render every placeholder in .codex/local/worker-task-prompt.md, including canonical work-item type/URL, authoritative linked
-    issue, exact existing PR branch/head, repository ownership, author, and fresh/continuation/adopted-continuation mode.
-12. Create exactly one NEW one-time standalone app-owned task named "Sniffy <work-item-type> #<number> <status>: <title>" using
-    the current local project, a new isolated worktree, Sol, extra-high reasoning, and the rendered prompt. Never create it in this
-    dispatcher conversation.
-13. Do not use shell UI automation, Python observers, codex app-server, codex exec, or .codex/local/run-issue.sh for this
-    app-native adapter.
-14. After confirming the child task exists, publish one guarded control command updating the final worker reference, then verify
-    it. If child creation definitively fails, release to Ready through the same protocol. If the creation result is ambiguous, keep
-    the provisional `In progress` ownership for targeted recovery under step 4; never release and redispatch speculatively. Set
-    Blocked only when Dmitry must decide or act.
+1. Fetch current origin/develop. In one batched local command read this prompt, runtime-contract.md, profile.yml, and the worker
+   template exactly once. Do not load the detailed lifecycle/control/routing/supervision/verification documents before selection.
+2. Run `.codex/local/project-queue-snapshot.sh` exactly once. It is the only normal full-Project query. Retain that JSON for the
+   whole selection phase. Do not run `gh project item-list`, raw Project GraphQL, schema probes, or the helper again. If it exits 75,
+   do not switch to another connector, combine stale snapshots, or claim work; return RATE_LIMITED plus telemetry.
+3. Inspect `ownedInProgress` first. Continue only an item whose durable next observation is due after 15 minutes, another 15
+   minutes, then hourly. Provider inventory is allowed only to recover one selected `In progress` item whose provisional reference
+   leaves child creation uncertain, scoped to its claim token and generation.
+4. Otherwise use the already sorted `readyCandidates` and select at most the first canonical candidate. Compute available capacity
+   from `executors.Local Codex.maxConcurrentWorkers` in profile.yml minus `ownedInProgress`. Do not call `List projects`, list all
+   tasks/conversations, or use provider-wide inventory on the normal `Ready` claim path.
+5. If no candidate is due or ready, create no target comment, control command, task, worktree, branch, or Project mutation. Return
+   NO_CHANGE plus telemetry.
+6. Only after selection, perform minimum targeted live reads: canonical item type/open state, formal closing links, exact existing
+   PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue. Do not read the
+   complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker owns those reads.
+7. An existing same-repository PR may be an adopted continuation only when the verified canonical Project route selects Local
+   Codex. Reuse the exact branch and PR. Do not adopt fork or Dependabot branches for direct correction.
+8. Claim with one guarded `delivery-control/v1` command. Use the human-readable Markdown wrapper, exact start/end markers, and
+   lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type, Status, Execution=Ready,
+   Executor=Local Codex, and exact PR head when applicable; set In progress with token, owner, lease, provisional worker reference,
+   and first observation point. Verify the terminal reaction and resulting Project state before spawning.
+9. Render every worker placeholder. Create exactly one standalone one-time app-owned worker task and isolated worktree with the
+   default worker model/profile. Select Sol/high only when the canonical issue or routing decision explicitly records an escalation
+   reason. Never create the worker inside this dispatcher conversation.
+10. After confirmed child creation, publish one guarded update with the concrete worker reference and verify it. If creation
+    definitively fails, release to Ready. If ambiguous, preserve the one provisional generation for targeted recovery; never
+    redispatch speculatively. Block only for an exact Dmitry decision/action.
+11. Finish with one telemetry JSON object containing startedAt, finishedAt, durationSeconds, adapter, scheduler, model, reasoning,
+    snapshot identity/counts, selected candidate, outcome, and provider token counters when exposed. Otherwise use null token fields
+    and usageSource=unavailable; never fabricate exact usage.
 
 Never dispatch the same lifecycle generation twice. Never merge or enable auto-merge.
 ```
 
-## Required smoke test
+## Smoke test
 
-Before enabling or replacing the recurring dispatcher, prove with disposable/read-only items that:
-
-- one tick invokes `project-queue-snapshot.sh` once and never invokes `gh project item-list` directly;
-- a normal `Ready` claim derives capacity from `ownedInProgress` plus `maxConcurrentWorkers` and performs no provider-wide Codex
-  project/task inventory;
-- recovery may inspect provider inventory only for one provisional `In progress` claim token/generation after ambiguous child
-  creation;
-- an empty snapshot stays in this conversation and creates no worktree;
-- a rate-limited snapshot creates no claim and does not switch data sources;
-- one eligible issue item creates exactly one standalone worker conversation and isolated WSL worktree;
-- one explicitly routed same-repository PR continuation reuses its exact branch and PR without creating a duplicate;
-- fork and Dependabot PRs are rejected for adopted direct correction;
-- the worker uses Sol / extra-high and receives intended canonical item, Status, routing, and exact-head fields;
-- concurrent guarded claims produce one success and one conflict without target-item claim comments;
-- failed child creation releases the claim;
-- a completed worker hands off the canonical item to the next lifecycle status rather than creating its own reviewer conversation.
-
-Repeat after material Codex automation changes. If nested one-time task creation is unavailable, pause this adapter and use a
-manual app worker or the headless Linux adapter; do not substitute external UI automation.
+Before enabling recurrence, prove that the snapshot helper runs once; an empty tick creates no worker/worktree; a rate-limited tick
+claims nothing; normal Ready selection performs no provider-wide inventory; one issue creates one worker; a routed same-repository
+PR reuses its exact branch/PR; fork and Dependabot PRs are rejected for adoption; concurrent guarded claims have one winner; failed
+creation releases; and a completed worker performs a guarded lifecycle handoff rather than spawning a reviewer.

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -35,8 +35,8 @@ worker PR, merge, or enable auto-merge.
 5. If no candidate is due or ready, create no target comment, control command, task, worktree, branch, or Project mutation. Return
    NO_CHANGE plus telemetry.
 6. Only after selection, perform minimum targeted live reads: canonical item type/open state, formal closing links, exact existing
-   PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue. Do not read the
-   complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker owns those reads.
+   PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue.
+   Do not read the complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker owns those reads.
 7. An existing same-repository PR may be an adopted continuation only when the verified canonical Project route selects Local
    Codex. Reuse the exact branch and PR. Do not adopt fork or Dependabot branches for direct correction.
 8. Claim with one guarded `delivery-control/v1` command. Use the human-readable Markdown wrapper, exact start/end markers, and

--- a/.codex/local/worker-task-prompt.md
+++ b/.codex/local/worker-task-prompt.md
@@ -22,6 +22,8 @@ Implementer: <IMPLEMENTER>
 Verifier: <VERIFIER>
 Claim token: <CLAIM_TOKEN>
 Generation: <DISPATCH_GENERATION>
+Claimed at: <CLAIMED_AT>
+Lease until: <LEASE_UNTIL>
 Model/reasoning: <MODEL> / <REASONING>
 Escalation reason: <ESCALATION_REASON_OR_NONE>
 
@@ -32,6 +34,10 @@ lifecycle/runbook sections needed for <STATUS>. Verify the claim token/generatio
 Use the active control issue for every Project transition. Emit the human-readable Markdown wrapper with exact start/end markers
 and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. A handoff is complete only after the terminal
 reaction and current Project/assignment/PR state are re-read.
+
+This worker owns completion signalling. When its lifecycle turn finishes, it must publish evidence and perform the guarded handoff
+itself; do not rely on the dispatcher to discover normal completion. If legitimate work will exceed <LEASE_UNTIL>, renew the same
+claim/generation before expiry through a guarded Worker reference update. Never let the lease expire silently while still working.
 
 Canonical/branch rules:
 - one closing issue -> issue canonical; no closing issue -> PR canonical; several -> PR Planning;
@@ -51,16 +57,16 @@ If <STATUS> is Implementation:
    while implementation or locally available proof is incomplete.
 5. When complete, mark the PR ready for review and re-read it as open, targeting develop, non-draft, and at the exact published
    head. Synchronize its description and publish exact human-useful evidence.
-6. Hand off through one guarded command to Review / Ready / ChatGPT with PR URL and exact head. For a canonical issue include
-   reviewPullRequest.number and reviewPullRequest.head; for a canonical PR guard expected.head. Verify reaction, Project state,
-   assignment to bedrin-gpt, and non-draft exact-head PR state.
+6. Hand off through one guarded command to Review / Ready / ChatGPT with PR URL and exact head, clearing claim/lease ownership. For
+   a canonical issue include reviewPullRequest.number and reviewPullRequest.head; for a canonical PR guard expected.head. Verify
+   reaction, Project state, assignment to bedrin-gpt, and non-draft exact-head PR state.
 7. Do not review your own implementation or create a reviewer task.
 
 If <STATUS> is Verification:
 1. Identify the observable journey, negative cases, exact implementation head/artifact, and representative environment.
 2. Perform outcome-centric integration/system/browser/compatibility proof rather than repeating unit tests. Record environment,
    actions, logs, requests/errors, screenshots, cleanup, and artifact identity as applicable.
-3. Publish the result and route with one guarded command:
+3. Publish the result and route with one guarded command, clearing claim/lease ownership:
    - pass -> Approval / Ready / Human;
    - implementation defect -> Implementation / Ready / <IMPLEMENTER>, only after deliberate supported routing;
    - evidence/harness defect -> Verification / Ready / <VERIFIER>;
@@ -68,9 +74,9 @@ If <STATUS> is Verification:
    - exact Dmitry action required -> Verification / Blocked / Human.
 4. Do not change production code as an unrecorded verification shortcut.
 
-For either status, routine CI/operation waiting remains In progress with `nextObservationAt`: first after 15 minutes, again after 15
-minutes, then hourly. Leave no finished or missing worker in In progress. Block only for an exact Dmitry decision/action. Never
-perform privileged operations or merge without Dmitry's explicit instruction.
+For either status, a genuine Dmitry decision/action may use Blocked / Human. Routine CI or publication waiting remains In progress
+under the same claim and lease; either finish the handoff in this worker or renew before expiry. Leave no finished worker in
+In progress. Never perform privileged operations or merge without Dmitry's explicit instruction.
 
 Finish with final lifecycle/evidence state and one telemetry JSON object containing startedAt, finishedAt, durationSeconds, model,
 reasoning, canonical target, outcome, exact provider token counters when exposed, or null counters with usageSource=unavailable.
@@ -81,5 +87,6 @@ Never invent exact token usage.
 
 `<WORK_ITEM_TYPE>` is `Issue` or `PullRequest`; `<WORK_MODE>` is `fresh`, `continuation`, `adopted-continuation`, or
 `published-head`; branch/PR/head/ownership/author fields describe the exact live implementation; Implementer/Verifier are deliberate
-routes; claim/generation identify ownership; model/reasoning come from the profile; escalation reason is `none` unless Sol/high was
-deliberately selected. Do not launch with unresolved placeholders or an unverified claim.
+routes; claim/generation identify ownership; claimed/lease timestamps come from the verified guarded claim; model/reasoning come
+from the profile; escalation reason is `none` unless Sol/high was deliberately selected. Do not launch with unresolved placeholders
+or an unverified claim.

--- a/.codex/local/worker-task-prompt.md
+++ b/.codex/local/worker-task-prompt.md
@@ -1,133 +1,85 @@
-# Sniffy app-native Local Codex lifecycle-worker template
+# Local Codex lifecycle-worker template
 
-The dispatcher renders this template into one standalone app-owned worker conversation and isolated worktree. The worker owns
-one lifecycle turn only. Shared policy lives in `AGENTS.md` and `docs/ai-delivery/`. The current Local Codex profile is Sol with
-extra-high reasoning.
+The dispatcher renders this into one standalone worker and isolated worktree. Default profile: **`gpt-5.6-terra` / medium**.
+Use Sol/high only when the rendered task contains an explicit escalation reason.
 
 ```text
-Work autonomously on one lifecycle status of canonical Sniffy <WORK_ITEM_TYPE> #<WORK_ITEM_NUMBER> in this dedicated worker
-conversation and isolated worktree.
+Perform one autonomous lifecycle turn for canonical Sniffy <WORK_ITEM_TYPE> #<WORK_ITEM_NUMBER>.
 
-Work item title: <WORK_ITEM_TITLE>
-Work item URL: <WORK_ITEM_URL>
+Title: <WORK_ITEM_TITLE>
+Canonical URL: <WORK_ITEM_URL>
 Authoritative issue: <AUTHORITATIVE_ISSUE_URL_OR_NONE>
 Status: <STATUS>
 Execution: In progress
 Mode: <WORK_MODE>
-Base branch: develop
+Base: develop
 Branch: <BRANCH_NAME>
-Existing pull request: <PR_URL_OR_NONE>
-Exact pull-request head: <PR_HEAD_SHA_OR_NONE>
-Pull-request repository ownership: <SAME_REPOSITORY_OR_FORK_OR_NONE>
-Pull-request author: <PR_AUTHOR_OR_NONE>
+Existing PR: <PR_URL_OR_NONE>
+Exact PR head: <PR_HEAD_SHA_OR_NONE>
+Ownership: <SAME_REPOSITORY_OR_FORK_OR_NONE>
+PR author: <PR_AUTHOR_OR_NONE>
 Implementer: <IMPLEMENTER>
 Verifier: <VERIFIER>
 Claim token: <CLAIM_TOKEN>
-Dispatch generation: <DISPATCH_GENERATION>
-Local Codex profile: Sol / extra-high reasoning
+Generation: <DISPATCH_GENERATION>
+Model/reasoning: <MODEL> / <REASONING>
+Escalation reason: <ESCALATION_REASON_OR_NONE>
 
-Before any mutation, read the complete canonical work item/comments, every formally linked issue, linked PR, review submissions
-and unresolved threads, current CI, Project fields, worker record, remote develop, nearest AGENTS.md, and
-`docs/ai-delivery/{profile,lifecycle,control-plane,pull-request-intake,routing,supervision,verification}.md`. Verify this task still
-owns the exact claim token/generation and worker reference.
+Record startedAt. Before mutation, read the complete canonical item and relevant comments, formal links, exact PR, current
+reviews/threads/CI, remote develop, nearest applicable AGENTS.md files, docs/ai-delivery/runtime-contract.md, and only the detailed
+lifecycle/runbook sections needed for <STATUS>. Verify the claim token/generation and worker reference still belong to this task.
 
-Use the common rotating technical control issue for every ProjectV2 transition. Post every new command with the concise
-human-readable Markdown wrapper from control-plane.md, including its exact start/end markers and lowercase `json` fence. Derive
-the display-only prose from the JSON, treat the marked JSON as authoritative, and never emit bare JSON. Never post /project-status,
-/project-field, claim arbitration, lease, or polling comments on the target item. A handoff is complete only after the guarded
-`delivery-control/v1` command has a terminal reaction and the canonical Project state has been re-read. A command setting
-Status=Review must identify the exact PR: target+expected.head for a canonical PR, or reviewPullRequest.number/head for a
-canonical issue. Re-read PR draft/head state after the command as well as Project fields.
+Use the active control issue for every Project transition. Emit the human-readable Markdown wrapper with exact start/end markers
+and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. A handoff is complete only after the terminal
+reaction and current Project/assignment/PR state are re-read.
 
-Stop autonomous work when a required product, API, architecture, compatibility, permission, credential, privileged operation,
-external service, or bespoke-infrastructure decision is missing. Keep current Status, set Execution=Blocked and Executor=Human
-through one guarded command, assign bedrin separately, and record the smallest target-item decision/action Dmitry must take.
-Routine waiting for CI or another observable operation remains In progress with a worker reference and next observation point.
-
-Canonical-item rules:
-- an issue is canonical when the PR formally closes exactly that one issue;
-- a standalone PR is canonical when it has no formal closing issue;
-- a PR with several formal closing issues is canonical only after Planning has routed the combined work;
-- mutate lifecycle fields only on <WORK_ITEM_URL>; linked issues/PRs are requirements and implementation evidence unless the
-  dispatcher explicitly says otherwise;
-- never create a shadow issue or second PR merely because this worker did not author the existing branch.
-
-Branch rules:
-- fresh Implementation: verify no branch/PR/worker already owns the canonical item and create <BRANCH_NAME> from current
-  origin/develop;
-- continuation or adopted-continuation Implementation: reuse the exact same-repository open PR branch even when it was originally
-  created by Dmitry, ChatGPT, an IDE agent, or another configured worker; verify local HEAD, remote branch, and PR head agree;
-- adopted continuation requires the explicit verified Project route to Local Codex; branch authorship alone is not permission;
-- never adopt a fork or Dependabot branch for direct correction. Return a precise blocker/route for contributor feedback, bot
-  commands, or a linked replacement task;
-- Verification: use the exact published implementation head/artifact named by Review;
-- never reset, rebase, force-push, replace an existing PR, discard unrelated work, or merge.
+Canonical/branch rules:
+- one closing issue -> issue canonical; no closing issue -> PR canonical; several -> PR Planning;
+- mutate lifecycle fields only on <WORK_ITEM_URL>;
+- fresh Implementation creates one branch from current origin/develop only when no valid branch/PR/worker owns the item;
+- continuation or adopted-continuation must reuse the exact same-repository open PR branch and preserve useful commits;
+- for continuation, do not create a fresh branch or duplicate PR;
+- never adopt a fork or Dependabot branch for direct correction;
+- never reset, rebase, force-push, replace the PR, discard unrelated work, merge, or enable auto-merge.
 
 If <STATUS> is Implementation:
-1. Convert every acceptance criterion from the canonical item and linked issues into implementer-owned proof and implement the
-   smallest coherent solution.
-2. For continuation, first inspect the entire existing PR and all Review findings; preserve useful commits and user changes. Do
-   not create a fresh branch or duplicate PR.
-3. Run focused tests first, broader applicable checks separately, and available runtime/browser checks. Confirm named tests ran;
-   record unsupported proof honestly.
-4. Inspect complete final diff, generated/unrelated files, dependencies, documentation, and proof. Run git diff --check.
-5. Commit and push with the dedicated worker identity. Create the intended PR only for fresh work; continuation must update the
-   existing PR. Keep it draft only while implementation or locally available proof is incomplete.
-6. When implementation and locally available proof are complete, mark the PR ready for review. Then re-read and verify the remote
-   PR is open, targets develop, has draft=false, and points to the exact published head. A successful push or green CI does not
-   substitute for this publication-state proof.
-7. Publish exact human-useful commands/results/limitations on the canonical issue/PR and keep the PR description synchronized.
-8. Hand off the canonical item with one guarded command setting Status=Review, Execution=Ready, Executor=ChatGPT, clearing worker
-   ownership, and recording the PR URL plus exact new head in Worker reference. If the canonical target is an issue, include
-   reviewPullRequest.number and reviewPullRequest.head. The control plane may repair a remaining draft as a final invariant, but
-   this worker must not rely on that repair instead of completing step 6.
-9. Inspect the terminal reaction, then re-read both the PR as non-draft at the same exact head and the canonical Project fields.
-   Assign bedrin-gpt separately and verify assignment. Do not report Review handoff before every check succeeds.
-10. Do not review or approve your own implementation and do not create a reviewer task. The shared event loop owns Review.
+1. Convert acceptance criteria into implementer-owned proof and implement the smallest coherent solution. For continuation, first
+   inspect the whole existing PR and all Review findings.
+2. Run focused checks first and broader applicable checks separately. Confirm named tests ran; record unsupported proof honestly.
+3. Inspect the complete final diff, generated/unrelated files, dependencies, docs, and proof. Run git diff --check.
+4. Commit and push the dedicated branch. Create a PR only for fresh work; continuation updates the existing PR. Keep it draft only
+   while implementation or locally available proof is incomplete.
+5. When complete, mark the PR ready for review and re-read it as open, targeting develop, non-draft, and at the exact published
+   head. Synchronize its description and publish exact human-useful evidence.
+6. Hand off through one guarded command to Review / Ready / ChatGPT with PR URL and exact head. For a canonical issue include
+   reviewPullRequest.number and reviewPullRequest.head; for a canonical PR guard expected.head. Verify reaction, Project state,
+   assignment to bedrin-gpt, and non-draft exact-head PR state.
+7. Do not review your own implementation or create a reviewer task.
 
 If <STATUS> is Verification:
-1. Re-read the canonical item and later discussion. Identify observable journey, negative cases, exact implementation head/artifact,
-   and representative environment.
-2. Perform outcome-centric system/integration/browser/compatibility proof. Do not merely repeat unit tests or trust implementer
-   summary. Record runtime actions, logs, browser errors/requests, screenshots, cleanup, and artifact identity as applicable.
-3. Classify the result and use one guarded handoff command on the canonical item:
-   - pass -> Status=Approval, Execution=Ready, Executor=Human; assign bedrin separately;
-   - implementation defect -> Status=Implementation, Execution=Ready, Executor=<IMPLEMENTER>, but only when Implementer is a
-     deliberately selected supported executor;
-   - verification harness/evidence defect -> Status=Verification, Execution=Ready, Executor=<VERIFIER>;
-   - requirement/architecture/canonicalization defect -> Status=Planning, Execution=Ready, Executor=ChatGPT; assign bedrin-gpt;
-   - Dmitry decision/action required -> keep Status=Verification, Execution=Blocked, Executor=Human; assign bedrin and record the
-     exact request on the target item.
-4. Publish exact environment, source/artifact identity, commands/actions, results, and failure classification before handoff.
-5. Do not modify production code as an unrecorded shortcut. A required correction returns to a deliberately routed Implementation.
+1. Identify the observable journey, negative cases, exact implementation head/artifact, and representative environment.
+2. Perform outcome-centric integration/system/browser/compatibility proof rather than repeating unit tests. Record environment,
+   actions, logs, requests/errors, screenshots, cleanup, and artifact identity as applicable.
+3. Publish the result and route with one guarded command:
+   - pass -> Approval / Ready / Human;
+   - implementation defect -> Implementation / Ready / <IMPLEMENTER>, only after deliberate supported routing;
+   - evidence/harness defect -> Verification / Ready / <VERIFIER>;
+   - requirement/architecture/canonicalization defect -> Planning / Ready / ChatGPT;
+   - exact Dmitry action required -> Verification / Blocked / Human.
+4. Do not change production code as an unrecorded verification shortcut.
 
-For either lifecycle status:
-- leave no In progress item with a finished or missing worker;
-- never close the canonical item, merge, enable auto-merge, bypass protection, or perform privileged operations without Dmitry's
-  explicit instruction;
-- finish by reporting final lifecycle handoff and exact remote/evidence state in this worker conversation.
+For either status, routine CI/operation waiting remains In progress with `nextObservationAt`: first after 15 minutes, again after 15
+minutes, then hourly. Leave no finished or missing worker in In progress. Block only for an exact Dmitry decision/action. Never
+perform privileged operations or merge without Dmitry's explicit instruction.
+
+Finish with final lifecycle/evidence state and one telemetry JSON object containing startedAt, finishedAt, durationSeconds, model,
+reasoning, canonical target, outcome, exact provider token counters when exposed, or null counters with usageSource=unavailable.
+Never invent exact token usage.
 ```
 
 ## Placeholder contract
 
-| Placeholder | Meaning |
-| --- | --- |
-| `<WORK_ITEM_TYPE>` | `Issue` or `PullRequest` for the canonical Project item |
-| `<WORK_ITEM_NUMBER>` | Numeric canonical item number |
-| `<WORK_ITEM_TITLE>` | Current canonical item title |
-| `<WORK_ITEM_URL>` | Canonical issue or PR URL and delivery-control target |
-| `<AUTHORITATIVE_ISSUE_URL_OR_NONE>` | Requirement issue URL when one exists, otherwise `none` |
-| `<STATUS>` | `Implementation` or `Verification` |
-| `<WORK_MODE>` | `fresh`, `continuation`, or `adopted-continuation`; `published-head` for Verification |
-| `<BRANCH_NAME>` | Fresh branch or exact existing PR head branch |
-| `<PR_URL_OR_NONE>` | Existing/published PR or `none` for fresh Implementation |
-| `<PR_HEAD_SHA_OR_NONE>` | Exact existing/published PR head or `none` |
-| `<SAME_REPOSITORY_OR_FORK_OR_NONE>` | `same-repository`, `fork`, or `none` |
-| `<PR_AUTHOR_OR_NONE>` | Current PR author login or `none` |
-| `<IMPLEMENTER>` | Deliberately selected Implementer field value for Implementation |
-| `<VERIFIER>` | Planned Verifier field value |
-| `<CLAIM_TOKEN>` | Verified guarded claim token |
-| `<DISPATCH_GENERATION>` | Current lifecycle dispatch generation |
-
-Do not launch a worker with unresolved placeholders or an unverified claim. An existing PR created outside the delivery system is
-not a duplicate when the canonical Project route explicitly selects continuation of that exact PR.
+`<WORK_ITEM_TYPE>` is `Issue` or `PullRequest`; `<WORK_MODE>` is `fresh`, `continuation`, `adopted-continuation`, or
+`published-head`; branch/PR/head/ownership/author fields describe the exact live implementation; Implementer/Verifier are deliberate
+routes; claim/generation identify ownership; model/reasoning come from the profile; escalation reason is `none` unless Sol/high was
+deliberately selected. Do not launch with unresolved placeholders or an unverified claim.

--- a/.github/scripts/delivery-dispatch-view.js
+++ b/.github/scripts/delivery-dispatch-view.js
@@ -5,7 +5,7 @@ const fs = require('node:fs');
 const DOWNSTREAM_HEAD_STATUSES = new Set(['Review', 'Verification', 'Approval']);
 const PRIORITY_RANK = new Map([['Urgent', 0], ['High', 1], ['Medium', 2], ['Low', 3]]);
 const SHA_PATTERN = /\b[0-9a-f]{40}\b/gi;
-const NEXT_OBSERVATION_PATTERN = /nextObservationAt\s*[=:]\s*([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)/i;
+const LEASE_UNTIL_PATTERN = /\b"?leaseUntil"?\s*[=:]\s*"?([^"\s;,}]+)/i;
 
 function asArray(value) {
   return Array.isArray(value) ? value : [];
@@ -62,11 +62,14 @@ function compareCandidates(left, right) {
   return 0;
 }
 
+function leaseUntilFrom(workerReference) {
+  if (typeof workerReference !== 'string') return null;
+  return workerReference.match(LEASE_UNTIL_PATTERN)?.[1] ?? null;
+}
+
 function compactItem(item, rawById) {
   const raw = rawById.get(item.projectItemId) || {};
   const workerReference = field(item, 'Worker reference');
-  const nextMatch = typeof workerReference === 'string' ? workerReference.match(NEXT_OBSERVATION_PATTERN) : null;
-  const nextObservationAt = nextMatch?.[1] ?? null;
   return {
     projectItemId: item.projectItemId,
     repository: item.content?.repository ?? null,
@@ -87,7 +90,7 @@ function compactItem(item, rawById) {
     priority: field(item, 'Priority'),
     readyTimestamp: field(item, 'Ready timestamp'),
     workerReference,
-    nextObservationAt,
+    leaseUntil: leaseUntilFrom(workerReference),
     assignees: assigneeLogins(raw)
   };
 }
@@ -191,6 +194,17 @@ function staleExactHeadCandidate(projection) {
   };
 }
 
+function staleOwnershipReason(item, generatedAt) {
+  if (typeof item.workerReference !== 'string' || item.workerReference.trim() === '') {
+    return 'missing-worker-reference';
+  }
+  if (!item.leaseUntil) return 'missing-lease';
+  const leaseUntil = Date.parse(item.leaseUntil);
+  if (!Number.isFinite(leaseUntil)) return 'invalid-lease';
+  if (!Number.isFinite(generatedAt)) return 'invalid-snapshot-time';
+  return leaseUntil <= generatedAt ? 'lease-expired' : null;
+}
+
 function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
   const baseBranch = options.baseBranch ?? 'develop';
   const executorAssignees = options.executorAssignees || {};
@@ -207,11 +221,11 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
   const ready = compactItems.filter(item => item.execution === 'Ready');
   const inProgress = compactItems.filter(item => item.execution === 'In progress');
   const generatedAt = Date.parse(snapshot.generatedAt);
-  const dueInProgress = inProgress.filter(item => {
-    if (!item.nextObservationAt) return true;
-    const dueAt = Date.parse(item.nextObservationAt);
-    return !Number.isFinite(dueAt) || !Number.isFinite(generatedAt) || dueAt <= generatedAt;
-  });
+  const staleInProgress = inProgress
+    .map(item => ({...item, staleReason: staleOwnershipReason(item, generatedAt)}))
+    .filter(item => item.staleReason !== null);
+  const staleIds = new Set(staleInProgress.map(item => item.projectItemId));
+  const activeInProgress = inProgress.filter(item => !staleIds.has(item.projectItemId));
 
   const routeMismatches = ready.filter(item => {
     const expected = executorAssignees[item.executor];
@@ -234,10 +248,10 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
     ...intake.map(value => ({kind: 'pr-intake', canonical: value.canonical, pullRequest: value})),
     ...staleExactHead,
     ...routeMismatches.map(value => ({kind: 'route-mismatch', item: value})),
-    ...dueInProgress
+    ...staleInProgress
       .filter(value => value.executor === 'ChatGPT' || value.executor === 'Codex Cloud')
       .sort(compareCandidates)
-      .map(value => ({kind: 'due-owned-observation', item: value})),
+      .map(value => ({kind: 'stale-owned-recovery', item: value})),
     ...ready
       .filter(value => value.executor === 'Codex Cloud')
       .sort(compareCandidates)
@@ -253,7 +267,8 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
     baseBranch,
     readyByExecutor: groupByExecutor(ready),
     inProgressByExecutor: groupByExecutor(inProgress),
-    dueInProgressByExecutor: groupByExecutor(dueInProgress),
+    activeInProgressByExecutor: groupByExecutor(activeInProgress),
+    staleInProgressByExecutor: groupByExecutor(staleInProgress),
     routeMismatches,
     pullRequests: {conflicting, managedConflicts, intake, drafts},
     staleExactHead,
@@ -261,7 +276,8 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
     counts: {
       ready: ready.length,
       inProgress: inProgress.length,
-      dueInProgress: dueInProgress.length,
+      activeInProgress: activeInProgress.length,
+      staleInProgress: staleInProgress.length,
       routeMismatches: routeMismatches.length,
       conflictingPullRequests: conflicting.length,
       managedConflictPullRequests: managedConflicts.length,
@@ -298,7 +314,8 @@ function main(argv) {
   });
   snapshot.semantics = {
     ...(snapshot.semantics || {}),
-    dispatch: 'deterministic selection projection; live-read only the selected candidate before a guarded mutation'
+    dispatch: 'deterministic selection projection; live-read only the selected candidate before a guarded mutation',
+    inProgress: 'active ownership is ignored until lease expiry; only missing, invalid, or expired leases enter stale recovery'
   };
   fs.writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
 }
@@ -312,4 +329,11 @@ if (require.main === module) {
   }
 }
 
-module.exports = {buildDispatch, canonicalIdentity, compareCandidates, exactHeads};
+module.exports = {
+  buildDispatch,
+  canonicalIdentity,
+  compareCandidates,
+  exactHeads,
+  leaseUntilFrom,
+  staleOwnershipReason
+};

--- a/.github/scripts/delivery-dispatch-view.js
+++ b/.github/scripts/delivery-dispatch-view.js
@@ -129,6 +129,18 @@ function projectItemsForPullRequest(pullRequest, itemsByIdentity) {
   return identities.flatMap(identity => itemsByIdentity.get(itemKey(identity.type, identity.number)) || []);
 }
 
+function conflictModeFor({pullRequest, canonicalItem, dependabot, reviewable}) {
+  const hasConflict = reviewable &&
+    (pullRequest.mergeable === 'CONFLICTING' || pullRequest.mergeStateStatus === 'DIRTY');
+  const routedImplementation = canonicalItem?.status === 'Implementation' &&
+    ['Ready', 'In progress'].includes(canonicalItem.execution) && canonicalItem.executor !== null;
+  if (!hasConflict || routedImplementation) return null;
+  if (dependabot) return 'dependabot-operation';
+  if (pullRequest.repositoryOwnership === 'fork') return 'contributor-feedback';
+  if (pullRequest.repositoryOwnership === 'same-repository') return 'same-repository-continuation';
+  return 'inspect-ownership';
+}
+
 function pullRequestProjection(pullRequest, rawPullRequestsByNumber, itemsByIdentity, baseBranch) {
   const canonical = canonicalIdentity(pullRequest);
   const canonicalItems = itemsByIdentity.get(itemKey(canonical.type, canonical.number)) || [];
@@ -141,6 +153,7 @@ function pullRequestProjection(pullRequest, rawPullRequestsByNumber, itemsByIden
   const onBase = pullRequest.baseRefName === baseBranch;
   const reviewable = onBase && pullRequest.isDraft === false;
   const statusNeedsIntake = canonicalItem === null || canonicalItem.status === null || canonicalItem.status === 'Draft';
+  const conflictMode = conflictModeFor({pullRequest, canonicalItem, dependabot, reviewable});
   return {
     number: pullRequest.number,
     url: pullRequest.url,
@@ -159,8 +172,8 @@ function pullRequestProjection(pullRequest, rawPullRequestsByNumber, itemsByIden
     duplicateProjectItems: duplicateItems,
     isDependabot: dependabot,
     needsIntake: reviewable && (statusNeedsIntake || duplicateItems.length > 0),
-    conflictCandidate: reviewable && pullRequest.repositoryOwnership === 'same-repository' && !dependabot &&
-      (pullRequest.mergeable === 'CONFLICTING' || pullRequest.mergeStateStatus === 'DIRTY')
+    conflictMode,
+    conflictCandidate: conflictMode !== null
   };
 }
 
@@ -208,13 +221,16 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
   const pullRequests = asArray(snapshot.pullRequests)
     .filter(value => value.baseRefName === baseBranch)
     .map(value => pullRequestProjection(value, rawPullRequestsByNumber, itemsByIdentity, baseBranch));
-  const conflicting = pullRequests.filter(value => value.conflictCandidate);
-  const intake = pullRequests.filter(value => value.needsIntake && !value.conflictCandidate);
+  const conflicting = pullRequests.filter(value => value.conflictMode === 'same-repository-continuation');
+  const managedConflicts = pullRequests.filter(value =>
+    value.conflictMode !== null && value.conflictMode !== 'same-repository-continuation');
+  const intake = pullRequests.filter(value => value.needsIntake && value.conflictMode === null);
   const drafts = pullRequests.filter(value => value.isDraft);
   const staleExactHead = pullRequests.map(staleExactHeadCandidate).filter(Boolean);
 
   const orderedCandidates = [
     ...conflicting.map(value => ({kind: 'conflicting-pr', canonical: value.canonical, pullRequest: value})),
+    ...managedConflicts.map(value => ({kind: 'managed-pr-conflict', canonical: value.canonical, pullRequest: value})),
     ...intake.map(value => ({kind: 'pr-intake', canonical: value.canonical, pullRequest: value})),
     ...staleExactHead,
     ...routeMismatches.map(value => ({kind: 'route-mismatch', item: value})),
@@ -239,7 +255,7 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
     inProgressByExecutor: groupByExecutor(inProgress),
     dueInProgressByExecutor: groupByExecutor(dueInProgress),
     routeMismatches,
-    pullRequests: {conflicting, intake, drafts},
+    pullRequests: {conflicting, managedConflicts, intake, drafts},
     staleExactHead,
     orderedCandidates,
     counts: {
@@ -248,6 +264,7 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
       dueInProgress: dueInProgress.length,
       routeMismatches: routeMismatches.length,
       conflictingPullRequests: conflicting.length,
+      managedConflictPullRequests: managedConflicts.length,
       intakePullRequests: intake.length,
       staleExactHead: staleExactHead.length,
       orderedCandidates: orderedCandidates.length

--- a/.github/scripts/delivery-dispatch-view.js
+++ b/.github/scripts/delivery-dispatch-view.js
@@ -1,0 +1,298 @@
+'use strict';
+
+const fs = require('node:fs');
+
+const DOWNSTREAM_HEAD_STATUSES = new Set(['Review', 'Verification', 'Approval', 'Blocked']);
+const PRIORITY_RANK = new Map([['Urgent', 0], ['High', 1], ['Medium', 2], ['Low', 3]]);
+const SHA_PATTERN = /\b[0-9a-f]{40}\b/gi;
+const NEXT_OBSERVATION_PATTERN = /nextObservationAt\s*[=:]\s*([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)/i;
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function field(item, name) {
+  const fields = item?.fields || {};
+  const key = Object.keys(fields).find(candidate => candidate.toLowerCase() === name.toLowerCase());
+  return key === undefined ? null : fields[key] ?? null;
+}
+
+function assigneeLogins(rawItem) {
+  return asArray(rawItem?.assignees).flatMap(value => {
+    if (typeof value === 'string') return [value];
+    if (value && typeof value === 'object') return [value.login ?? value.name].filter(Boolean);
+    return [];
+  }).sort();
+}
+
+function labelNames(rawPullRequest) {
+  return asArray(rawPullRequest?.labels).flatMap(value => {
+    if (typeof value === 'string') return [value];
+    if (value && typeof value === 'object') return [value.name].filter(Boolean);
+    return [];
+  }).sort();
+}
+
+function normalizedType(value) {
+  const type = String(value ?? '').toUpperCase();
+  if (type === 'PULLREQUEST' || type === 'PULL_REQUEST') return 'PullRequest';
+  if (type === 'ISSUE') return 'Issue';
+  return value ?? null;
+}
+
+function priorityRank(value) {
+  return PRIORITY_RANK.get(value) ?? 4;
+}
+
+function compareCandidates(left, right) {
+  const keys = candidate => [
+    priorityRank(candidate.priority),
+    candidate.readyTimestamp ?? '9999-12-31T23:59:59Z',
+    candidate.repository ?? '',
+    Number.isFinite(Number(candidate.number)) ? Number(candidate.number) : Number.MAX_SAFE_INTEGER,
+    candidate.type ?? '',
+    candidate.projectItemId ?? ''
+  ];
+  const a = keys(left);
+  const b = keys(right);
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] < b[index]) return -1;
+    if (a[index] > b[index]) return 1;
+  }
+  return 0;
+}
+
+function compactItem(item, rawById) {
+  const raw = rawById.get(item.projectItemId) || {};
+  const workerReference = field(item, 'Worker reference');
+  const nextMatch = typeof workerReference === 'string' ? workerReference.match(NEXT_OBSERVATION_PATTERN) : null;
+  const nextObservationAt = nextMatch?.[1] ?? null;
+  return {
+    projectItemId: item.projectItemId,
+    repository: item.content?.repository ?? null,
+    type: normalizedType(item.content?.type),
+    number: item.content?.number ?? null,
+    title: item.content?.title ?? null,
+    url: item.content?.url ?? null,
+    state: item.content?.state ?? null,
+    isDraft: item.content?.isDraft ?? false,
+    baseRefName: item.content?.baseRefName ?? null,
+    headRefName: item.content?.headRefName ?? null,
+    headRefOid: item.content?.headRefOid ?? null,
+    status: field(item, 'Status'),
+    execution: field(item, 'Execution'),
+    executor: field(item, 'Executor'),
+    implementer: field(item, 'Implementer'),
+    verifier: field(item, 'Verifier'),
+    priority: field(item, 'Priority'),
+    readyTimestamp: field(item, 'Ready timestamp'),
+    workerReference,
+    nextObservationAt,
+    assignees: assigneeLogins(raw)
+  };
+}
+
+function groupByExecutor(items) {
+  const grouped = {};
+  for (const item of [...items].sort(compareCandidates)) {
+    const executor = item.executor ?? 'Unassigned';
+    (grouped[executor] ||= []).push(item);
+  }
+  return grouped;
+}
+
+function itemKey(type, number) {
+  return `${normalizedType(type)}#${Number(number)}`;
+}
+
+function canonicalIdentity(pullRequest) {
+  const closing = asArray(pullRequest.closingIssueNumbers);
+  if (closing.length === 1) return {type: 'Issue', number: closing[0], expectedInitialStatus: 'Review'};
+  if (closing.length === 0) return {type: 'PullRequest', number: pullRequest.number, expectedInitialStatus: 'Review'};
+  return {type: 'PullRequest', number: pullRequest.number, expectedInitialStatus: 'Planning'};
+}
+
+function projectIdentity(item) {
+  return itemKey(item.type, item.number);
+}
+
+function exactHeads(workerReference) {
+  if (typeof workerReference !== 'string') return [];
+  return [...new Set(workerReference.match(SHA_PATTERN) || [])].map(value => value.toLowerCase());
+}
+
+function projectItemsForPullRequest(pullRequest, itemsByIdentity) {
+  const identities = [{type: 'PullRequest', number: pullRequest.number}];
+  for (const issueNumber of asArray(pullRequest.closingIssueNumbers)) {
+    identities.push({type: 'Issue', number: issueNumber});
+  }
+  return identities.flatMap(identity => itemsByIdentity.get(itemKey(identity.type, identity.number)) || []);
+}
+
+function pullRequestProjection(pullRequest, rawPullRequestsByNumber, itemsByIdentity, baseBranch) {
+  const canonical = canonicalIdentity(pullRequest);
+  const canonicalItems = itemsByIdentity.get(itemKey(canonical.type, canonical.number)) || [];
+  const relatedItems = projectItemsForPullRequest(pullRequest, itemsByIdentity);
+  const duplicateItems = relatedItems.filter(item => projectIdentity(item) !== itemKey(canonical.type, canonical.number));
+  const canonicalItem = canonicalItems[0] ?? null;
+  const raw = rawPullRequestsByNumber.get(Number(pullRequest.number)) || {};
+  const labels = labelNames(raw);
+  const dependabot = String(pullRequest.author ?? '').toLowerCase().startsWith('dependabot') || labels.includes('dependencies');
+  const onBase = pullRequest.baseRefName === baseBranch;
+  const reviewable = onBase && pullRequest.isDraft === false;
+  const statusNeedsIntake = canonicalItem === null || canonicalItem.status === null || canonicalItem.status === 'Draft';
+  const implementationPublication = canonicalItem?.status === 'Implementation' && canonicalItem?.execution !== 'In progress';
+  return {
+    number: pullRequest.number,
+    url: pullRequest.url,
+    author: pullRequest.author,
+    labels,
+    repositoryOwnership: pullRequest.repositoryOwnership,
+    isDraft: pullRequest.isDraft,
+    baseRefName: pullRequest.baseRefName,
+    headRefName: pullRequest.headRefName,
+    headRefOid: pullRequest.headRefOid,
+    mergeable: pullRequest.mergeable,
+    mergeStateStatus: pullRequest.mergeStateStatus,
+    closingIssueNumbers: asArray(pullRequest.closingIssueNumbers),
+    canonical,
+    canonicalProjectItem: canonicalItem,
+    duplicateProjectItems: duplicateItems,
+    isDependabot: dependabot,
+    needsIntake: reviewable && (statusNeedsIntake || duplicateItems.length > 0 || implementationPublication),
+    conflictCandidate: reviewable && pullRequest.repositoryOwnership === 'same-repository' && !dependabot &&
+      (pullRequest.mergeable === 'CONFLICTING' || pullRequest.mergeStateStatus === 'DIRTY')
+  };
+}
+
+function staleExactHeadCandidate(projection) {
+  const item = projection.canonicalProjectItem;
+  const currentHead = String(projection.headRefOid ?? '').toLowerCase();
+  if (!item || !currentHead || !DOWNSTREAM_HEAD_STATUSES.has(item.status)) return null;
+  const recordedHeads = exactHeads(item.workerReference);
+  if (recordedHeads.length === 0 || recordedHeads.includes(currentHead)) return null;
+  return {
+    kind: 'stale-exact-head',
+    canonical: projection.canonical,
+    pullRequest: projection,
+    recordedHeads
+  };
+}
+
+function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
+  const baseBranch = options.baseBranch ?? 'develop';
+  const executorAssignees = options.executorAssignees || {};
+  const rawById = new Map(asArray(rawItems?.items).map(item => [item.id, item]));
+  const rawPullRequestsByNumber = new Map(asArray(rawPullRequests).map(item => [Number(item.number), item]));
+  const compactItems = asArray(snapshot.items).map(item => compactItem(item, rawById));
+  const itemsByIdentity = new Map();
+  for (const item of compactItems) {
+    const key = projectIdentity(item);
+    (itemsByIdentity.get(key) || itemsByIdentity.set(key, []).get(key)).push(item);
+  }
+
+  const ready = compactItems.filter(item => item.execution === 'Ready');
+  const inProgress = compactItems.filter(item => item.execution === 'In progress');
+  const generatedAt = Date.parse(snapshot.generatedAt);
+  const dueInProgress = inProgress.filter(item => {
+    if (!item.nextObservationAt) return true;
+    const dueAt = Date.parse(item.nextObservationAt);
+    return !Number.isFinite(dueAt) || !Number.isFinite(generatedAt) || dueAt <= generatedAt;
+  });
+
+  const routeMismatches = ready.filter(item => {
+    const expected = executorAssignees[item.executor];
+    return expected && item.assignees.length > 0 && !item.assignees.includes(expected);
+  }).sort(compareCandidates);
+
+  const pullRequests = asArray(snapshot.pullRequests)
+    .filter(value => value.baseRefName === baseBranch)
+    .map(value => pullRequestProjection(value, rawPullRequestsByNumber, itemsByIdentity, baseBranch));
+  const conflicting = pullRequests.filter(value => value.conflictCandidate);
+  const intake = pullRequests.filter(value => value.needsIntake && !value.conflictCandidate);
+  const drafts = pullRequests.filter(value => value.isDraft);
+  const staleExactHead = pullRequests.map(staleExactHeadCandidate).filter(Boolean);
+
+  const orderedCandidates = [
+    ...conflicting.map(value => ({kind: 'conflicting-pr', canonical: value.canonical, pullRequest: value})),
+    ...intake.map(value => ({kind: 'pr-intake', canonical: value.canonical, pullRequest: value})),
+    ...staleExactHead,
+    ...routeMismatches.map(value => ({kind: 'route-mismatch', item: value})),
+    ...dueInProgress
+      .filter(value => value.executor === 'ChatGPT' || value.executor === 'Codex Cloud')
+      .sort(compareCandidates)
+      .map(value => ({kind: 'due-owned-observation', item: value})),
+    ...ready
+      .filter(value => value.executor === 'Codex Cloud')
+      .sort(compareCandidates)
+      .map(value => ({kind: 'supervised-ready', item: value})),
+    ...ready
+      .filter(value => value.executor === 'ChatGPT')
+      .sort(compareCandidates)
+      .map(value => ({kind: 'chatgpt-ready', item: value}))
+  ];
+
+  return {
+    generatedAt: snapshot.generatedAt,
+    baseBranch,
+    readyByExecutor: groupByExecutor(ready),
+    inProgressByExecutor: groupByExecutor(inProgress),
+    dueInProgressByExecutor: groupByExecutor(dueInProgress),
+    routeMismatches,
+    pullRequests: {conflicting, intake, drafts},
+    staleExactHead,
+    orderedCandidates,
+    counts: {
+      ready: ready.length,
+      inProgress: inProgress.length,
+      dueInProgress: dueInProgress.length,
+      routeMismatches: routeMismatches.length,
+      conflictingPullRequests: conflicting.length,
+      intakePullRequests: intake.length,
+      staleExactHead: staleExactHead.length,
+      orderedCandidates: orderedCandidates.length
+    }
+  };
+}
+
+function parseArguments(argv) {
+  const [snapshotPath, rawItemsPath, rawPullRequestsPath, ...rest] = argv;
+  if (!snapshotPath || !rawItemsPath || !rawPullRequestsPath) {
+    throw new Error('Usage: delivery-dispatch-view.js <snapshot.json> <raw-items.json> <raw-pull-requests.json> [--base-branch NAME] [--executor-assignees JSON]');
+  }
+  const options = {};
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+    if (!key?.startsWith('--') || value === undefined) throw new Error(`Invalid argument sequence near ${key ?? '<end>'}`);
+    options[key.slice(2)] = value;
+  }
+  return {snapshotPath, rawItemsPath, rawPullRequestsPath, options};
+}
+
+function main(argv) {
+  const {snapshotPath, rawItemsPath, rawPullRequestsPath, options} = parseArguments(argv);
+  const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+  const rawItems = JSON.parse(fs.readFileSync(rawItemsPath, 'utf8'));
+  const rawPullRequests = JSON.parse(fs.readFileSync(rawPullRequestsPath, 'utf8'));
+  snapshot.dispatch = buildDispatch(snapshot, rawItems, rawPullRequests, {
+    baseBranch: options['base-branch'] ?? 'develop',
+    executorAssignees: options['executor-assignees'] ? JSON.parse(options['executor-assignees']) : {}
+  });
+  snapshot.semantics = {
+    ...(snapshot.semantics || {}),
+    dispatch: 'deterministic selection projection; live-read only the selected candidate before a guarded mutation'
+  };
+  fs.writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {buildDispatch, canonicalIdentity, compareCandidates, exactHeads};

--- a/.github/scripts/delivery-dispatch-view.js
+++ b/.github/scripts/delivery-dispatch-view.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 
-const DOWNSTREAM_HEAD_STATUSES = new Set(['Review', 'Verification', 'Approval', 'Blocked']);
+const DOWNSTREAM_HEAD_STATUSES = new Set(['Review', 'Verification', 'Approval']);
 const PRIORITY_RANK = new Map([['Urgent', 0], ['High', 1], ['Medium', 2], ['Low', 3]]);
 const SHA_PATTERN = /\b[0-9a-f]{40}\b/gi;
 const NEXT_OBSERVATION_PATTERN = /nextObservationAt\s*[=:]\s*([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)/i;
@@ -137,11 +137,10 @@ function pullRequestProjection(pullRequest, rawPullRequestsByNumber, itemsByIden
   const canonicalItem = canonicalItems[0] ?? null;
   const raw = rawPullRequestsByNumber.get(Number(pullRequest.number)) || {};
   const labels = labelNames(raw);
-  const dependabot = String(pullRequest.author ?? '').toLowerCase().startsWith('dependabot') || labels.includes('dependencies');
+  const dependabot = String(pullRequest.author ?? '').toLowerCase().startsWith('dependabot');
   const onBase = pullRequest.baseRefName === baseBranch;
   const reviewable = onBase && pullRequest.isDraft === false;
   const statusNeedsIntake = canonicalItem === null || canonicalItem.status === null || canonicalItem.status === 'Draft';
-  const implementationPublication = canonicalItem?.status === 'Implementation' && canonicalItem?.execution !== 'In progress';
   return {
     number: pullRequest.number,
     url: pullRequest.url,
@@ -159,7 +158,7 @@ function pullRequestProjection(pullRequest, rawPullRequestsByNumber, itemsByIden
     canonicalProjectItem: canonicalItem,
     duplicateProjectItems: duplicateItems,
     isDependabot: dependabot,
-    needsIntake: reviewable && (statusNeedsIntake || duplicateItems.length > 0 || implementationPublication),
+    needsIntake: reviewable && (statusNeedsIntake || duplicateItems.length > 0),
     conflictCandidate: reviewable && pullRequest.repositoryOwnership === 'same-repository' && !dependabot &&
       (pullRequest.mergeable === 'CONFLICTING' || pullRequest.mergeStateStatus === 'DIRTY')
   };
@@ -188,7 +187,8 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
   const itemsByIdentity = new Map();
   for (const item of compactItems) {
     const key = projectIdentity(item);
-    (itemsByIdentity.get(key) || itemsByIdentity.set(key, []).get(key)).push(item);
+    if (!itemsByIdentity.has(key)) itemsByIdentity.set(key, []);
+    itemsByIdentity.get(key).push(item);
   }
 
   const ready = compactItems.filter(item => item.execution === 'Ready');

--- a/.github/scripts/delivery-dispatch-view.test.js
+++ b/.github/scripts/delivery-dispatch-view.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {buildDispatch, canonicalIdentity, exactHeads} = require('./delivery-dispatch-view');
+
+function projectItem(number, fields = {}, type = 'Issue') {
+  return {
+    projectItemId: `${type}-${number}`,
+    content: {
+      type,
+      number,
+      repository: 'sniffy/sniffy',
+      title: `${type} ${number}`,
+      url: `https://github.com/sniffy/sniffy/${type === 'Issue' ? 'issues' : 'pull'}/${number}`
+    },
+    fields: {
+      Status: null,
+      Execution: null,
+      Executor: null,
+      Implementer: null,
+      Verifier: null,
+      Priority: null,
+      'Ready timestamp': null,
+      'Worker reference': null,
+      ...fields
+    }
+  };
+}
+
+function pullRequest(number, closingIssueNumbers = [], overrides = {}) {
+  return {
+    number,
+    url: `https://github.com/sniffy/sniffy/pull/${number}`,
+    author: 'contributor',
+    repositoryOwnership: 'same-repository',
+    isDraft: false,
+    baseRefName: 'develop',
+    headRefName: `agent/pr-${number}`,
+    headRefOid: String(number).padStart(40, 'a').slice(-40),
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    closingIssueNumbers,
+    ...overrides
+  };
+}
+
+function rawItem(item, assignees = []) {
+  return {id: item.projectItemId, assignees: assignees.map(login => ({login}))};
+}
+
+function snapshot(items, pullRequests = []) {
+  return {
+    generatedAt: '2026-08-03T00:00:00Z',
+    items,
+    pullRequests
+  };
+}
+
+test('canonicalizes PRs without asking the dispatcher model', () => {
+  assert.deepEqual(canonicalIdentity(pullRequest(10, [9])), {
+    type: 'Issue', number: 9, expectedInitialStatus: 'Review'
+  });
+  assert.deepEqual(canonicalIdentity(pullRequest(10)), {
+    type: 'PullRequest', number: 10, expectedInitialStatus: 'Review'
+  });
+  assert.deepEqual(canonicalIdentity(pullRequest(10, [8, 9])), {
+    type: 'PullRequest', number: 10, expectedInitialStatus: 'Planning'
+  });
+});
+
+test('groups ready and in-progress work and detects route mismatch', () => {
+  const ready = projectItem(2, {
+    Status: 'Review', Execution: 'Ready', Executor: 'ChatGPT', Priority: 'High'
+  });
+  const owned = projectItem(3, {
+    Status: 'Implementation', Execution: 'In progress', Executor: 'Codex Cloud',
+    'Worker reference': 'task cloud-3; nextObservationAt=2026-08-02T23:30:00Z'
+  });
+  const result = buildDispatch(
+    snapshot([ready, owned]),
+    {items: [rawItem(ready, ['bedrin-codex-local']), rawItem(owned, ['bedrin-codex-cloud'])]},
+    [],
+    {executorAssignees: {ChatGPT: 'bedrin-gpt', 'Codex Cloud': 'bedrin-codex-cloud'}}
+  );
+
+  assert.deepEqual(result.readyByExecutor.ChatGPT.map(item => item.number), [2]);
+  assert.deepEqual(result.dueInProgressByExecutor['Codex Cloud'].map(item => item.number), [3]);
+  assert.deepEqual(result.routeMismatches.map(item => item.number), [2]);
+  assert.equal(result.orderedCandidates[0].kind, 'route-mismatch');
+});
+
+test('does not select an in-progress observation before its durable due time', () => {
+  const owned = projectItem(3, {
+    Status: 'Implementation', Execution: 'In progress', Executor: 'Codex Cloud',
+    'Worker reference': 'nextObservationAt=2026-08-03T00:15:00Z'
+  });
+  const result = buildDispatch(snapshot([owned]), {items: [rawItem(owned)]}, [], {});
+  assert.equal(result.inProgressByExecutor['Codex Cloud'].length, 1);
+  assert.equal(result.dueInProgressByExecutor['Codex Cloud'], undefined);
+  assert.equal(result.orderedCandidates.length, 0);
+});
+
+test('projects PR intake, duplicate representation, and conflicts', () => {
+  const issue = projectItem(9, {Status: 'Draft'}, 'Issue');
+  const duplicatePr = projectItem(10, {Status: 'Review', Execution: 'Ready', Executor: 'ChatGPT'}, 'PullRequest');
+  const pr = pullRequest(10, [9], {mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY'});
+  const result = buildDispatch(
+    snapshot([issue, duplicatePr], [pr]),
+    {items: [rawItem(issue), rawItem(duplicatePr)]},
+    [{number: 10, labels: []}],
+    {}
+  );
+
+  assert.equal(result.pullRequests.conflicting.length, 1);
+  assert.equal(result.pullRequests.conflicting[0].canonical.type, 'Issue');
+  assert.equal(result.pullRequests.conflicting[0].duplicateProjectItems[0].number, 10);
+  assert.equal(result.orderedCandidates[0].kind, 'conflicting-pr');
+});
+
+test('keeps fork and Dependabot PRs out of direct conflict continuation', () => {
+  const fork = pullRequest(11, [], {repositoryOwnership: 'fork', mergeable: 'CONFLICTING'});
+  const dependabot = pullRequest(12, [], {author: 'dependabot[bot]', mergeable: 'CONFLICTING'});
+  const result = buildDispatch(
+    snapshot([], [fork, dependabot]),
+    {items: []},
+    [{number: 11, labels: []}, {number: 12, labels: [{name: 'dependencies'}]}],
+    {}
+  );
+  assert.equal(result.pullRequests.conflicting.length, 0);
+  assert.deepEqual(result.pullRequests.intake.map(value => value.number), [11, 12]);
+});
+
+test('detects downstream lifecycle evidence pinned to an older exact head', () => {
+  const oldHead = '1'.repeat(40);
+  const issue = projectItem(9, {
+    Status: 'Approval', Execution: 'Ready', Executor: 'Human',
+    'Worker reference': `PR #10 exact head ${oldHead}`
+  }, 'Issue');
+  const pr = pullRequest(10, [9], {headRefOid: '2'.repeat(40)});
+  const result = buildDispatch(
+    snapshot([issue], [pr]),
+    {items: [rawItem(issue)]},
+    [{number: 10, labels: []}],
+    {}
+  );
+  assert.equal(result.staleExactHead.length, 1);
+  assert.deepEqual(result.staleExactHead[0].recordedHeads, [oldHead]);
+  assert.ok(exactHeads(issue.fields['Worker reference']).includes(oldHead));
+});
+
+test('sorts ready work by priority and ready timestamp', () => {
+  const low = projectItem(1, {
+    Status: 'Review', Execution: 'Ready', Executor: 'ChatGPT', Priority: 'Low',
+    'Ready timestamp': '2026-08-01T00:00:00Z'
+  });
+  const highLate = projectItem(3, {
+    Status: 'Review', Execution: 'Ready', Executor: 'ChatGPT', Priority: 'High',
+    'Ready timestamp': '2026-08-02T00:00:00Z'
+  });
+  const highEarly = projectItem(2, {
+    Status: 'Review', Execution: 'Ready', Executor: 'ChatGPT', Priority: 'High',
+    'Ready timestamp': '2026-08-01T00:00:00Z'
+  });
+  const result = buildDispatch(
+    snapshot([low, highLate, highEarly]),
+    {items: [rawItem(low), rawItem(highLate), rawItem(highEarly)]},
+    [],
+    {}
+  );
+  assert.deepEqual(result.readyByExecutor.ChatGPT.map(item => item.number), [2, 3, 1]);
+});

--- a/.github/scripts/delivery-dispatch-view.test.js
+++ b/.github/scripts/delivery-dispatch-view.test.js
@@ -2,7 +2,13 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const {buildDispatch, canonicalIdentity, exactHeads} = require('./delivery-dispatch-view');
+const {
+  buildDispatch,
+  canonicalIdentity,
+  exactHeads,
+  leaseUntilFrom,
+  staleOwnershipReason
+} = require('./delivery-dispatch-view');
 
 function projectItem(number, fields = {}, type = 'Issue') {
   return {
@@ -49,12 +55,8 @@ function rawItem(item, assignees = []) {
   return {id: item.projectItemId, assignees: assignees.map(login => ({login}))};
 }
 
-function snapshot(items, pullRequests = []) {
-  return {
-    generatedAt: '2026-08-03T00:00:00Z',
-    items,
-    pullRequests
-  };
+function snapshot(items, pullRequests = [], generatedAt = '2026-08-03T00:00:00Z') {
+  return {generatedAt, items, pullRequests};
 }
 
 test('canonicalizes PRs without asking the dispatcher model', () => {
@@ -69,36 +71,77 @@ test('canonicalizes PRs without asking the dispatcher model', () => {
   });
 });
 
-test('groups ready and in-progress work and detects route mismatch', () => {
+test('groups active and stale in-progress work and detects route mismatch', () => {
   const ready = projectItem(2, {
     Status: 'Review', Execution: 'Ready', Executor: 'ChatGPT', Priority: 'High'
   });
-  const owned = projectItem(3, {
+  const stale = projectItem(3, {
     Status: 'Implementation', Execution: 'In progress', Executor: 'Codex Cloud',
-    'Worker reference': 'task cloud-3; nextObservationAt=2026-08-02T23:30:00Z'
+    'Worker reference': 'task=cloud-3; claimToken=g3; leaseUntil=2026-08-02T23:30:00Z'
+  });
+  const active = projectItem(4, {
+    Status: 'Implementation', Execution: 'In progress', Executor: 'Codex Cloud',
+    'Worker reference': 'task=cloud-4; claimToken=g4; leaseUntil=2026-08-03T01:00:00Z'
   });
   const result = buildDispatch(
-    snapshot([ready, owned]),
-    {items: [rawItem(ready, ['bedrin-codex-local']), rawItem(owned, ['bedrin-codex-cloud'])]},
+    snapshot([ready, stale, active]),
+    {items: [
+      rawItem(ready, ['bedrin-codex-local']),
+      rawItem(stale, ['bedrin-codex-cloud']),
+      rawItem(active, ['bedrin-codex-cloud'])
+    ]},
     [],
     {executorAssignees: {ChatGPT: 'bedrin-gpt', 'Codex Cloud': 'bedrin-codex-cloud'}}
   );
 
   assert.deepEqual(result.readyByExecutor.ChatGPT.map(item => item.number), [2]);
-  assert.deepEqual(result.dueInProgressByExecutor['Codex Cloud'].map(item => item.number), [3]);
+  assert.deepEqual(result.activeInProgressByExecutor['Codex Cloud'].map(item => item.number), [4]);
+  assert.deepEqual(result.staleInProgressByExecutor['Codex Cloud'].map(item => item.number), [3]);
+  assert.equal(result.staleInProgressByExecutor['Codex Cloud'][0].staleReason, 'lease-expired');
   assert.deepEqual(result.routeMismatches.map(item => item.number), [2]);
   assert.equal(result.orderedCandidates[0].kind, 'route-mismatch');
+  assert.equal(result.orderedCandidates[1].kind, 'stale-owned-recovery');
 });
 
-test('does not select an in-progress observation before its durable due time', () => {
+test('ignores normal in-progress ownership until its lease expires', () => {
   const owned = projectItem(3, {
     Status: 'Implementation', Execution: 'In progress', Executor: 'Codex Cloud',
-    'Worker reference': 'nextObservationAt=2026-08-03T00:15:00Z'
+    'Worker reference': 'worker=cloud-3; leaseUntil=2026-08-03T00:15:00Z'
   });
   const result = buildDispatch(snapshot([owned]), {items: [rawItem(owned)]}, [], {});
   assert.equal(result.inProgressByExecutor['Codex Cloud'].length, 1);
-  assert.equal(result.dueInProgressByExecutor['Codex Cloud'], undefined);
+  assert.equal(result.activeInProgressByExecutor['Codex Cloud'].length, 1);
+  assert.equal(result.staleInProgressByExecutor['Codex Cloud'], undefined);
   assert.equal(result.orderedCandidates.length, 0);
+});
+
+test('treats missing or invalid lease evidence as stale recovery', () => {
+  const missingReference = projectItem(5, {
+    Status: 'Implementation', Execution: 'In progress', Executor: 'ChatGPT'
+  });
+  const missingLease = projectItem(6, {
+    Status: 'Implementation', Execution: 'In progress', Executor: 'ChatGPT',
+    'Worker reference': 'worker=chat-6; claimToken=g6'
+  });
+  const invalidLease = projectItem(7, {
+    Status: 'Implementation', Execution: 'In progress', Executor: 'ChatGPT',
+    'Worker reference': 'worker=chat-7; leaseUntil=tomorrowish'
+  });
+  const result = buildDispatch(
+    snapshot([missingReference, missingLease, invalidLease]),
+    {items: [rawItem(missingReference), rawItem(missingLease), rawItem(invalidLease)]},
+    [],
+    {}
+  );
+  assert.deepEqual(
+    result.staleInProgressByExecutor.ChatGPT.map(item => item.staleReason),
+    ['missing-worker-reference', 'missing-lease', 'invalid-lease']
+  );
+  assert.deepEqual(result.orderedCandidates.map(value => value.kind), [
+    'stale-owned-recovery', 'stale-owned-recovery', 'stale-owned-recovery'
+  ]);
+  assert.equal(leaseUntilFrom('{"leaseUntil":"2026-08-03T02:00:00Z"}'), '2026-08-03T02:00:00Z');
+  assert.equal(staleOwnershipReason(result.staleInProgressByExecutor.ChatGPT[1], Date.parse('2026-08-03T00:00:00Z')), 'missing-lease');
 });
 
 test('projects PR intake, duplicate representation, and conflicts', () => {

--- a/.github/scripts/delivery-dispatch-view.test.js
+++ b/.github/scripts/delivery-dispatch-view.test.js
@@ -118,7 +118,7 @@ test('projects PR intake, duplicate representation, and conflicts', () => {
   assert.equal(result.orderedCandidates[0].kind, 'conflicting-pr');
 });
 
-test('keeps fork and Dependabot PRs out of direct conflict continuation', () => {
+test('keeps fork and Dependabot conflicts visible without direct branch adoption', () => {
   const fork = pullRequest(11, [], {repositoryOwnership: 'fork', mergeable: 'CONFLICTING'});
   const dependabot = pullRequest(12, [], {author: 'dependabot[bot]', mergeable: 'CONFLICTING'});
   const result = buildDispatch(
@@ -128,7 +128,12 @@ test('keeps fork and Dependabot PRs out of direct conflict continuation', () => 
     {}
   );
   assert.equal(result.pullRequests.conflicting.length, 0);
-  assert.deepEqual(result.pullRequests.intake.map(value => value.number), [11, 12]);
+  assert.deepEqual(result.pullRequests.managedConflicts.map(value => value.number), [11, 12]);
+  assert.deepEqual(result.pullRequests.managedConflicts.map(value => value.conflictMode), [
+    'contributor-feedback', 'dependabot-operation'
+  ]);
+  assert.equal(result.pullRequests.intake.length, 0);
+  assert.deepEqual(result.orderedCandidates.map(value => value.kind), ['managed-pr-conflict', 'managed-pr-conflict']);
 });
 
 test('does not treat a human dependency PR as Dependabot', () => {
@@ -143,11 +148,11 @@ test('does not treat a human dependency PR as Dependabot', () => {
   assert.equal(result.pullRequests.conflicting[0].isDependabot, false);
 });
 
-test('does not steal an explicit Local Codex correction route as PR intake', () => {
+test('does not steal an explicit Local Codex correction route as intake or conflict handling', () => {
   const canonicalPr = projectItem(14, {
     Status: 'Implementation', Execution: 'Ready', Executor: 'Local Codex', Implementer: 'Local Codex'
   }, 'PullRequest');
-  const pr = pullRequest(14);
+  const pr = pullRequest(14, [], {mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY'});
   const result = buildDispatch(
     snapshot([canonicalPr], [pr]),
     {items: [rawItem(canonicalPr)]},
@@ -155,6 +160,8 @@ test('does not steal an explicit Local Codex correction route as PR intake', () 
     {}
   );
   assert.equal(result.pullRequests.intake.length, 0);
+  assert.equal(result.pullRequests.conflicting.length, 0);
+  assert.equal(result.pullRequests.managedConflicts.length, 0);
   assert.equal(result.orderedCandidates.length, 0);
 });
 

--- a/.github/scripts/delivery-dispatch-view.test.js
+++ b/.github/scripts/delivery-dispatch-view.test.js
@@ -131,6 +131,33 @@ test('keeps fork and Dependabot PRs out of direct conflict continuation', () => 
   assert.deepEqual(result.pullRequests.intake.map(value => value.number), [11, 12]);
 });
 
+test('does not treat a human dependency PR as Dependabot', () => {
+  const human = pullRequest(13, [], {author: 'human', mergeable: 'CONFLICTING'});
+  const result = buildDispatch(
+    snapshot([], [human]),
+    {items: []},
+    [{number: 13, labels: [{name: 'dependencies'}]}],
+    {}
+  );
+  assert.equal(result.pullRequests.conflicting.length, 1);
+  assert.equal(result.pullRequests.conflicting[0].isDependabot, false);
+});
+
+test('does not steal an explicit Local Codex correction route as PR intake', () => {
+  const canonicalPr = projectItem(14, {
+    Status: 'Implementation', Execution: 'Ready', Executor: 'Local Codex', Implementer: 'Local Codex'
+  }, 'PullRequest');
+  const pr = pullRequest(14);
+  const result = buildDispatch(
+    snapshot([canonicalPr], [pr]),
+    {items: [rawItem(canonicalPr)]},
+    [{number: 14, labels: []}],
+    {}
+  );
+  assert.equal(result.pullRequests.intake.length, 0);
+  assert.equal(result.orderedCandidates.length, 0);
+});
+
 test('detects downstream lifecycle evidence pinned to an older exact head', () => {
   const oldHead = '1'.repeat(40);
   const issue = projectItem(9, {

--- a/.github/scripts/delivery-policy.test.js
+++ b/.github/scripts/delivery-policy.test.js
@@ -20,7 +20,7 @@ test('ChatGPT dispatcher scans and canonicalizes every develop pull request', ()
   assert.match(prompt, /No formal closing issue: the non-draft PR itself is the canonical lifecycle item/i);
   assert.match(prompt, /Multiple formal closing issues: the non-draft PR is the canonical coordination item/i);
   assert.match(prompt, /Draft PR: do not start Review/i);
-  assert.match(prompt, /regardless of author, label, bot\/provider, branch creator/i);
+  assert.match(prompt, /regardless of author,\s*label, bot\/provider, or branch creator/i);
   assert.doesNotMatch(prompt, /Find eligible open sniffy\/sniffy dependency PRs missing/i);
 });
 
@@ -37,28 +37,51 @@ test('profile makes universal intake and existing-PR routing explicit', () => {
   assert.match(profile, /Local Codex:[\s\S]*maxConcurrentWorkers:\s*1/);
 });
 
-test('ChatGPT supervises Ready Codex Cloud dispatch instead of stranding it', () => {
+test('ChatGPT supervises Ready Codex Cloud dispatch without polling healthy workers', () => {
   const prompt = read('.chatgpt/scheduled-task-prompt.md');
   const profile = read('docs/ai-delivery/profile.yml');
   const eventLoop = read('docs/ai-delivery/event-loop.md');
   const supervision = read('docs/ai-delivery/supervision.md');
 
   assert.match(profile, /Codex Cloud:[\s\S]*dispatchMode:\s*supervised[\s\S]*dispatchOwner:\s*ChatGPT/);
-  assert.match(prompt, /supervised Codex Cloud dispatch:[\s\S]*Status = Implementation[\s\S]*Execution = Ready[\s\S]*Executor = Codex Cloud/i);
-  assert.match(prompt, /Codex Cloud does not poll Project 2/i);
-  assert.match(prompt, /post one\s+exact implementation trigger[\s\S]*durable acknowledgement/i);
-  assert.match(prompt, /If the trigger was\s+not submitted or was definitively rejected, release to Ready/i);
-  assert.match(prompt, /submission succeeded but acknowledgement is uncertain[\s\S]*never redispatch that generation/i);
-  assert.match(prompt, /first 15-minute observation point/i);
-  assert.match(prompt, /ChatGPT-supervised Codex Cloud `Execution = In progress` items/i);
-  assert.match(eventLoop, /dispatchMode: supervised[\s\S]*ChatGPT as\s+its dispatch owner/i);
-  assert.match(supervision, /claim while\s+preserving Executor[\s\S]*release the provisional claim to Ready/i);
+  assert.match(prompt, /supervised Codex Cloud dispatch[\s\S]*Status = Implementation[\s\S]*Execution = Ready[\s\S]*Executor = Codex Cloud/i);
+  assert.match(prompt, /Codex Cloud\s+does not poll Project 2/i);
+  assert.match(prompt, /post one exact implementation trigger[\s\S]*durable acknowledgement/i);
+  assert.match(prompt, /trigger was not submitted or was definitively rejected, release to Ready/i);
+  assert.match(prompt, /submission succeeded but acknowledgement is uncertain[\s\S]*never redispatch it/i);
+  assert.match(prompt, /concrete generation plus lease/i);
+  assert.match(eventLoop, /dispatchMode: supervised[\s\S]*ChatGPT as its dispatch owner/i);
+  assert.match(supervision, /claim while preserving Executor/i);
+  assert.match(supervision, /release the provisional claim to Ready/i);
+  assert.match(supervision, /does \*\*not\*\* poll healthy workers every 15 minutes/i);
+});
+
+test('lease-based stale recovery replaces periodic worker observation', () => {
+  const profile = read('docs/ai-delivery/profile.yml');
+  const runtime = read('docs/ai-delivery/runtime-contract.md');
+  const prompt = read('.chatgpt/scheduled-task-prompt.md');
+  const localDispatcher = read('.codex/local/scheduled-task-prompt.md');
+  const localWorker = read('.codex/local/worker-task-prompt.md');
+  const projection = read('.github/scripts/delivery-dispatch-view.js');
+  const combined = [profile, runtime, prompt, localDispatcher, localWorker, projection].join('\n');
+
+  assert.match(profile, /mode:\s*lease-based-stale-recovery/);
+  assert.match(profile, /schedulerChecksOnlyExpiredOrInvalidLease:\s*true/);
+  assert.match(profile, /workerMayRenewBeforeExpiry:\s*true/);
+  assert.match(runtime, /Normal `In progress` ownership is not polled/i);
+  assert.match(prompt, /valid future `leaseUntil` is invisible to this tick/i);
+  assert.match(localDispatcher, /valid future `leaseUntil` consumes capacity and is ignored/i);
+  assert.match(localWorker, /perform the guarded handoff\s+itself/i);
+  assert.match(localWorker, /renew the same\s+claim\/generation before expiry/i);
+  assert.match(projection, /stale-owned-recovery/);
+  assert.match(projection, /activeInProgressByExecutor/);
+  assert.match(projection, /staleInProgressByExecutor/);
+  assert.doesNotMatch(combined, /nextObservationAt|dueInProgress|due-owned-observation|second-15-minute|15\/15\/hourly/i);
 });
 
 test('configured Ready routes with the wrong assignee require reconciliation', () => {
   const prompt = read('.chatgpt/scheduled-task-prompt.md');
   const eventLoop = read('docs/ai-delivery/event-loop.md');
-
   assert.match(prompt, /unclaimable `Execution = Ready` route[\s\S]*Assignee belongs to a different executor pool/i);
   assert.match(prompt, /Never silently filter out that mismatch/i);
   assert.match(eventLoop, /Ready route whose Assignee belongs to another executor pool is a supervisory reconciliation obligation/i);
@@ -71,7 +94,7 @@ test('Local Codex can adopt an explicitly routed same-repository PR without dupl
   assert.match(worker, /adopted-continuation/);
   assert.match(worker, /reuse the exact same-repository open PR branch/i);
   assert.match(worker, /never adopt a fork or Dependabot branch/i);
-  assert.match(worker, /Do\s+not create a fresh branch or duplicate PR/i);
+  assert.match(worker, /do not create a fresh branch or duplicate PR/i);
   assert.match(dispatcher, /existing same-repository PR may be an adopted continuation/i);
   assert.match(dispatcher, /Reuse the exact branch and PR/i);
   assert.match(dispatcher, /Do not adopt fork or Dependabot branches/i);
@@ -93,7 +116,7 @@ test('Cloud does not turn arbitrary existing PRs into duplicate fresh work', () 
   const cloud = read('docs/ai-delivery/executors/codex-cloud.md');
   assert.match(cloud, /Do not route an arbitrary existing PR/i);
   assert.match(cloud, /Cloud must not open a duplicate branch\/PR/i);
-  assert.match(cloud, /existing-PR continuation normally goes to Local Codex/i);
+  assert.match(cloud, /existing-PR continuation\s+normally goes to Local Codex/i);
 });
 
 test('delivery executors require readable control comments with authoritative marked JSON', () => {
@@ -150,7 +173,6 @@ test('every implementation executor publishes a non-draft exact-head PR before R
   const worker = read('.codex/local/worker-task-prompt.md');
   const control = read('docs/ai-delivery/control-plane.md');
   const workflow = read('.github/workflows/delivery-control.yml');
-
   assert.match(prompt, /reviewPullRequest\.number.*reviewPullRequest\.head/is);
   assert.match(worker, /reviewPullRequest\.number.*reviewPullRequest\.head/is);
   assert.match(control, /reviewPullRequest/);
@@ -169,8 +191,8 @@ test('blocking Review always publishes feedback and completes a same-tick durabl
 
   assert.match(prompt, /reviewer is independent[\s\S]*comprehensive REQUEST_CHANGES/i);
   assert.match(prompt, /reviewer is the PR author[\s\S]*ordinary\s+PR\s+comment[\s\S]*identity limitation/i);
-  assert.match(prompt, /In either case, route the canonical item durably in this same tick/i);
-  assert.match(prompt, /never leave the reviewed exact head in Review \/ Ready \/ ChatGPT/i);
+  assert.match(prompt, /In either case route the canonical item durably in this same tick/i);
+  assert.match(prompt, /never leave the\s+reviewed exact head in Review \/ Ready \/ ChatGPT/i);
   assert.match(prompt, /do not wait for the formal-review return adapter/i);
   assert.match(prompt, /technically acceptable[\s\S]*Verification or Approval \/ Ready \/ Human/i);
 
@@ -198,11 +220,11 @@ test('Local Codex uses one bounded normalized Project snapshot per tick', () => 
   assert.match(dispatcher, /project-queue-snapshot\.sh` exactly once/i);
   assert.match(dispatcher, /only normal full-Project query/i);
   assert.match(dispatcher, /Do not run `gh project item-list`/i);
-  assert.match(dispatcher, /Do not switch to another\s+connector, combine stale snapshots/i);
-  assert.match(dispatcher, /Compute available capacity from `executors\.Local Codex\.maxConcurrentWorkers`[\s\S]*`ownedInProgress`/i);
-  assert.match(dispatcher, /Do not call `List projects`[\s\S]*provider-wide inventory on\s+the normal `Ready` claim path/i);
-  assert.match(dispatcher, /inventory is allowed only to recover one selected `In progress` item[\s\S]*claim token and generation/i);
-  assert.match(dispatcher, /Do not read the complete discussion, proof matrix, review submissions,[\s\S]*the lifecycle worker owns those reads/i);
+  assert.match(dispatcher, /do not switch to another connector, combine stale snapshots/i);
+  assert.match(dispatcher, /Compute available capacity[\s\S]*`executors\.Local Codex\.maxConcurrentWorkers`[\s\S]*`ownedInProgress`/i);
+  assert.match(dispatcher, /Do not call `List projects`[\s\S]*provider-wide inventory on the normal Ready path/i);
+  assert.match(dispatcher, /Targeted provider inventory is allowed only for that selected recovery[\s\S]*claim token\/generation/i);
+  assert.match(dispatcher, /Do not read the\s+complete discussion, proof matrix, review submissions, review threads, or CI before claim[\s\S]*lifecycle worker owns those reads/i);
   assert.equal((helper.match(/^\s*if ! gh project item-list\b/gm) || []).length, 1);
   assert.match(helper, /exit 75/);
 
@@ -212,47 +234,36 @@ test('Local Codex uses one bounded normalized Project snapshot per tick', () => 
     totalCount: 3,
     items: [
       {
-        id: 'READY',
-        title: 'Ready implementation',
+        id: 'READY', title: 'Ready implementation',
         content: {type: 'Issue', number: 762, url: 'https://github.com/sniffy/sniffy/issues/762', repository: 'sniffy/sniffy'},
-        status: 'Implementation',
-        execution: 'Ready',
-        executor: 'Local Codex',
-        implementer: 'Local Codex',
-        assignees: [],
-        priority: 'High'
+        status: 'Implementation', execution: 'Ready', executor: 'Local Codex', implementer: 'Local Codex',
+        assignees: [], priority: 'High'
       },
       {
-        id: 'OWNED',
-        title: 'Owned verification',
+        id: 'OWNED', title: 'Owned verification',
         content: {type: 'PullRequest', number: 700, url: 'https://github.com/sniffy/sniffy/pull/700', repository: {nameWithOwner: 'sniffy/sniffy'}},
-        status: 'Verification',
-        execution: 'In progress',
-        executor: 'Local Codex',
-        assignees: [{login: 'bedrin-codex-local'}],
-        'worker reference': 'worker-700'
+        status: 'Verification', execution: 'In progress', executor: 'Local Codex',
+        assignees: [{login: 'bedrin-codex-local'}], 'worker reference': 'worker-700; leaseUntil=2999-01-01T00:00:00Z'
       },
       {
-        id: 'OTHER',
-        title: 'ChatGPT work',
+        id: 'OTHER', title: 'ChatGPT work',
         content: {type: 'Issue', number: 701, url: 'https://github.com/sniffy/sniffy/issues/701', repository: 'sniffy/sniffy'},
-        status: 'Review',
-        execution: 'Ready',
-        executor: 'ChatGPT'
+        status: 'Review', execution: 'Ready', executor: 'ChatGPT'
       }
     ]
   }));
 
   try {
-    const output = execFileSync('bash', [path.join(root, '.codex/local/project-queue-snapshot.sh'), '--input', fixture], {
-      encoding: 'utf8'
-    });
+    const output = execFileSync('bash', [path.join(root, '.codex/local/project-queue-snapshot.sh'), '--input', fixture], {encoding: 'utf8'});
     const snapshot = JSON.parse(output);
     assert.equal(snapshot.totalCount, 3);
     assert.equal(snapshot.repositoryItemCount, 3);
     assert.deepEqual(snapshot.ownedInProgress.map(item => item.number), [700]);
     assert.deepEqual(snapshot.readyCandidates.map(item => item.number), [762]);
     assert.deepEqual(snapshot.ownedInProgress[0].assignees, ['bedrin-codex-local']);
+    assert.equal(snapshot.ownedInProgress[0].leaseUntil, '2999-01-01T00:00:00Z');
+    assert.deepEqual(snapshot.activeOwnedInProgress.map(item => item.number), [700]);
+    assert.deepEqual(snapshot.staleOwnedInProgress, []);
   } finally {
     fs.rmSync(directory, {recursive: true, force: true});
   }

--- a/.github/scripts/delivery-runtime-budget.test.js
+++ b/.github/scripts/delivery-runtime-budget.test.js
@@ -77,3 +77,35 @@ test('generated status artifact includes deterministic dispatch projection', () 
   assert.match(workflow, /--executor-assignees/);
   assert.match(workflow, /project-2-status\.json/);
 });
+
+test('worker supervision is lease-based stale recovery rather than periodic polling', () => {
+  const profile = read('docs/ai-delivery/profile.yml');
+  const runtime = read('docs/ai-delivery/runtime-contract.md');
+  const chat = read('.chatgpt/scheduled-task-prompt.md');
+  const dispatcher = read('.codex/local/scheduled-task-prompt.md');
+  const worker = read('.codex/local/worker-task-prompt.md');
+  const projection = read('.github/scripts/delivery-dispatch-view.js');
+  const combined = [profile, runtime, chat, dispatcher, worker, projection].join('\n');
+
+  assert.match(profile, /mode:\s*lease-based-stale-recovery/);
+  assert.match(profile, /schedulerChecksOnlyExpiredOrInvalidLease:\s*true/);
+  assert.match(profile, /workerMayRenewBeforeExpiry:\s*true/);
+  assert.match(profile, /leaseMinutes:[\s\S]*Codex Cloud:\s*120[\s\S]*Local Codex:\s*240/);
+  assert.match(runtime, /Normal `In progress` ownership is not polled/i);
+  assert.match(runtime, /missing, invalid, or expired lease/i);
+  assert.match(chat, /valid future `leaseUntil` is invisible to this tick/i);
+  assert.match(dispatcher, /valid future `leaseUntil` consumes capacity and is ignored/i);
+  assert.match(worker, /renew the same\s+claim\/generation before expiry/i);
+  assert.match(projection, /stale-owned-recovery/);
+  assert.match(projection, /activeInProgressByExecutor/);
+  assert.match(projection, /staleInProgressByExecutor/);
+
+  assert.doesNotMatch(combined, /nextObservationAt/);
+  assert.doesNotMatch(combined, /dueInProgress/);
+  assert.doesNotMatch(combined, /due-owned-observation/);
+  assert.doesNotMatch(combined, /initialObservationMinutes/);
+  assert.doesNotMatch(combined, /secondObservationMinutes/);
+  assert.doesNotMatch(combined, /incompleteObservationMinutes/);
+  assert.doesNotMatch(combined, /15\/15\/hourly/i);
+  assert.doesNotMatch(combined, /second-15-minute/i);
+});

--- a/.github/scripts/delivery-runtime-budget.test.js
+++ b/.github/scripts/delivery-runtime-budget.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.join(__dirname, '../..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function bytes(relativePath) {
+  return Buffer.byteLength(read(relativePath), 'utf8');
+}
+
+test('recurring prompts stay within reviewed byte budgets', () => {
+  assert.ok(bytes('.chatgpt/scheduled-task-prompt.md') <= 10000, 'ChatGPT scheduler prompt exceeded 10 KB');
+  assert.ok(bytes('.chatgpt/status-snapshot-instructions.md') <= 6500, 'snapshot supplement exceeded 6.5 KB');
+  assert.ok(bytes('.codex/local/scheduled-task-prompt.md') <= 8500, 'Local Codex dispatcher prompt exceeded 8.5 KB');
+  assert.ok(bytes('.codex/local/worker-task-prompt.md') <= 9500, 'Local Codex worker prompt exceeded 9.5 KB');
+});
+
+test('ChatGPT recurring scheduler is Chat, not Work, and reads compact policy', () => {
+  const prompt = read('.chatgpt/scheduled-task-prompt.md');
+  const profile = read('docs/ai-delivery/profile.yml');
+  assert.match(prompt, /Create this scheduler in \*\*Chat\*\*, not \*\*Work\*\*/);
+  assert.match(prompt, /runtime-contract\.md/);
+  assert.match(prompt, /dispatch\.orderedCandidates/);
+  assert.doesNotMatch(prompt, /docs\/ai-delivery\/\{README,profile,lifecycle,control-plane/i);
+  assert.match(profile, /ChatGPT:[\s\S]*surface:\s*Chat[\s\S]*forbiddenSurface:\s*Work/);
+});
+
+test('Local Codex uses Luna dispatcher, Terra worker, and explicit Sol escalation', () => {
+  const profile = read('docs/ai-delivery/profile.yml');
+  const dispatcher = read('.codex/local/scheduled-task-prompt.md');
+  const worker = read('.codex/local/worker-task-prompt.md');
+  const runIssue = read('.codex/local/run-issue.sh');
+
+  assert.match(profile, /dispatcherModel:\s*gpt-5\.6-luna/);
+  assert.match(profile, /dispatcherReasoning:\s*low/);
+  assert.match(profile, /workerModel:\s*gpt-5\.6-terra/);
+  assert.match(profile, /workerReasoning:\s*medium/);
+  assert.match(profile, /escalationModel:\s*gpt-5\.6-sol/);
+  assert.match(profile, /escalationReasoning:\s*high/);
+  assert.match(dispatcher, /gpt-5\.6-luna.*low/i);
+  assert.match(dispatcher, /gpt-5\.6-terra.*medium/is);
+  assert.match(worker, /gpt-5\.6-terra.*medium/is);
+  assert.match(runIssue, /CODEX_MODEL:-gpt-5\.6-terra/);
+  assert.match(runIssue, /CODEX_REASONING_EFFORT:-medium/);
+  assert.doesNotMatch(runIssue, /CODEX_MODEL:-gpt-5\.6-sol/);
+  assert.doesNotMatch(runIssue, /CODEX_REASONING_EFFORT:-xhigh/);
+});
+
+test('runtime telemetry is explicit and never fabricates token counters', () => {
+  for (const file of [
+    'docs/ai-delivery/runtime-contract.md',
+    '.chatgpt/scheduled-task-prompt.md',
+    '.codex/local/scheduled-task-prompt.md',
+    '.codex/local/worker-task-prompt.md',
+    '.codex/local/run-issue.sh'
+  ]) {
+    const content = read(file);
+    assert.match(content, /startedAt/);
+    assert.match(content, /durationSeconds/);
+    assert.match(content, /usageSource/);
+    assert.match(content, /token/i);
+    assert.match(content, /null|unavailable/i);
+    assert.match(content, /never (?:invent|fabricate)/i);
+  }
+});
+
+test('generated status artifact includes deterministic dispatch projection', () => {
+  const workflow = read('.github/workflows/delivery-status.yml');
+  assert.match(workflow, /delivery-dispatch-view\.js/);
+  assert.match(workflow, /--executor-assignees/);
+  assert.match(workflow, /project-2-status\.json/);
+});

--- a/.github/scripts/delivery-status-checkout-policy.test.js
+++ b/.github/scripts/delivery-status-checkout-policy.test.js
@@ -28,6 +28,9 @@ test('validation checkout materializes the exact focused inputs without credenti
   assert.deepEqual(sparsePaths('validate'), [
     '.chatgpt/scheduled-task-prompt.md',
     '.chatgpt/status-snapshot-instructions.md',
+    '.codex/local/scheduled-task-prompt.md',
+    '.codex/local/worker-task-prompt.md',
+    '.codex/local/run-issue.sh',
     '.github/scripts/delivery-status.js',
     '.github/scripts/delivery-status.test.js',
     '.github/scripts/delivery-status-policy.test.js',
@@ -35,15 +38,20 @@ test('validation checkout materializes the exact focused inputs without credenti
     '.github/scripts/delivery-status-runner-policy.test.js',
     '.github/scripts/delivery-status-mergeability.js',
     '.github/scripts/delivery-status-mergeability.test.js',
+    '.github/scripts/delivery-dispatch-view.js',
+    '.github/scripts/delivery-dispatch-view.test.js',
+    '.github/scripts/delivery-runtime-budget.test.js',
     '.github/workflows/delivery-status.yml',
     'docs/ai-delivery/README.md',
     'docs/ai-delivery/profile.yml',
+    'docs/ai-delivery/runtime-contract.md',
+    'docs/ai-delivery/instruction-audit.md',
     'docs/ai-delivery/status-snapshot.md',
     'docs/ai-delivery/status-workflow-optimization.md'
   ]);
 });
 
-test('trusted publication checks out only its two scripts from develop without credentials', () => {
+test('trusted publication checks out only its three scripts from develop without credentials', () => {
   const publish = jobBlock('publish');
   assert.match(publish, /ref:\s*develop/);
   assert.doesNotMatch(publish, /filter:/);
@@ -51,6 +59,7 @@ test('trusted publication checks out only its two scripts from develop without c
   assert.match(publish, /persist-credentials:\s*false/);
   assert.deepEqual(sparsePaths('publish'), [
     '.github/scripts/delivery-status.js',
-    '.github/scripts/delivery-status-mergeability.js'
+    '.github/scripts/delivery-status-mergeability.js',
+    '.github/scripts/delivery-dispatch-view.js'
   ]);
 });

--- a/.github/scripts/delivery-status-policy.test.js
+++ b/.github/scripts/delivery-status-policy.test.js
@@ -11,24 +11,33 @@ function read(relativePath) {
   return fs.readFileSync(path.join(root, relativePath), 'utf8');
 }
 
+function chatRuntime() {
+  return [
+    read('.chatgpt/scheduled-task-prompt.md'),
+    read('.chatgpt/status-snapshot-instructions.md'),
+    read('docs/ai-delivery/runtime-contract.md')
+  ].join('\n');
+}
+
 test('ChatGPT scheduled ticks require the labeled status artifact fallback', () => {
-  const prompt = read('.chatgpt/scheduled-task-prompt.md');
-  assert.match(prompt, /\.chatgpt\/status-snapshot-instructions\.md/);
-  assert.match(prompt, /newest open non-PR issue labeled ai-delivery-status/i);
-  assert.match(prompt, /download the artifact by\s+numeric artifact ID/is);
-  assert.match(prompt, /read project-2-status\.json/i);
-  assert.match(prompt, /missing, expired, inaccessible, malformed, mismatched, or stale snapshot/i);
-  assert.match(prompt, /\/ai-delivery-status refresh/);
-  assert.match(prompt, /terminal \+1 reaction/i);
-  assert.match(prompt, /refreshRequest\.commentId/i);
+  const policy = chatRuntime();
+  assert.match(policy, /\.chatgpt\/status-snapshot-instructions\.md/);
+  assert.match(policy, /newest open non-PR issue.*labelled `ai-delivery-status`/is);
+  assert.match(policy, /download that artifact by numeric ID/is);
+  assert.match(policy, /project-2-status\.json/i);
+  assert.match(policy, /malformed, inconsistent, incomplete, stale, or inaccessible/i);
+  assert.match(policy, /\/ai-delivery-status refresh/);
+  assert.match(policy, /terminal reaction/i);
+  assert.match(policy, /refresh comment provenance/i);
 });
 
 test('snapshot-backed commands retain live compare-and-set semantics', () => {
-  const prompt = read('.chatgpt/scheduled-task-prompt.md');
-  assert.match(prompt, /snapshot is an eventually consistent selection aid, not a mutation ledger or lease/i);
-  assert.match(prompt, /Every Project mutation still goes through delivery-control\/v1/i);
-  assert.match(prompt, /confused reaction means the snapshot lost a race/i);
-  assert.match(prompt, /snapshot generated after the preceding successful command/i);
+  const policy = chatRuntime();
+  assert.match(policy, /materialized selection view/i);
+  assert.match(policy, /Every Project claim and\s+handoff uses the guarded `delivery-control\/v1` protocol/i);
+  assert.match(policy, /A conflict means another actor\s+won or state changed/i);
+  assert.match(policy, /snapshot generated after the preceding successful command/i);
+  assert.match(policy, /live-read only the selected candidate/i);
 });
 
 test('profile fixes the status protocol, label, artifact and freshness contract', () => {
@@ -42,6 +51,7 @@ test('profile fixes the status protocol, label, artifact and freshness contract'
   assert.match(profile, /refreshCommand:\s*"\/ai-delivery-status refresh"/);
   assert.match(profile, /refreshTimeoutSeconds:\s*120/);
   assert.match(profile, /refreshActors:\s*\[bedrin, bedrin-gpt\]/);
+  assert.match(profile, /dispatchProjection:\s*true/);
 });
 
 test('status documentation preserves the read-only mutation boundary', () => {

--- a/.github/workflows/delivery-status.yml
+++ b/.github/workflows/delivery-status.yml
@@ -12,9 +12,14 @@ on:
       - .github/scripts/delivery-status-runner-policy.test.js
       - .github/scripts/delivery-status-mergeability.js
       - .github/scripts/delivery-status-mergeability.test.js
+      - .github/scripts/delivery-dispatch-view.js
+      - .github/scripts/delivery-dispatch-view.test.js
+      - .github/scripts/delivery-runtime-budget.test.js
       - .github/workflows/delivery-status.yml
       - docs/ai-delivery/README.md
       - docs/ai-delivery/profile.yml
+      - docs/ai-delivery/runtime-contract.md
+      - docs/ai-delivery/instruction-audit.md
       - docs/ai-delivery/status-snapshot.md
       - docs/ai-delivery/status-workflow-optimization.md
       - docs/ai-delivery/ubuntu-slim-capability-experiment.md
@@ -42,6 +47,9 @@ jobs:
           sparse-checkout: |
             .chatgpt/scheduled-task-prompt.md
             .chatgpt/status-snapshot-instructions.md
+            .codex/local/scheduled-task-prompt.md
+            .codex/local/worker-task-prompt.md
+            .codex/local/run-issue.sh
             .github/scripts/delivery-status.js
             .github/scripts/delivery-status.test.js
             .github/scripts/delivery-status-policy.test.js
@@ -49,9 +57,14 @@ jobs:
             .github/scripts/delivery-status-runner-policy.test.js
             .github/scripts/delivery-status-mergeability.js
             .github/scripts/delivery-status-mergeability.test.js
+            .github/scripts/delivery-dispatch-view.js
+            .github/scripts/delivery-dispatch-view.test.js
+            .github/scripts/delivery-runtime-budget.test.js
             .github/workflows/delivery-status.yml
             docs/ai-delivery/README.md
             docs/ai-delivery/profile.yml
+            docs/ai-delivery/runtime-contract.md
+            docs/ai-delivery/instruction-audit.md
             docs/ai-delivery/status-snapshot.md
             docs/ai-delivery/status-workflow-optimization.md
           sparse-checkout-cone-mode: false
@@ -68,12 +81,17 @@ jobs:
           node --check .github/scripts/delivery-status-runner-policy.test.js
           node --check .github/scripts/delivery-status-mergeability.js
           node --check .github/scripts/delivery-status-mergeability.test.js
+          node --check .github/scripts/delivery-dispatch-view.js
+          node --check .github/scripts/delivery-dispatch-view.test.js
+          node --check .github/scripts/delivery-runtime-budget.test.js
           node --test \
             .github/scripts/delivery-status.test.js \
             .github/scripts/delivery-status-policy.test.js \
             .github/scripts/delivery-status-checkout-policy.test.js \
             .github/scripts/delivery-status-runner-policy.test.js \
-            .github/scripts/delivery-status-mergeability.test.js
+            .github/scripts/delivery-status-mergeability.test.js \
+            .github/scripts/delivery-dispatch-view.test.js \
+            .github/scripts/delivery-runtime-budget.test.js
       - name: Parse workflow and profile YAML
         run: >-
           ruby -e 'require "yaml";
@@ -117,6 +135,7 @@ jobs:
           sparse-checkout: |
             .github/scripts/delivery-status.js
             .github/scripts/delivery-status-mergeability.js
+            .github/scripts/delivery-dispatch-view.js
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -206,6 +225,13 @@ jobs:
             status-artifact/project-2-status.json \
             status-artifact/repository-pull-requests.raw.json \
             "$RUNNER_TEMP/repository-pull-request-closing-issues.raw.json"
+
+          node .github/scripts/delivery-dispatch-view.js \
+            status-artifact/project-2-status.json \
+            status-artifact/project-items.raw.json \
+            status-artifact/repository-pull-requests.raw.json \
+            --base-branch develop \
+            --executor-assignees '{"ChatGPT":"bedrin-gpt","Codex Cloud":"bedrin-codex-cloud","Local Codex":"bedrin-codex-local","Human":"bedrin"}'
 
           {
             echo "generated_at=$generated_at"

--- a/docs/ai-delivery/README.md
+++ b/docs/ai-delivery/README.md
@@ -11,16 +11,14 @@ Dispatchers must not load this whole directory on every heartbeat.
 - [`runtime-contract.md`](runtime-contract.md) is the compact policy loaded by every dispatcher tick.
 - [`profile.yml`](profile.yml) is the Sniffy-specific declarative configuration.
 - the GitHub status workflow and local snapshot helper perform deterministic queue filtering.
-- detailed documents are loaded after candidate selection, and only by the lifecycle worker that needs them.
-- [`instruction-audit.md`](instruction-audit.md) records the effective entry points, token-cost findings, model choices, and
-  migration from prompt-driven selection to generated dispatch projections.
+- detailed documents are loaded after candidate selection, only by the lifecycle worker that needs them.
+- [`instruction-audit.md`](instruction-audit.md) records entry points, token-cost findings, model choices, and migration to generated
+  dispatch projections.
 
 The status artifact is a read-only materialized selection view. It never replaces live GitHub state or the guarded
 `delivery-control/v1` mutation protocol.
 
 ## Core model
-
-`Status` describes the kind of work; `Execution` describes whether its current action can run:
 
 ```text
 Status:    Draft -> Planning -> Implementation -> Review -> Verification (when required) -> Approval -> Done
@@ -28,18 +26,19 @@ Execution: Ready | In progress | Blocked
 ```
 
 `Implementer` and `Verifier` are planned future roles. `Executor` is the current product/runtime route. `Assignee` is the concrete
-GitHub identity or human. `Worker reference` records the active task/process/branch/PR/head/lease/next observation.
+GitHub identity or human. `Worker reference` records the active claim, generation, worker/task/process, branch/PR/head,
+`claimedAt`, and `leaseUntil`.
 
-Issues and PRs are both first-class, but one item owns lifecycle state for one published change:
+Issues and PRs are both first-class, but one item owns lifecycle state:
 
 ```text
 one formal closing issue -> issue canonical; PR is implementation evidence
 no formal closing issue  -> PR canonical
-several closing issues   -> PR canonical in Planning
+two or more issues       -> PR canonical in Planning
 ```
 
-PR authorship is provenance, not an automatic Implementer choice. Draft PRs do not enter Review. A Review handoff requires the
-open, non-draft PR at the exact published head. Merge remains Dmitry's explicit decision.
+PR authorship is provenance, not an automatic Implementer. Draft PRs do not enter Review. A Review handoff requires an open,
+ready-for-review/non-draft PR at the exact published head. Merge remains Dmitry's explicit decision.
 
 ## Control and execution planes
 
@@ -59,44 +58,49 @@ selected lifecycle worker -> exact evidence -> guarded handoff
 Dmitry accepts privileged actions and merge
 ```
 
-All executors use the same rotating technical control issue. New autonomous commands use the human-readable wrapper and marked
-JSON specified in [`control-plane.md`](control-plane.md). Target issues/PRs contain human-useful plans, reviews, proof, blockers, and
-handoffs—not field commands, leases, polling noise, or claim elections.
+All executors use the same rotating technical control issue. Autonomous commands use the human-readable Markdown wrapper, exact
+markers, lowercase `json` fence, and authoritative marked JSON specified in [`control-plane.md`](control-plane.md). Target
+issues/PRs contain human-useful plans, reviews, proof, blockers, and handoffs—not field commands, polling, or lease noise.
 
 ## Current adapters
 
 ### ChatGPT
 
-Create recurring dispatcher tasks in **Chat**, not **Work**. Use either one hourly budget task or four compact hourly tasks at
-`:00`, `:15`, `:30`, and `:45` when 15-minute queue latency is worth the usage. The exact setup prompt is
+Create recurring dispatcher tasks in **Chat**, not **Work**. Use one hourly budget task or four compact hourly tasks at `:00`,
+`:15`, `:30`, and `:45` when 15-minute queue latency is worth the usage. The exact prompt is
 [`.chatgpt/scheduled-task-prompt.md`](../../.chatgpt/scheduled-task-prompt.md).
 
-Each tick reads the compact runtime contract and one fresh generated status artifact. It chooses at most one
-`dispatch.orderedCandidates` entry and live-reads only that target. Codex Cloud is `dispatchMode: supervised`; ChatGPT claims and
-starts one routed Cloud generation because Cloud does not poll Project 2.
+Each tick reads the compact runtime contract and one fresh generated status artifact, selects at most one
+`dispatch.orderedCandidates` entry, and live-reads only that target. Codex Cloud is supervised because it does not poll Project 2.
 
 ### Local Codex
 
-The app dispatcher uses `gpt-5.6-luna` with low reasoning. Normal implementation/verification workers use `gpt-5.6-terra` with
-medium reasoning. `gpt-5.6-sol` with high reasoning is an explicit difficult-task escalation rather than the heartbeat/default.
-The app prompt is [`.codex/local/scheduled-task-prompt.md`](../../.codex/local/scheduled-task-prompt.md); the worker template is
-[`.codex/local/worker-task-prompt.md`](../../.codex/local/worker-task-prompt.md). Headless workers use
-[`.codex/local/run-issue.sh`](../../.codex/local/run-issue.sh) and may override model/reasoning explicitly.
+The persistent dispatcher uses `gpt-5.6-luna` / low. Normal implementation/verification workers use `gpt-5.6-terra` / medium.
+`gpt-5.6-sol` / high is an explicit difficult-task escalation; xhigh requires an exceptional recorded reason. The app prompt and
+worker template live under `.codex/local/`; the headless helper defaults to Terra/medium.
 
 Local Codex is preferred for complex/persistent work and exact same-repository existing-PR continuation. It never adopts a fork or
 Dependabot branch for direct correction.
 
 ### Status and control workflows
 
-- `.github/workflows/delivery-status.yml` publishes Project, issue, PR, formal-closing-link, mergeability, and deterministic dispatch
-  projections.
+- `.github/workflows/delivery-status.yml` publishes Project, issue, PR, formal-link, mergeability, and deterministic dispatch views.
 - `.github/workflows/delivery-control.yml` validates and serializes guarded Project transitions.
-- raw status exports are diagnostic; normal dispatchers consume the normalized `dispatch` view.
+- raw exports are diagnostic; normal dispatchers consume the normalized `dispatch` view.
 
-## Supervision and telemetry
+## Lease-based supervision
 
-A newly started worker or operation is observed after 15 minutes, again after 15 minutes, then hourly while incomplete. The next
-observation belongs in durable worker evidence. Routine waiting remains `In progress`; `Blocked` means Dmitry must decide or act.
+A worker owns completion signalling. When its lifecycle turn finishes, it publishes evidence and performs the guarded handoff.
+Normal scheduler ticks ignore `In progress` ownership while `leaseUntil` is valid; they do not poll the worker.
+
+The worker may renew the same claim/generation before expiry. A stale-recovery candidate exists only when the worker reference is
+missing, the lease is missing/invalid, or the lease has expired. Targeted recovery preserves the exact generation/branch/task,
+finishes a lost handoff when possible, and releases to Ready only when no active or recoverable work remains. No duplicate worker or
+separate monitoring scheduler is created.
+
+CI waits, contributor updates, bot commands, rebases, and draft publication use bounded operation leases under the same rule.
+
+## Telemetry
 
 Every non-interactive tick/worker records start/end, duration, adapter, model/reasoning, snapshot identity, selected candidate,
 outcome, and provider token counters when available. Missing counters are `null` with `usageSource: unavailable`; exact billing
@@ -104,25 +108,21 @@ usage is never fabricated.
 
 ## Documentation map
 
-- [`runtime-contract.md`](runtime-contract.md) — compact recurring dispatcher/worker contract.
-- [`instruction-audit.md`](instruction-audit.md) — entry-point analysis, token budget, scheduler/model setup, and baseline tag.
-- [`profile.yml`](profile.yml) — Sniffy repository/Project, identities, routes, model profiles, supervision, telemetry, and snapshot
-  configuration.
-- [`lifecycle.md`](lifecycle.md) — statuses, execution states, canonical item, planned/current routing, and corrections.
-- [`control-plane.md`](control-plane.md) — guarded mutation schema, readable command wrapper, concurrency, reactions, and rotation.
-- [`status-snapshot.md`](status-snapshot.md) — read-only materialization, freshness, artifact pointer, and permissions.
-- [`event-loop.md`](event-loop.md) — reusable clock, generated selection, claims, adapters, and leases.
+- [`runtime-contract.md`](runtime-contract.md) — compact recurring contract.
+- [`instruction-audit.md`](instruction-audit.md) — entry-point/token/model/profile audit and baseline tag command.
+- [`profile.yml`](profile.yml) — repository/Project, identities, routes, model profiles, leases, telemetry, and snapshot settings.
+- [`lifecycle.md`](lifecycle.md) — statuses, execution states, canonical item, routes, and corrections.
+- [`control-plane.md`](control-plane.md) — guarded mutation schema, readable wrapper, concurrency, reactions, and rotation.
+- [`status-snapshot.md`](status-snapshot.md) — materialization, freshness, dispatch projections, and permissions.
+- [`event-loop.md`](event-loop.md) — clock, generated selection, claims, leases, and stale recovery.
 - [`pull-request-intake.md`](pull-request-intake.md) — universal PR discovery/canonicalization and fork/bot boundaries.
-- [`routing.md`](routing.md) — executor/model/provenance separation, capability/risk routing, existing PR continuity, convergence.
-- [`supervision.md`](supervision.md) — dispatch proof, 15/15/hourly observation, correction convergence, and merge boundary.
+- [`routing.md`](routing.md) — executor/model/provenance separation, continuity, and convergence.
+- [`supervision.md`](supervision.md) — dispatch proof, lease recovery, review convergence, and merge boundary.
 - [`verification.md`](verification.md) — implementer, reviewer, verifier, CI, runtime/browser/system proof.
-- [`executors/chatgpt.md`](executors/chatgpt.md), [`executors/codex-cloud.md`](executors/codex-cloud.md),
-  [`executors/codex-local.md`](executors/codex-local.md), [`executors/ide-agent.md`](executors/ide-agent.md) — environment adapters.
-- [`chat-retention.md`](chat-retention.md) — bounded replacement of persistent scheduler chats.
-- [`../retrospectives/`](../retrospectives/README.md) — historical incidents and durable lessons, never recurring prompt input.
+- executor runbooks under [`executors/`](executors/) — environment-specific adapters.
 
 ## Authority
 
 Use, in order: Dmitry's explicit current decision; canonical issue/PR and superseding comments; exact implementation PR/head and
-its evidence; nearest `AGENTS.md`; root `AGENTS.md`; runtime contract/profile; detailed shared policy; executor runbook; concrete
-prompt. Historical chats and Actions logs are evidence, not durable delivery state.
+evidence; nearest `AGENTS.md`; root `AGENTS.md`; runtime contract/profile; detailed shared policy; executor runbook; concrete prompt.
+Historical chats and Actions logs are evidence, not durable delivery state.

--- a/docs/ai-delivery/README.md
+++ b/docs/ai-delivery/README.md
@@ -1,181 +1,128 @@
 # AI-assisted delivery in Sniffy
 
-This directory describes how Dmitry and ChatGPT plan, canonicalize, route, supervise, review, and verify work performed by ChatGPT,
-Codex Cloud, Local Codex, an IDE-hosted coding agent, automation such as Dependabot, an external contributor, or a human. It is the
-control-plane documentation for delivery. Repository engineering rules remain in the nearest applicable `AGENTS.md`.
+This directory defines the provider-neutral lifecycle, control plane, routing, supervision, review, and verification model used by
+ChatGPT, Codex Cloud, Local Codex, IDE agents, automation, contributors, and humans. Repository engineering rules remain in the
+nearest applicable `AGENTS.md`.
 
-The current Sniffy routing knobs live in [`profile.yml`](profile.yml). Shared semantics belong in Markdown; the profile selects
-current executors, identities, Local Codex model/effort, control-log rotation thresholds, default routes, universal PR intake
-behavior, and the repository-owned Project status read model without redefining the lifecycle.
+## Runtime versus reference policy
 
-## Terminology
+Dispatchers must not load this whole directory on every heartbeat.
 
-| Term | Meaning | Sniffy example |
-| --- | --- | --- |
-| Work item | An issue or pull request represented in the delivery Project | feature issue, standalone PR |
-| Canonical item | The one Project item that owns lifecycle state for one published change | linked issue or standalone PR |
-| Implementation evidence | Exact PR branch/head, diff, CI, and review conversation linked to the canonical item | PR #763 at `6d45aff...` |
-| Role | A responsibility in the delivery process | supervisor, implementer, reviewer, verifier, operator |
-| Executor | The product and environment performing a current action | ChatGPT, Codex Cloud, Local Codex, human |
-| Implementer | Optional planned executor for a future Implementation turn | Local Codex; empty for an already-published PR |
-| Verifier | Planned executor coordinating Verification | ChatGPT |
-| Assignee | Concrete GitHub identity or human responsible now | `bedrin-gpt`, `bedrin-codex-local`, `bedrin` |
-| Agent instance | One concrete running chat, task, process, or worker | one Codex task and worktree |
-| Repository instructions | Engineering policy applied by path | root or nested `AGENTS.md` |
-| Runbook | Environment- or procedure-specific operating instructions | Codex Cloud setup, local worker |
-| Task prompt | One launch or continuation request | a rendered worker prompt for an issue or PR |
-| Control command | Guarded provider-neutral ProjectV2 transition | one `delivery-control/v1` JSON comment |
-| Status snapshot | Eventually consistent read-only ProjectV2 materialization | artifact pointer in an `ai-delivery-status` issue |
+- [`runtime-contract.md`](runtime-contract.md) is the compact policy loaded by every dispatcher tick.
+- [`profile.yml`](profile.yml) is the Sniffy-specific declarative configuration.
+- the GitHub status workflow and local snapshot helper perform deterministic queue filtering.
+- detailed documents are loaded after candidate selection, and only by the lifecycle worker that needs them.
+- [`instruction-audit.md`](instruction-audit.md) records the effective entry points, token-cost findings, model choices, and
+  migration from prompt-driven selection to generated dispatch projections.
 
-Roles, executors, identities, and PR provenance are independent. ChatGPT is the default supervisor, but it may also implement,
-review, or verify a task. Codex Cloud and Local Codex may perform the same implementer role in different environments. Model
-selection is a separate configuration axis: Cloud is provider-managed, while the current Local Codex profile uses Sol with
-extra-high reasoning.
+The status artifact is a read-only materialized selection view. It never replaces live GitHub state or the guarded
+`delivery-control/v1` mutation protocol.
 
-PR authorship is provenance, not a routing decision. A PR created by Dmitry, ChatGPT, an IDE agent, Dependabot, an external
-contributor, or a future bot is eligible for intake. Its author controls formal-review independence and branch-correction policy,
-but intake does not copy that identity into `Implementer`.
+## Core model
 
-## Issue and PR relationship
-
-Issues and pull requests are both first-class Project items, but one item owns lifecycle state for one published change:
-
-```text
-one formal closing issue -> issue is canonical; PR is implementation evidence
-no formal closing issue  -> PR is canonical
-several closing issues   -> PR is canonical in Planning
-```
-
-This lets Dmitry push a ready PR from IntelliJ without first creating an issue, while preserving an existing issue as the durable
-requirements item when one already exists. The event loop must not review both an issue and its PR as duplicate work.
-
-## Lifecycle summary
-
-`Status` describes the kind of work; `Execution` describes whether the next action can run:
+`Status` describes the kind of work; `Execution` describes whether its current action can run:
 
 ```text
 Status:    Draft -> Planning -> Implementation -> Review -> Verification (when required) -> Approval -> Done
 Execution: Ready | In progress | Blocked
 ```
 
-Planning records `Implementer` when a future Implementation turn is needed and records `Verifier` when Verification may be needed.
-`Executor` materializes who performs the next current action, while `Assignee` names the concrete identity or human. A non-draft
-PR may enter directly at `Review / Ready` with an empty Implementer when its implementation already exists and its scope is clear.
-A multi-issue PR enters Planning first.
+`Implementer` and `Verifier` are planned future roles. `Executor` is the current product/runtime route. `Assignee` is the concrete
+GitHub identity or human. `Worker reference` records the active task/process/branch/PR/head/lease/next observation.
 
-A worker owns one lifecycle turn. A corrected implementation that returns to Review with substantive blockers does not immediately
-receive another narrow patch request: ChatGPT first performs the convergence checkpoint in [`routing.md`](routing.md) and
-[`supervision.md`](supervision.md).
-
-## Control plane and execution plane
+Issues and PRs are both first-class, but one item owns lifecycle state for one published change:
 
 ```text
-Dmitry + ChatGPT decide canonical item, outcome, risk, routing, and proof
-                              |
-                              v
-             guarded control command + exact worker dispatch
-                              |
-                              v
-        ChatGPT | Codex Cloud | Local Codex | automation | human
-                              |
-                              v
-          exact PR-head evidence and independent verification
-                              |
-                              v
-               Dmitry authorizes privileged actions or merge
+one formal closing issue -> issue canonical; PR is implementation evidence
+no formal closing issue  -> PR canonical
+several closing issues   -> PR canonical in Planning
 ```
 
-All configured executors use the same central control-issue protocol for ProjectV2 transitions. The canonical issue/PR conversation
-is reserved for human-useful plans, reviews, evidence, blockers, and handoffs. Omitted Project fields remain unchanged, and an empty
-optional field is valid state rather than a reason to invent a new select option. See [`control-plane.md`](control-plane.md).
+PR authorship is provenance, not an automatic Implementer choice. Draft PRs do not enter Review. A Review handoff requires the
+open, non-draft PR at the exact published head. Merge remains Dmitry's explicit decision.
 
-Scheduled ChatGPT ticks request the repository-owned status snapshot in [`status-snapshot.md`](status-snapshot.md) before queue
-selection and use it when a complete direct organization ProjectV2 read is unavailable. The snapshot is a read-only selection aid.
-It never authorizes a mutation: every claim and handoff still goes through `delivery-control/v1`, whose workflow re-reads and
-verifies live ProjectV2 state. A failed refresh, stale, or unavailable snapshot blocks snapshot-dependent autonomous selection
-rather than permitting remembered or guessed field values.
+## Control and execution planes
 
-Dmitry owns product decisions, accepted risk, privileged repository/hosting operations, final acceptance, and merge authorization.
-ChatGPT owns issue refinement, universal PR intake/canonicalization, routing proposals, supervision, code review, verification
-coordination, control-log rotation, and clear handoff. An executor owns only the lifecycle turn and proof explicitly routed to it.
+```text
+programmatic snapshot/queue projection
+            |
+            v
+compact dispatcher -> one selected canonical candidate
+            |
+            v
+guarded delivery-control/v1 claim or reconciliation
+            |
+            v
+selected lifecycle worker -> exact evidence -> guarded handoff
+            |
+            v
+Dmitry accepts privileged actions and merge
+```
 
-## Sources of truth
-
-Use this precedence when instructions differ:
-
-1. Dmitry's explicit current decision, especially for product, risk, privileged operations, and merge.
-2. The authoritative canonical GitHub issue or pull request, including later comments that explicitly supersede older guidance.
-3. The linked implementation PR exact branch/head, reviews, CI, and artifacts.
-4. The nearest applicable `AGENTS.md` for files being changed.
-5. Root `AGENTS.md`.
-6. This directory and [`profile.yml`](profile.yml).
-7. The selected executor runbook or skill.
-8. The concrete task prompt.
-
-The status snapshot is not inserted into this authority order as a new ledger. It is a materialized view of current Project fields
-for readers that cannot query ProjectV2 directly. Live GitHub source state and guarded control verification remain authoritative
-for the operations they cover.
-
-Historical tick chats, Codex conversations, and Actions logs are telemetry and evidence, not the only copy of durable delivery
-state.
-
-## Documentation map
-
-- [`profile.yml`](profile.yml) — current Sniffy Project, field, identity, routing, Local Codex, intake, control, status-snapshot, and
-  rotation configuration.
-- [`lifecycle.md`](lifecycle.md) — statuses, execution states, canonical issue/PR rules, optional planned routing, and corrections.
-- [`control-plane.md`](control-plane.md) — one guarded mutation protocol, optional/omitted fields, control issue, concurrency,
-  reactions, and rotation.
-- [`status-snapshot.md`](status-snapshot.md) — read-only Project materialization, labeled pointer issue, artifact format, freshness,
-  active-item semantics, permissions, and ChatGPT read procedure.
-- [`event-loop.md`](event-loop.md) — reusable clock, universal PR intake/canonicalization, dispatcher, claims, and provider adapters.
-- [`.chatgpt/scheduled-task-prompt.md`](../../.chatgpt/scheduled-task-prompt.md) — exact prompt for four ChatGPT Scheduled Tasks.
-- [`.chatgpt/status-snapshot-instructions.md`](../../.chatgpt/status-snapshot-instructions.md) — mandatory Project read supplement
-  for ChatGPT ticks when direct ProjectV2 access is unavailable.
-- [`pull-request-intake.md`](pull-request-intake.md) — arbitrary PR discovery, canonical issue/PR selection, drafts, forks,
-  Dependabot, review, correction, and completion.
-- [`chat-retention.md`](chat-retention.md) — persistent Scheduled Task chats, compact outputs, and bounded manual rotation.
-- [`routing.md`](routing.md) — role/executor/model/provenance separation, fresh versus existing-PR routing, and convergence.
-- [`supervision.md`](supervision.md) — canonical handoff, dispatch proof, worker/PR monitoring, review convergence, and merge boundaries.
-- [`verification.md`](verification.md) — implementer, reviewer, verifier, CI, browser/system proof, and capability routing.
-- [`executors/chatgpt.md`](executors/chatgpt.md) — ChatGPT direct execution, scheduling, and limitations.
-- [`executors/codex-cloud.md`](executors/codex-cloud.md) — Cloud fresh-work routing, setup, credentials, publication, and troubleshooting.
-- [`executors/codex-local.md`](executors/codex-local.md) — app-native/headless workers and adopted existing-PR continuation.
-- [`executors/ide-agent.md`](executors/ide-agent.md) — generic VS Code/IntelliJ agent-host guidance.
-- [`../chatgpt-site-preview.md`](../chatgpt-site-preview.md) — exact-head website artifact and Chromium verification.
-- [`../retrospectives/`](../retrospectives/README.md) — historical incidents and durable lessons incorporated here.
+All executors use the same rotating technical control issue. New autonomous commands use the human-readable wrapper and marked
+JSON specified in [`control-plane.md`](control-plane.md). Target issues/PRs contain human-useful plans, reviews, proof, blockers, and
+handoffs—not field commands, leases, polling noise, or claim elections.
 
 ## Current adapters
 
-The ChatGPT clock uses four hourly Scheduled Tasks offset by 15 minutes. Product testing on 2026-07-30 showed that recurrences
-append to each task's defining chat rather than reliably creating a new chat. Every occurrence must therefore behave statelessly by
-instruction and re-read GitHub/repository state, while the four defining chats are retained and periodically replaced as a
-maintenance action. No Scheduled Task may rely on previous chat turns as state.
+### ChatGPT
 
-A no-op tick creates no work-item, Project, source, or worker mutation; the required status-refresh request and its reaction are
-read-path telemetry. A productive tick performs at most one canonicalization/reconciliation or lifecycle turn directly, or makes
-one supported external dispatch. Scheduled ChatGPT ticks cannot create child Scheduled Tasks.
+Create recurring dispatcher tasks in **Chat**, not **Work**. Use either one hourly budget task or four compact hourly tasks at
+`:00`, `:15`, `:30`, and `:45` when 15-minute queue latency is worth the usage. The exact setup prompt is
+[`.chatgpt/scheduled-task-prompt.md`](../../.chatgpt/scheduled-task-prompt.md).
 
-At the start of each tick, the configured status-snapshot supplement creates an on-demand read barrier: find the newest open issue
-labeled `ai-delivery-status`, post the exact refresh command, wait for its terminal reaction, then validate the newer JSON pointer
-and artifact. When direct ProjectV2 reads are unavailable, the tick uses those explicit normalized fields. Technical
-`ai-delivery-control` and `ai-delivery-status` issues are never canonical work. See [`status-snapshot.md`](status-snapshot.md).
+Each tick reads the compact runtime contract and one fresh generated status artifact. It chooses at most one
+`dispatch.orderedCandidates` entry and live-reads only that target. Codex Cloud is `dispatchMode: supervised`; ChatGPT claims and
+starts one routed Cloud generation because Cloud does not poll Project 2.
 
-Every open PR targeting `develop` is scanned. A single linked issue remains canonical; a standalone PR becomes the Project item;
-a multi-issue PR enters Planning. Same-repository corrections can be adopted by ChatGPT or Local Codex on the exact existing
-branch/PR. Forks and managed-bot branches use contributor/bot operations or a linked replacement task.
+### Local Codex
 
-GitHub Project auto-add remains useful for issues created by agents and dependency PR discovery, but it does not replace
-canonicalization. Project 2 currently retains a `Dependabot` Implementer option for manual/historical classification; normal
-intake does not select it.
+The app dispatcher uses `gpt-5.6-luna` with low reasoning. Normal implementation/verification workers use `gpt-5.6-terra` with
+medium reasoning. `gpt-5.6-sol` with high reasoning is an explicit difficult-task escalation rather than the heartbeat/default.
+The app prompt is [`.codex/local/scheduled-task-prompt.md`](../../.codex/local/scheduled-task-prompt.md); the worker template is
+[`.codex/local/worker-task-prompt.md`](../../.codex/local/worker-task-prompt.md). Headless workers use
+[`.codex/local/run-issue.sh`](../../.codex/local/run-issue.sh) and may override model/reasoning explicitly.
 
-## Provider-specific files
+Local Codex is preferred for complex/persistent work and exact same-repository existing-PR continuation. It never adopts a fork or
+Dependabot branch for direct correction.
 
-- `.chatgpt/` contains copy-paste Scheduled Task prompts and connector-read supplements, not durable delivery state.
-- `.codex/` contains Codex environment scripts and launch prompts, not general repository policy.
-- `.github/workflows/delivery-control.yml` and `.github/scripts/delivery-control.js` implement the provider-neutral mutation bridge.
-- `.github/workflows/delivery-status.yml` and `.github/scripts/delivery-status.js` implement the read-only Project status bridge.
-- `.github/scripts/delivery-policy.test.js` protects the canonical universal-intake and adopted-continuation prompt contract.
-- `.github/copilot-instructions.md` is a small Copilot adapter pointing to `AGENTS.md` and this directory.
-- `.agents/skills/` contains optional reusable procedures that an executor invokes only when applicable.
-- IDE-specific rule directories should not duplicate `AGENTS.md`; add them only for a proven client-specific gap.
+### Status and control workflows
+
+- `.github/workflows/delivery-status.yml` publishes Project, issue, PR, formal-closing-link, mergeability, and deterministic dispatch
+  projections.
+- `.github/workflows/delivery-control.yml` validates and serializes guarded Project transitions.
+- raw status exports are diagnostic; normal dispatchers consume the normalized `dispatch` view.
+
+## Supervision and telemetry
+
+A newly started worker or operation is observed after 15 minutes, again after 15 minutes, then hourly while incomplete. The next
+observation belongs in durable worker evidence. Routine waiting remains `In progress`; `Blocked` means Dmitry must decide or act.
+
+Every non-interactive tick/worker records start/end, duration, adapter, model/reasoning, snapshot identity, selected candidate,
+outcome, and provider token counters when available. Missing counters are `null` with `usageSource: unavailable`; exact billing
+usage is never fabricated.
+
+## Documentation map
+
+- [`runtime-contract.md`](runtime-contract.md) — compact recurring dispatcher/worker contract.
+- [`instruction-audit.md`](instruction-audit.md) — entry-point analysis, token budget, scheduler/model setup, and baseline tag.
+- [`profile.yml`](profile.yml) — Sniffy repository/Project, identities, routes, model profiles, supervision, telemetry, and snapshot
+  configuration.
+- [`lifecycle.md`](lifecycle.md) — statuses, execution states, canonical item, planned/current routing, and corrections.
+- [`control-plane.md`](control-plane.md) — guarded mutation schema, readable command wrapper, concurrency, reactions, and rotation.
+- [`status-snapshot.md`](status-snapshot.md) — read-only materialization, freshness, artifact pointer, and permissions.
+- [`event-loop.md`](event-loop.md) — reusable clock, generated selection, claims, adapters, and leases.
+- [`pull-request-intake.md`](pull-request-intake.md) — universal PR discovery/canonicalization and fork/bot boundaries.
+- [`routing.md`](routing.md) — executor/model/provenance separation, capability/risk routing, existing PR continuity, convergence.
+- [`supervision.md`](supervision.md) — dispatch proof, 15/15/hourly observation, correction convergence, and merge boundary.
+- [`verification.md`](verification.md) — implementer, reviewer, verifier, CI, runtime/browser/system proof.
+- [`executors/chatgpt.md`](executors/chatgpt.md), [`executors/codex-cloud.md`](executors/codex-cloud.md),
+  [`executors/codex-local.md`](executors/codex-local.md), [`executors/ide-agent.md`](executors/ide-agent.md) — environment adapters.
+- [`chat-retention.md`](chat-retention.md) — bounded replacement of persistent scheduler chats.
+- [`../retrospectives/`](../retrospectives/README.md) — historical incidents and durable lessons, never recurring prompt input.
+
+## Authority
+
+Use, in order: Dmitry's explicit current decision; canonical issue/PR and superseding comments; exact implementation PR/head and
+its evidence; nearest `AGENTS.md`; root `AGENTS.md`; runtime contract/profile; detailed shared policy; executor runbook; concrete
+prompt. Historical chats and Actions logs are evidence, not durable delivery state.

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -20,140 +20,129 @@ A clock knows cadence and scheduler identity only. It must not embed lifecycle p
 - ChatGPT full-latency clock: four hourly Chat tasks at `:00`, `:15`, `:30`, and `:45`.
 - Local/headless clock: cron or systemd timer with host-local overlap protection.
 
-Create ChatGPT heartbeats in **Chat**, not **Work**. Work and strong coding models are reserved for selected work rather than empty
-queue checks.
+Create ChatGPT heartbeats in **Chat**, not **Work**. The 15-minute clock controls queue latency; it is not a command to poll every
+active worker every 15 minutes.
 
 ## Programmatic selection
 
-The GitHub status workflow publishes a normalized artifact with:
+The status workflow publishes active Project items, every open base-branch PR, formal closing links, exact heads, ownership,
+mergeability hints, and deterministic projections:
 
-- active Project items and every explicit field value;
-- every open base-branch PR, formal closing issues, exact head, draft/ownership, and mergeability hints;
-- `dispatch.readyByExecutor` and `dispatch.inProgressByExecutor`;
-- due observations, route mismatches, PR intake/conflict candidates, stale exact-head candidates, and one ordered attention list.
+- `readyByExecutor`;
+- `inProgressByExecutor`, split into active and stale ownership;
+- route/assignee mismatches;
+- PR conflict/intake/duplicate candidates;
+- stale exact-head candidates;
+- `orderedCandidates`.
 
-Local Codex uses `.codex/local/project-queue-snapshot.sh` once per tick for equivalent ready/in-progress selection. A future generic
-framework may compile `profile.yml` into versioned runtime JSON; dispatchers should consume generated JSON, not parse policy prose.
+Local Codex uses `.codex/local/project-queue-snapshot.sh` once per tick for equivalent selection. A future generic framework may
+compile `profile.yml` once into versioned runtime JSON. Dispatchers consume generated JSON instead of interpreting policy prose.
 
-Snapshot selection never authorizes mutation. After choosing one candidate, the dispatcher live-reads only that target and uses the
-guarded control workflow as the authoritative compare-and-set.
+Snapshot selection never authorizes mutation. After selecting one candidate, the dispatcher live-reads only that target and uses
+the guarded control workflow as the authoritative compare-and-set.
 
 ## Candidate order
 
 A dispatcher handles at most one outcome per tick:
 
 1. conflicting same-repository PR requiring deliberate routing;
-2. universal PR intake/canonicalization or duplicate representation;
+2. managed fork/Dependabot operation or universal PR intake/canonicalization;
 3. stale exact-head downstream state;
 4. Ready route/assignee mismatch;
-5. due owned `In progress` observation;
+5. stale `In progress` ownership with missing/invalid/expired lease;
 6. Ready work for a supervised executor;
 7. Ready work for the dispatcher itself.
 
-If no candidate remains actionable after the targeted re-read, return `NO_CHANGE`. Do not read whole discussions, diffs, review
+If no candidate remains actionable after targeted re-read, return `NO_CHANGE`. Do not load whole discussions, diffs, review
 threads, CI logs, artifacts, or detailed runbooks merely to prove the queue is empty.
 
-## Universal pull-request intake
+## Universal PR intake
 
 Every open PR targeting the configured base branch is represented in the generated snapshot regardless of author, label,
-bot/provider, branch creator, or whether an issue existed first. The programmatic projection identifies candidates; the dispatcher
-live-reads only the selected one.
-
-Canonicalization remains:
+bot/provider, or branch creator. Canonicalization remains:
 
 ```text
 one formal closing issue -> issue canonical
 no formal closing issue  -> PR canonical
-two or more closing issues -> PR canonical in Planning
+two or more issues       -> PR canonical in Planning
 ```
 
-Draft PRs are telemetry and possible implementation evidence but do not enter Review. If both an issue and PR are materialized,
-keep one canonical active lifecycle item and make the duplicate non-claimable. Same-repository corrections preserve the exact
-branch/PR. Fork and Dependabot branches remain contributor/bot-owned or are superseded by a deliberate internal task.
+Draft PRs do not enter Review. If issue and PR are both materialized, keep one canonical active lifecycle item. Same-repository
+corrections preserve the exact branch/PR. Fork and Dependabot branches remain contributor/bot-owned or are superseded by a
+deliberate internal task.
 
 ## Exact-head and route reconciliation
 
-Review, Verification, Approval, or a derived human handoff is valid only for the exact PR head named in durable evidence. When the
-current head differs, the generated projection flags it. A supervising tick live-verifies the new head, then uses one guarded
-transition to `Review / Ready / ChatGPT` with the new exact PR identity and cleared stale ownership.
+Review, Verification, Approval, or a derived human handoff is valid only for the exact PR head named in durable evidence. A changed
+head is programmatically flagged and routed back to `Review / Ready / ChatGPT` after targeted live verification.
 
-A configured Ready route whose Assignee belongs to another executor pool is a supervisory reconciliation obligation. Re-read the
-route and either correct assignment or deliberately route the lifecycle status/executor. Never silently filter out an otherwise
-Ready item and never infer a human blocker from stale assignment alone.
+A Ready route whose Assignee belongs to another executor pool is a supervisory reconciliation obligation. Correct assignment or
+route deliberately; never silently filter the item or infer a Human blocker from stale assignment alone.
 
 ## Supervised executors
 
-The current profile marks Codex Cloud `dispatchMode: supervised`, with ChatGPT as its dispatch owner. Cloud does not poll Project
-2. A ChatGPT tick may therefore select `Implementation / Ready / Codex Cloud`, claim while preserving Executor, submit exactly one
-Cloud trigger, require durable acknowledgement, record the generation and first observation, then stop.
+The current profile marks Codex Cloud `dispatchMode: supervised` with ChatGPT as its dispatch owner. Codex Cloud does not poll
+Project 2. A ChatGPT tick may select `Implementation / Ready / Codex Cloud`, claim while preserving Executor, submit one exact
+Cloud trigger, require durable acknowledgement, record generation plus lease, and stop.
 
 A trigger never submitted or definitively rejected is released to Ready. A submitted trigger with uncertain acknowledgement stays
-one provisional `In progress` generation for targeted recovery; never dispatch a duplicate. Arbitrary existing-PR continuation is
-routed to Local Codex unless it is an explicitly recoverable Cloud branch.
+one provisional generation under a shorter lease. Never dispatch a duplicate. Arbitrary existing-PR continuation normally routes
+to Local Codex unless it is an explicitly recoverable Cloud-owned branch.
 
-## Polling executors
+## Polling executors and capacity
 
-A polling dispatcher selects:
-
-```text
-Execution = Ready
-Executor = its executor pool
-Assignee = empty or the pool identity
-```
-
-Eligibility must not require optional Implementer/Verifier values outside the lifecycle status that uses them. A blank Implementer
-means no implementation route has yet been deliberately selected.
-
-Capacity is derived from owned `In progress` items in the retained snapshot and the profile's configured maximum. Provider-wide
-conversation/task inventory is not a normal capacity or duplicate-generation check; use it only for targeted recovery of one
-already-claimed ambiguous generation. Per-target guarded claims prevent duplicate ownership.
+A polling dispatcher selects `Execution = Ready`, its Executor pool, and an empty/pool Assignee. Capacity is derived from all owned
+`In progress` items in the retained snapshot, including stale ownership until recovery resolves it. Provider-wide task inventory is
+not a normal capacity or duplicate-generation check; it is allowed only for one targeted stale recovery.
 
 ## Guarded claim
 
 A claim:
 
 1. live-reads current canonical type, Status, Execution, Executor, assignment, worker reference, and exact PR head when applicable;
-2. creates a unique token, lease, owner, concrete/provisional worker reference, and next observation time;
-3. posts one `delivery-control/v1` command on the active control issue using the readable wrapper from `control-plane.md`;
-4. guards current type, Status, `Execution = Ready`, Executor, and exact PR head;
-5. sets `Execution = In progress` and Worker reference in the same command;
-6. inspects the terminal reaction and re-reads current state;
+2. creates a unique token/generation, owner, concrete/provisional worker reference, `claimedAt`, and `leaseUntil`;
+3. posts one `delivery-control/v1` command using the human-readable Markdown wrapper from `control-plane.md`;
+4. preserves exact start/end markers, lowercase `json` fence, and authoritative marked JSON;
+5. guards current type, Status, `Execution = Ready`, Executor, and exact PR head;
+6. sets `Execution = In progress` and ownership in the same command;
 7. starts work only for the verified winner.
 
-A guarded conflict is normal coordination. Make no source or work mutation from the stale view. If execution cannot start, release
-to Ready. Set `Blocked / Human` only for one exact Dmitry decision/action.
+A guarded conflict is normal coordination. Make no source mutation from a stale view. If execution cannot start, release to Ready;
+use `Blocked / Human` only for one exact Dmitry decision/action.
 
 ## Worker contract
 
-One worker owns one lifecycle turn. After claim it reads the complete canonical item and relevant comments, formal links, exact PR,
-nearest `AGENTS.md`, current reviews/threads/CI/artifacts, and only the detailed lifecycle/runbook sections it needs.
+One worker owns one lifecycle turn. It reads the complete canonical item, relevant comments/formal links, exact PR,
+nearest `AGENTS.md`, current reviews/threads/CI/artifacts, and only the detailed runbook sections it needs.
 
-- Planning resolves outcome, canonical scope, decisions, non-goals, risk, routes, and proof.
-- Implementation changes the repository, proves the change, publishes one intended non-draft exact-head PR, and hands to Review.
-- Review inspects the complete exact-head diff and publishes one comprehensive outcome with honest identity handling.
-- Verification proves observable behavior in a representative environment rather than trusting unit tests or summaries.
-- Approval and merge remain human-owned.
+Implementation publishes one intended ready-for-review/non-draft PR at the exact head and performs the guarded Review handoff.
+Review publishes one comprehensive exact-head outcome with honest identity handling. Verification proves observable behavior in a
+representative environment. Approval and merge remain human-owned.
 
-A transition to Review identifies the exact PR structurally. A canonical PR uses target plus `expected.head`; a canonical issue uses
-`reviewPullRequest.number/head`. The PR must be open, target the base branch, be ready/non-draft, and match the exact head.
+## Lease and stale recovery
 
-## Supervision and recovery
+A worker owns completion signalling and may renew its own lease before expiry. While `leaseUntil` is valid, scheduler ticks ignore
+the item and do not inspect the worker.
 
-After starting a worker, CI run, contributor operation, bot command, or draft publication, observe after 15 minutes, again after 15
-minutes, then hourly while incomplete. Store `nextObservationAt` in durable worker evidence. The same event-loop responsibility
-selects due observations; do not leave the first check until an hour later.
+Missing worker reference, missing/invalid lease, or expired `leaseUntil` creates one stale-recovery candidate. The dispatcher then:
 
-Before expiring a lease, inspect the concrete worker/task/branch/PR and latest observable evidence. Routine waiting remains
-`In progress`. Recover the exact existing worker/branch where possible; release only genuinely stale ownership.
+1. re-reads the exact worker/task/generation and branch/PR/head evidence;
+2. stops if handoff already completed;
+3. extends the same lease only when the same worker is demonstrably active;
+4. completes a lost deterministic handoff when evidence is sufficient;
+5. recovers the same workspace/branch/generation when possible;
+6. releases to Ready only when nothing active or recoverable remains;
+7. never starts a duplicate worker, generation, branch, or PR.
 
-## Telemetry
+External waits such as CI, contributors, bot operations, rebases, and draft publication use bounded operation leases. New GitHub
+state may create another actionable candidate before expiry; otherwise recovery waits for lease expiry. There is no separate
+monitoring scheduler or per-worker observation cadence.
+
+## Telemetry and profile
 
 Every tick emits start/end/duration, adapter/scheduler, model/reasoning, snapshot identity, selected candidate, outcome, and exact
-provider token counters when exposed. Missing counters are null with `usageSource: unavailable`; estimates must be explicitly
-labelled and derived from measured bytes rather than presented as billing facts.
+provider token counters when exposed. Missing counters are null with `usageSource: unavailable`.
 
-## Generic core and project profile
-
-Shared Markdown defines lifecycle semantics, canonicalization, guarded ownership, supervision, verification, and merge authority.
-`profile.yml` supplies repository/Project, identities, capacity, scheduler surface/cadence, model defaults, and routing choices.
-Generated dispatch JSON is the runtime form. A profile must not redefine lifecycle meaning or weaken exact-head/no-merge rules.
+Shared Markdown defines lifecycle semantics; `profile.yml` supplies repository/Project, identities, capacity, scheduler surface,
+model defaults, lease budgets, and routes. Generated dispatch JSON is the runtime form. A profile must not weaken exact-head,
+review-independence, verification, or no-merge rules.

--- a/docs/ai-delivery/event-loop.md
+++ b/docs/ai-delivery/event-loop.md
@@ -1,335 +1,159 @@
 # Reusable event loop and claim protocol
 
-This design separates a provider-neutral queue engine from ChatGPT, Codex, GitHub Project, and repository-specific adapters.
-Sniffy is the first profile, not the framework itself. Current Sniffy configuration lives in [`profile.yml`](profile.yml).
-
-## Components
+The event loop separates a provider-neutral queue engine from clocks, Project adapters, ChatGPT, Codex, and project-specific
+profiles. Sniffy is the first profile, not the framework itself.
 
 ```text
-Clock
-  -> Dispatcher tick
-      -> Intake and canonicalization adapters
-          -> Guarded claim/transition protocol
-              -> Lifecycle worker
+clock
+  -> programmatic status/queue projection
+      -> compact dispatcher selects one attention candidate
+          -> guarded claim/reconciliation
+              -> one lifecycle worker
+                  -> exact evidence and guarded handoff
 ```
 
-- **Clock** starts one dispatcher tick. It knows only cadence and slot identity.
-- **Dispatcher tick** loads one or more project profiles, reconciles source systems, queries eligible work, and selects a
-  deterministic candidate.
-- **Intake adapters** materialize arbitrary pull requests and other external work into the same lifecycle.
-- **Canonicalization** chooses one active Project item when an issue and PR describe the same delivery.
-- **Control protocol** serializes guarded ProjectV2 claims and transitions through one technical control issue.
-- **Lifecycle worker** performs one lifecycle turn, publishes evidence, and hands the task to the next status as `Ready`.
+## Clock
 
-Some adapters split dispatch and work into separate processes or conversations. Others, including the current ChatGPT adapter,
-execute the claimed lifecycle turn directly in the same scheduled occurrence. Child-worker spawning is optional, not a
-requirement of the generic protocol.
+A clock knows cadence and scheduler identity only. It must not embed lifecycle policy.
 
-A no-op tick creates no work-item, Project, source branch, worktree, control command, or worker claim. A read adapter may still
-emit its configured refresh request/reaction, and a provider may append a compact execution transcript to its scheduler
-conversation.
+- ChatGPT budget clock: one hourly Chat Scheduled Task.
+- ChatGPT full-latency clock: four hourly Chat tasks at `:00`, `:15`, `:30`, and `:45`.
+- Local/headless clock: cron or systemd timer with host-local overlap protection.
 
-## Desired cadence
+Create ChatGPT heartbeats in **Chat**, not **Work**. Work and strong coding models are reserved for selected work rather than empty
+queue checks.
 
-The logical queue should be checked every 15 minutes. Worker follow-up is part of the same event-loop responsibility; it is not a
-second independent scheduler. When an existing worker or observable PR operation is due for observation, a tick continues or
-recovers that ownership before claiming unrelated work.
+## Programmatic selection
 
-### ChatGPT Scheduled Tasks adapter
+The GitHub status workflow publishes a normalized artifact with:
 
-Current documented ChatGPT limits require sharding the logical clock:
+- active Project items and every explicit field value;
+- every open base-branch PR, formal closing issues, exact head, draft/ownership, and mergeability hints;
+- `dispatch.readyByExecutor` and `dispatch.inProgressByExecutor`;
+- due observations, route mismatches, PR intake/conflict candidates, stale exact-head candidates, and one ordered attention list.
 
-- Scheduled Tasks cannot run more than once per hour;
-- Pro and Enterprise accounts may have up to 15 active tasks;
-- deleting a task's associated chat pauses the task;
-- a task created in a ChatGPT Project that has files cannot access those files.
+Local Codex uses `.codex/local/project-queue-snapshot.sh` once per tick for equivalent ready/in-progress selection. A future generic
+framework may compile `profile.yml` into versioned runtime JSON; dispatchers should consume generated JSON, not parse policy prose.
 
-Use four permanent hourly Scheduled Tasks:
+Snapshot selection never authorizes mutation. After choosing one candidate, the dispatcher live-reads only that target and uses the
+guarded control workflow as the authoritative compare-and-set.
+
+## Candidate order
+
+A dispatcher handles at most one outcome per tick:
+
+1. conflicting same-repository PR requiring deliberate routing;
+2. universal PR intake/canonicalization or duplicate representation;
+3. stale exact-head downstream state;
+4. Ready route/assignee mismatch;
+5. due owned `In progress` observation;
+6. Ready work for a supervised executor;
+7. Ready work for the dispatcher itself.
+
+If no candidate remains actionable after the targeted re-read, return `NO_CHANGE`. Do not read whole discussions, diffs, review
+threads, CI logs, artifacts, or detailed runbooks merely to prove the queue is empty.
+
+## Universal pull-request intake
+
+Every open PR targeting the configured base branch is represented in the generated snapshot regardless of author, label,
+bot/provider, branch creator, or whether an issue existed first. The programmatic projection identifies candidates; the dispatcher
+live-reads only the selected one.
+
+Canonicalization remains:
 
 ```text
-slot-00 -> hourly at :00
-slot-15 -> hourly at :15
-slot-30 -> hourly at :30
-slot-45 -> hourly at :45
+one formal closing issue -> issue canonical
+no formal closing issue  -> PR canonical
+two or more closing issues -> PR canonical in Planning
 ```
 
-Copy the exact prompt from [`.chatgpt/scheduled-task-prompt.md`](../../.chatgpt/scheduled-task-prompt.md). Create each task from a
-separate defining chat inside one dedicated fileless `AI Delivery Event Loop` Project so four task logs remain isolated from one
-another.
+Draft PRs are telemetry and possible implementation evidence but do not enter Review. If both an issue and PR are materialized,
+keep one canonical active lifecycle item and make the duplicate non-claimable. Same-repository corrections preserve the exact
+branch/PR. Fork and Dependabot branches remain contributor/bot-owned or are superseded by a deliberate internal task.
 
-Product testing on 2026-07-30 showed that recurrences append to the defining task chat rather than reliably starting a new chat.
-Treat each occurrence as logically stateless even though the transcript is persistent:
+## Exact-head and route reconciliation
 
-1. ignore prior-run conclusions and mutable conversational context;
-2. read current GitHub state, repository policy, and [`profile.yml`](profile.yml) from scratch;
-3. request and validate the on-demand status snapshot barrier;
-4. reconcile every open PR targeting the configured base branch and choose one canonical issue/PR item;
-5. reconcile a canonical issue/PR whose current head no longer matches the exact head supporting its downstream lifecycle state;
-6. reconcile one invalid Ready route/assignee, continue one due owned worker/PR operation, dispatch one configured non-polling
-   executor, or select at most one eligible lifecycle turn;
-7. submit one guarded control command to claim it;
-8. verify the successful reaction and resulting Project state before doing work;
-9. perform the lifecycle turn directly or make one supported external dispatch with durable acknowledgement;
-10. publish human-useful evidence on the canonical target item;
-11. submit one guarded control command for the lifecycle handoff and verify the result;
-12. return `NO_CHANGE` when no intake, head reconciliation, continuation, rotation, or eligible work exists.
+Review, Verification, Approval, or a derived human handoff is valid only for the exact PR head named in durable evidence. When the
+current head differs, the generated projection flags it. A supervising tick live-verifies the new head, then uses one guarded
+transition to `Review / Ready / ChatGPT` with the new exact PR identity and cleared stale ownership.
 
-A tick must never claim work it cannot reasonably complete or hand off durably during that occurrence. Route long
-implementation, dependency-heavy builds, persistent services, existing-PR continuation, and environment-specific verification to
-Codex Cloud, Local Codex, CI, or a human as documented in [`routing.md`](routing.md).
+A configured Ready route whose Assignee belongs to another executor pool is a supervisory reconciliation obligation. Re-read the
+route and either correct assignment or deliberately route the lifecycle status/executor. Never silently filter out an otherwise
+Ready item and never infer a human blocker from stale assignment alone.
 
-Scheduled Task executions cannot create child Scheduled Tasks. They may dispatch a supported external worker, but `In progress`
-is valid only after a concrete worker/task/branch/process/reference exists.
+## Supervised executors
 
-The four chats are operational telemetry, not durable state. Keep output compact and follow [`chat-retention.md`](chat-retention.md)
-for bounded replacement of long task chats. Chat rotation must never alter GitHub lifecycle state.
+The current profile marks Codex Cloud `dispatchMode: supervised`, with ChatGPT as its dispatch owner. Cloud does not poll Project
+2. A ChatGPT tick may therefore select `Implementation / Ready / Codex Cloud`, claim while preserving Executor, submit exactly one
+Cloud trigger, require durable acknowledgement, record the generation and first observation, then stop.
 
-### Dedicated scheduler Project
+A trigger never submitted or definitively rejected is released to Ready. A submitted trigger with uncertain acknowledgement stays
+one provisional `In progress` generation for targeted recovery; never dispatch a duplicate. Arbitrary existing-PR continuation is
+routed to Local Codex unless it is an explicitly recoverable Cloud branch.
 
-Use one dedicated fileless ChatGPT Project, such as `AI Delivery Event Loop`, as a UI namespace for the four task definitions and
-their persistent transcripts. The Project is not configuration or task memory. Critical repository/profile locations must be
-present in every task prompt.
+## Polling executors
 
-The available scheduler operation cannot reliably target an arbitrary different ChatGPT Project, and a Scheduled Task cannot
-create another Scheduled Task. All durable context therefore lives in GitHub and repository-owned files.
-
-The four tasks may scan several repositories because queue state is external. Repository-specific filters and executor settings
-belong in explicit profiles, not in prior chat history.
-
-### Supervisor-dispatched executors
-
-Not every executor polls Project state. The current Sniffy profile marks Codex Cloud as `dispatchMode: supervised` with ChatGPT as
-its dispatch owner. A `Ready / Codex Cloud` route is therefore eligible work for a ChatGPT tick even though ChatGPT is not the
-implementation executor. The tick claims the routed turn without changing Executor, starts exactly one supported Cloud task,
-requires durable acknowledgement, records the task/trigger and first observation point, and then stops.
-
-If the external trigger was never submitted or was definitively rejected, the tick releases the provisional claim back to Ready.
-If submission succeeded but acknowledgement is uncertain, the exact trigger comment or task-generation reference remains
-provisional `In progress` recovery evidence; the next observation performs targeted recovery and must not submit a duplicate
-generation. The tick must not invent a worker or wait for Cloud to discover Project 2 on its own. Arbitrary existing-PR
-continuation is routed to Local Codex rather than converted into duplicate fresh Cloud work; only an explicitly recoverable
-existing Cloud branch may be continued through Cloud.
-
-A configured non-Human Ready route whose Assignee belongs to another executor pool is a supervisory reconciliation obligation,
-not an invisible queue item. Re-read the authoritative route, correct the assignment when the route remains valid, or route the
-item deliberately to the correct lifecycle/executor. Do not infer a human blocker solely from stale assignment.
-
-## Universal pull-request intake adapter
-
-Every open PR targeting the configured base branch is a discovery source, regardless of author, label, bot/provider, branch
-creator, or whether an issue was created first. The adapter scans drafts as telemetry but only starts Review for non-draft PRs.
-
-Before ordinary work, a tick re-reads for each PR:
-
-- repository, base branch, draft/open state, exact head, mergeability, and same-repository/fork ownership;
-- author, labels, dependency/security metadata, and provider-specific controls;
-- formal closing issues and whether each issue/PR is already represented in Project 2;
-- current lifecycle fields, assignees, Worker reference, review decision, unresolved threads, and exact-head CI;
-- whether another canonical item or worker already owns the implementation.
-
-Canonicalization is deterministic:
-
-```text
-exactly one formal closing issue -> issue is canonical
-no formal closing issue          -> PR is canonical
-multiple formal closing issues   -> PR is canonical in Planning
-```
-
-For exactly one closing issue, add or locate that issue idempotently and attach the PR URL/exact head as implementation evidence.
-Do not add the PR as a second active lifecycle item. For a standalone PR, add or locate the PR itself. For a multi-issue PR, add or
-locate the PR as `Planning / Ready / ChatGPT` and suppress duplicate work on linked issues until Planning resolves combined scope
-and proof.
-
-A draft PR does not enter Review. It may remain linked to an existing canonical issue in `Implementation / In progress` and be
-monitored. Once it becomes ready for review, the next tick performs the canonical handoff; no separate event workflow is required.
-
-If both an issue and its PR were accidentally materialized, the tick does not review both. It prefers the canonical item above,
-makes the duplicate non-claimable through a guarded reconciliation when possible, and records the canonical link. The backfill key
-is repository plus item number; existing representation or ownership prevents duplication.
-
-A guarded intake/handoff:
-
-1. targets the canonical issue or PR;
-2. sets `Review / Ready / Executor = ChatGPT` for a reviewable implementation, or `Planning / Ready / ChatGPT` for a multi-issue or
-   ambiguous PR;
-3. chooses a Verifier from actual compatibility and observable-risk obligations;
-4. omits `Implementer`, preserving any deliberate existing value while treating absence as valid;
-5. records PR URL, branch, exact head, author, fork/same-repo status, linked issues, labels, and relevant security/dependency data;
-6. assigns `bedrin-gpt` separately and re-reads both Project state and GitHub assignment.
-
-PR authorship is provenance used for trust, formal-review independence, and provider-specific commands. It is not automatically a
-planned implementation route. Dependabot is one specialization of universal intake; trusted automation is not approval.
-See [`pull-request-intake.md`](pull-request-intake.md).
-
-GitHub Projects auto-add may assist discovery, especially for issues created by agents and dependency PRs, but it cannot perform
-canonicalization. Do not rely on blind PR auto-add as the only intake path.
-
-## Exact-head reconciliation
-
-A lifecycle result is valid only for the exact pull-request head named by its evidence. After universal PR intake and
-canonicalization, but before continuing owned work or selecting ordinary queue work, a supervising tick inspects every open PR
-whose canonical issue or PR state depends on completed Review, Verification, Approval, or a human handoff derived from one of
-those statuses.
-
-If the current PR head differs from the exact head supporting that state, the tick must:
-
-1. stop relying on the stale review, verification packet, approval handoff, blocked decision, or worker reference;
-2. submit one guarded `delivery-control/v1` command targeting the canonical item and expecting its current Status, Execution,
-   Executor, and the PR's exact current head;
-3. set `Status = Review`, `Execution = Ready`, and `Executor = ChatGPT`, clear stale worker ownership, and record the PR URL plus
-   new exact head as evidence in the same command;
-4. identify the review PR structurally: use target plus `expected.head` when the PR is canonical, or
-   `reviewPullRequest.number/head` when a canonical issue owns the PR;
-5. inspect the terminal reaction, then re-read both PR draft/head state and the canonical Project item before treating it as
-   re-queued;
-6. leave technical reconciliation details on the control issue rather than posting legacy field or claim comments on the PR.
-
-This reconciliation is supervisory work and may select a canonical item even when its current Status is not otherwise eligible
-for the ChatGPT queue, including `Approval` or `Blocked / Human`. It consumes at most one item in a tick and precedes due-worker
-continuation or a new claim. A conflict means state changed concurrently; re-read and do not overwrite the newer route. A later
-Review must inspect the complete diff and matching-head CI again; an approval or verification result for an older head is never
-inherited automatically. When a canonical issue owns the PR, keep the PR URL and new exact head in its Worker reference through
-Review and Verification.
-
-## Control-issue adapter
-
-All executors use [`control-plane.md`](control-plane.md). They find the one active control issue, post one guarded
-`delivery-control/v1` command, inspect its terminal reaction, and re-read Project state. No target-item field command or claim
-arbitration comment is permitted.
-
-Control-log rotation is ordinary event-loop maintenance. A tick needing to post a command may rotate an old/full log first, then
-continue. Rotation does not require an additional Scheduled Task.
-
-## Codex app automation adapter
-
-Codex automations can run on schedules, and some can return to the same conversation. Local automations require the computer to
-be awake and the Codex app running.
-
-Use one persistent dispatcher conversation when app-owned one-time worker creation is proven. The current Sniffy Local Codex
-profile is fixed to Sol with extra-high reasoning. The dispatcher selects work and routing; it does not pretend Cloud or Local
-model choice is the same axis as executor choice.
-
-The dispatcher may receive an issue or PR canonical item. An explicitly routed same-repository existing PR is a valid adopted
-continuation: reuse the exact branch and PR even when it was created by Dmitry, ChatGPT, an IDE agent, or another worker. Fork and
-Dependabot branches are not adopted for direct correction.
-
-### Headless Local Codex adapter
-
-For unattended local execution, prefer a normal Linux service when app-owned chats are not needed:
-
-```text
-systemd timer or cron
-  -> flock prevents overlapping ticks on one host
-  -> dispatcher loads project profiles
-  -> central guarded claim
-  -> isolated git worktree
-  -> codex exec with rendered lifecycle prompt
-  -> commit/update exact PR, evidence, and guarded handoff
-```
-
-A five- or fifteen-minute timer is straightforward locally. Host-local `flock` complements the GitHub target-item concurrency
-group; neither replaces the other.
-
-## Eligible work
-
-A polling dispatcher normally queries the materialized current route, not planned roles alone:
+A polling dispatcher selects:
 
 ```text
 Execution = Ready
-Executor = <dispatcher executor type>
-Assignee is empty OR Assignee belongs to this dispatcher pool
+Executor = its executor pool
+Assignee = empty or the pool identity
 ```
 
-A supervisor may also select `Execution = Ready` work for a configured `dispatchMode: supervised` executor whose
-`dispatchOwner` is that supervisor. This is dispatch ownership, not implementation ownership: the claim preserves the routed
-Executor and becomes durable only after the external worker acknowledgement is recorded. Sniffy's current instance is ChatGPT
-dispatching Codex Cloud. Local Codex remains a polling pool and Human remains a directed route.
+Eligibility must not require optional Implementer/Verifier values outside the lifecycle status that uses them. A blank Implementer
+means no implementation route has yet been deliberately selected.
 
-Before applying either selector, reconcile a configured non-Human Ready item whose Assignee belongs to a different executor pool.
-Silently excluding it would create a permanently unclaimable state even though its lifecycle fields say Ready.
-
-The canonical work item may be an issue or pull request. The dispatcher also checks lifecycle compatibility, required access,
-worker-pool capacity, existing branch/PR ownership, and absence of a valid current worker. It excludes duplicate representations
-and linked issues suppressed by an open canonical multi-issue PR.
-
-When a profile defines a worker limit, the normal dispatcher derives used capacity from owned `In progress` items in the same
-retained authoritative queue snapshot used for selection. Provider project/task/conversation inventory is not a normal pre-claim
-capacity or duplicate-worker check: it is slower, can be stale, and cannot make `inventory -> claim` atomic. Use provider inventory
-only for targeted recovery of an already claimed `In progress` generation when provisional worker evidence leaves child creation
-uncertain. Per-target duplicate-generation exclusion comes from the guarded claim. A strict cross-target global pool limit across
-several concurrent dispatchers requires a separately serialized semaphore; provider inventory is not that semaphore.
-
-Eligibility must not require `Implementer` or `Verifier` to be populated when the current status does not use them. A blank
-`Implementer` means unknown/not deliberately selected, while `Executor` remains the authoritative current route. Entering
-Implementation requires a non-empty deliberately selected Implementer; Review, PR monitoring, Verification, Approval, and closure
-do not.
-
-Use deterministic selection such as security priority, Project priority, ready timestamp, then repository, item type, and item
-number. Claim at most available capacity and never create duplicate workers or Project items.
+Capacity is derived from owned `In progress` items in the retained snapshot and the profile's configured maximum. Provider-wide
+conversation/task inventory is not a normal capacity or duplicate-generation check; use it only for targeted recovery of one
+already-claimed ambiguous generation. Per-target guarded claims prevent duplicate ownership.
 
 ## Guarded claim
 
-A claim is one ordinary `delivery-control/v1` transition, not a public comment-election protocol:
+A claim:
 
-1. query an eligible canonical `Ready` item;
-2. re-read its Status, Execution, Executor, Assignee, exact PR head when the item is a PR, linked branch/PR, worker reference, and
-   lease;
-3. construct a unique token and worker/tick reference;
-4. post one command guarding at least current Status, `Execution = Ready`, current Executor, canonical target type, and exact PR
-   head when applicable;
-5. set `Execution = In progress`, one Worker reference containing claim token, lease time, concrete owner, and relevant linked
-   PR/head in that same command;
-6. inspect the command reaction and re-read Project state;
-7. only the verified winner performs work or confirms an external dispatch.
+1. live-reads current canonical type, Status, Execution, Executor, assignment, worker reference, and exact PR head when applicable;
+2. creates a unique token, lease, owner, concrete/provisional worker reference, and next observation time;
+3. posts one `delivery-control/v1` command on the active control issue using the readable wrapper from `control-plane.md`;
+4. guards current type, Status, `Execution = Ready`, Executor, and exact PR head;
+5. sets `Execution = In progress` and Worker reference in the same command;
+6. inspects the terminal reaction and re-reads current state;
+7. starts work only for the verified winner.
 
-The transition workflow serializes commands by target work item. Concurrent contenders may both submit commands, but after the
-first succeeds the second sees a guarded-state conflict and performs no mutation. A conflict is normal coordination, not a
-blocker and not a reason to post on the target item.
-
-If execution or dispatch cannot start, submit a guarded release back to `Ready`. Set `Blocked` only when Dmitry must decide or
-act; then set `Executor = Human`, route the Assignee separately to `bedrin`, and record the exact requested action.
-
-## Lease and stale recovery
-
-A live ownership record includes:
-
-```text
-claimToken
-claimedAt
-leaseUntil
-workerReference
-lastObservableEvidence
-```
-
-Before expiring a lease, inspect the worker record, canonical item, linked issues/PR, branch, commits, review state, and CI. Lack
-of a recent target comment does not prove inactivity. Recover the exact existing branch/worker where possible. Release to `Ready`
-only when ownership is genuinely stale. Routine waiting for CI, contributor update, bot rebase, or draft publication remains
-`In progress`; use `Blocked` only when Dmitry must intervene.
-
-Worker monitoring follows [`supervision.md`](supervision.md): first observation after 15 minutes, a second 15 minutes later, then
-hourly while incomplete. Those due observations are selected by the same dispatcher ticks; no extra monitoring scheduler is
-required.
+A guarded conflict is normal coordination. Make no source or work mutation from the stale view. If execution cannot start, release
+to Ready. Set `Blocked / Human` only for one exact Dmitry decision/action.
 
 ## Worker contract
 
-One worker or direct ChatGPT tick owns one lifecycle turn. It must:
+One worker owns one lifecycle turn. After claim it reads the complete canonical item and relevant comments, formal links, exact PR,
+nearest `AGENTS.md`, current reviews/threads/CI/artifacts, and only the detailed lifecycle/runbook sections it needs.
 
-- re-read the canonical issue/PR, all linked requirements, current lifecycle fields, nearest `AGENTS.md`, exact branch/PR/head,
-  review threads, and CI;
-- verify its Project ownership before mutating source or GitHub;
-- perform only the routed lifecycle responsibility;
-- preserve and continue an explicitly adopted same-repository existing PR rather than creating a duplicate;
-- publish exact human-useful evidence on the canonical target;
-- use the common guarded control protocol for the next lifecycle state;
-- stop without spawning a replacement worker when blocked and route the exact next action to Dmitry;
-- never merge or enable auto-merge without explicit authorization.
+- Planning resolves outcome, canonical scope, decisions, non-goals, risk, routes, and proof.
+- Implementation changes the repository, proves the change, publishes one intended non-draft exact-head PR, and hands to Review.
+- Review inspects the complete exact-head diff and publishes one comprehensive outcome with honest identity handling.
+- Verification proves observable behavior in a representative environment rather than trusting unit tests or summaries.
+- Approval and merge remain human-owned.
 
-## Generic core versus project profile
+A transition to Review identifies the exact PR structurally. A canonical PR uses target plus `expected.head`; a canonical issue uses
+`reviewPullRequest.number/head`. The PR must be open, target the base branch, be ready/non-draft, and match the exact head.
 
-Generic documents define lifecycle, canonicalization, intake, guarded claims, leases, correction limits, publication,
-verification, and merge authority. [`profile.yml`](profile.yml) supplies current Sniffy configuration, including Project fields,
-identities, default routes, Local Codex Sol/extra-high settings, universal PR intake, and control-log thresholds.
+## Supervision and recovery
 
-Profiles may add filters, capacity, evidence requirements, or future executor settings, but must not redefine the shared meaning
-of Status, Execution, publication, verification, or merge authority. Update the profile when a routing preference changes; edit
-shared policy only when the semantics themselves change.
+After starting a worker, CI run, contributor operation, bot command, or draft publication, observe after 15 minutes, again after 15
+minutes, then hourly while incomplete. Store `nextObservationAt` in durable worker evidence. The same event-loop responsibility
+selects due observations; do not leave the first check until an hour later.
+
+Before expiring a lease, inspect the concrete worker/task/branch/PR and latest observable evidence. Routine waiting remains
+`In progress`. Recover the exact existing worker/branch where possible; release only genuinely stale ownership.
+
+## Telemetry
+
+Every tick emits start/end/duration, adapter/scheduler, model/reasoning, snapshot identity, selected candidate, outcome, and exact
+provider token counters when exposed. Missing counters are null with `usageSource: unavailable`; estimates must be explicitly
+labelled and derived from measured bytes rather than presented as billing facts.
+
+## Generic core and project profile
+
+Shared Markdown defines lifecycle semantics, canonicalization, guarded ownership, supervision, verification, and merge authority.
+`profile.yml` supplies repository/Project, identities, capacity, scheduler surface/cadence, model defaults, and routing choices.
+Generated dispatch JSON is the runtime form. A profile must not redefine lifecycle meaning or weaken exact-head/no-merge rules.

--- a/docs/ai-delivery/executors/chatgpt.md
+++ b/docs/ai-delivery/executors/chatgpt.md
@@ -1,218 +1,110 @@
 # ChatGPT supervisor and executor
 
-ChatGPT is the default Sniffy delivery supervisor and may also plan, implement, review, or verify when the current chat has the
-required GitHub, sandbox, artifact, browser, identity, and file-editing capabilities.
+ChatGPT is the default delivery supervisor and may plan, implement, review, or verify when the active chat has the required GitHub,
+sandbox, artifact, browser, identity, and publication capabilities.
 
-## Responsibilities
+## Recurring scheduler
 
-As supervisor, ChatGPT:
+Create recurring heartbeats in **Chat**, not **Work**. Work is reserved for a selected long-running investigation or lifecycle turn.
+The scheduler reads only `.chatgpt/status-snapshot-instructions.md`, `runtime-contract.md`, and one current generated dispatch view.
+It does not repeatedly preload the entire AI-delivery documentation set.
 
-- turns discussions into an authoritative issue with decisions, non-goals, Implementer when Implementation is needed, Verifier,
-  and proof obligations;
-- scans every open PR targeting `develop`, regardless of author/label/provider, and canonicalizes issue versus PR before work;
-- treats exactly one closing issue as canonical, standalone PRs as canonical, and multi-issue PRs as Planning items;
-- ingests ready implementations into Review without inferring Implementer from authorship;
-- suppresses duplicate issue/PR lifecycle representations and never reviews the same implementation twice;
-- tracks lifecycle fields, guarded claims, workers, branches, PRs, exact SHAs, draft state, reviews, Verification, CI, artifacts,
-  and blockers;
-- routes same-repository existing-PR corrections to ChatGPT or Local Codex continuation without opening a duplicate;
-- rotates the technical control issue during normal event-loop work;
-- performs the convergence checkpoint when corrected work returns to Review with substantive blockers;
-- never merges or performs privileged operations without explicit instruction.
+Use either:
 
-As executor, reviewer, or verifier, ChatGPT may:
+- one hourly budget Chat task; or
+- four compact hourly Chat tasks at `:00`, `:15`, `:30`, and `:45` for 15-minute queue latency.
 
-- inspect and modify repository files through the GitHub connector;
-- create issues, branches, commits, and pull requests when authorized;
-- continue an explicitly routed same-repository existing PR when connector-backed edits and validation are sufficient;
-- analyze exact-head diffs, comments, review threads, CI jobs, logs, and artifacts;
-- download supported CI artifacts and inspect their contents;
-- run focused commands when source and dependencies are present;
-- serve existing artifacts over localhost and drive installed Chromium when permitted;
-- prepare precise Request Changes, verification evidence, and operator checklists.
+The exact task text lives in [`.chatgpt/scheduled-task-prompt.md`](../../../.chatgpt/scheduled-task-prompt.md). Persistent task chats
+are telemetry, not durable state. Repository changes do not rewrite embedded task prompts; replace and smoke-test them manually.
 
-It delegates obligations it cannot truthfully perform, such as unavailable dependency installation, private/local services,
-hardware, privileged settings, complex existing-branch work, or formal review of its own GitHub-authored PR.
+A tick chooses at most the first programmatically generated attention candidate, live-reads only that target, performs one guarded
+reconciliation/lifecycle turn/external dispatch, and stops. Empty ticks return `NO_CHANGE` plus telemetry without work-item,
+Project, source, worker, target-comment, or control mutation.
 
-## Capability separation
+## Supervisor responsibilities
 
-Do not treat “ChatGPT has internet” as one capability. In the current Sniffy setup:
+ChatGPT owns:
 
-- the GitHub connector may read/write GitHub when the command sandbox cannot reach GitHub;
-- web search may be available while arbitrary sandbox processes have no outbound network;
-- Java may be installed while Maven/npm dependencies are absent;
-- an exact-head CI artifact may be available when source checkout/build is impossible;
-- Chromium may load a localhost artifact, which does not prove a source build;
-- direct workflow dispatch may be unavailable even though issue comments and repository writes are available.
+- universal base-branch PR intake and deterministic issue/PR canonicalization;
+- duplicate representation suppression;
+- stale exact-head and route/assignee reconciliation;
+- Planning and deliberate Implementer/Verifier selection;
+- supervised Codex Cloud dispatch and 15/15/hourly observation;
+- exact-head Review and verification coordination;
+- convergence checkpoints after repeated substantive blockers;
+- control-log rotation;
+- clear human handoff and no-merge enforcement.
 
-Run a capability preflight for canonical item, source, exact branch/head, dependencies, network, runtimes, browser, credentials,
-publication, branch ownership, and review identity. Use the strongest truthful evidence available and route missing obligations
-elsewhere.
+It does not copy PR author/provider identity into Implementer. It preserves an explicitly routed same-repository PR and never adopts
+a fork or Dependabot branch for direct correction.
 
-## Common ProjectV2 control path
+## Capabilities and delegation
 
-ChatGPT uses the same [`../control-plane.md`](../control-plane.md) protocol as Codex and human/CLI operators:
+Treat GitHub connector, arbitrary network, command sandbox, installed runtimes/dependencies, artifact access, browser, credentials,
+branch write permission, and formal review identity as separate capabilities. Run a targeted capability preflight after candidate
+selection. Delegate missing obligations rather than claiming unsupported proof.
 
-1. locate the one active technical control issue;
-2. choose and re-read the canonical issue or PR;
-3. post one guarded `delivery-control/v1` command using the human-readable Markdown wrapper from the control-plane document,
-   preserving its exact markers and lowercase `json` fence, deriving the display-only prose from the authoritative marked JSON;
-4. inspect the reaction and Actions result;
-5. re-read the resulting Project fields and any PR state coupled to the transition;
-6. only then claim ownership or report a handoff.
+Focused connector-backed implementation is allowed when ChatGPT can honestly edit, test/inspect, publish, and verify. Bounded fresh
+work may go to Codex Cloud. Complex/persistent/cross-version/service/browser or exact existing-PR work normally goes to Local Codex.
+Privileged or unresolved product/risk decisions go to Dmitry.
 
-When the canonical item is a PR, guard its exact head. When an issue is canonical, keep its Worker reference pinned to the linked
-PR URL and exact head. Omit optional fields that are not part of the transition. Universal PR intake leaves `Implementer`
-untouched and accepts an empty value; it does not synthesize an author, bot, provider, IDE, or `Unknown` option.
+## Common Project control path
 
-For a command setting `Status = Review`, identify the review PR structurally. A canonical PR uses target plus `expected.head`; a
-canonical issue includes `reviewPullRequest.number/head`. The control plane validates open/develop/exact-head identity, marks a
-draft PR ready if necessary, and verifies non-draft state before writing Project Review.
+ChatGPT uses `delivery-control/v1` on the newest active `ai-delivery-control` issue. Every new autonomous command uses the
+human-readable Markdown wrapper from `control-plane.md`, exact markers, and lowercase `json` fence. The authoritative marked JSON,
+not display prose, drives automation. Never post bare JSON, field commands, claim arbitration, leases, or polling messages on the
+target item.
 
-Do not post `/project-status`, `/project-field`, claim-intent, lease arbitration, or polling comments on target issues/PRs.
-`workflow_dispatch` is the administrative fallback to the same implementation and is not required for normal ChatGPT operation.
+A claim guards current canonical type, Status, `Execution = Ready`, Executor, and exact PR head when applicable; it sets a unique
+worker token/owner/lease/reference/next observation. A handoff is complete only after the terminal reaction and re-read Project,
+assignment, and coupled PR state.
 
-## Universal PR intake
+## PR intake and Review publication
 
-Before ordinary queue work, each stateless tick scans all open PRs targeting `develop`:
+Programmatic snapshot projections cover every open PR targeting `develop` regardless of author/label/provider. ChatGPT live-reads
+only a selected attention candidate.
 
-- draft PRs are telemetry and may be monitored by an existing Implementation owner, but do not enter Review;
-- one formal closing issue means that issue owns lifecycle state and the PR is exact-head implementation evidence;
-- no formal closing issue means the non-draft PR itself becomes the Project item;
-- several formal closing issues mean the PR enters Planning before Review;
-- same-repository, fork, Dependabot, maintainer, IDE, and configured-agent PRs all enter discovery;
-- author/repository ownership affects formal-review and correction policy, not eligibility.
+- one formal closing issue -> issue canonical;
+- no formal closing issue -> PR canonical;
+- multiple formal closing issues -> PR Planning;
+- draft PR -> no Review.
 
-If both an issue and its PR are materialized, ChatGPT reconciles one canonical active item and makes the duplicate non-claimable.
-It does not invent a shadow issue for a standalone PR and does not create a replacement PR solely because an agent did not author
-the existing branch.
+Implementation publication is complete only when the intended PR is open, targets develop, is ready for review/non-draft, matches
+the exact inspected remote head, and has synchronized evidence. A canonical issue transition includes
+`reviewPullRequest.number/head`; a canonical PR guards target plus `expected.head`.
 
-See [`../pull-request-intake.md`](../pull-request-intake.md).
+## Supervised Codex Cloud
 
-## Implementation publication and Review handoff
+The profile marks Codex Cloud `dispatchMode: supervised` with ChatGPT as dispatch owner. ChatGPT claims
+`Implementation / Ready / Codex Cloud` while preserving Executor, submits exactly one supported trigger, requires durable
+acknowledgement, records the generation and first 15-minute observation, then stops. A definitely rejected/non-submitted trigger is
+released to Ready. An uncertain acknowledged generation remains provisional and is recovered without duplicate dispatch.
 
-When ChatGPT performs Implementation directly, publication is complete only after all of the following are true:
+## Review identity and durable outcome
 
-1. the intended PR is open and targets `develop`;
-2. its remote head equals the exact published commit inspected by ChatGPT;
-3. implementation and all locally available proof are complete;
-4. the PR has been marked ready for review and re-read with `draft = false`;
-5. the PR description and evidence match that exact head.
+Review inspects the complete exact-head diff, canonical requirements, generated/unrelated files, tests actually run, unresolved
+threads, and matching-head CI/artifacts. Prefer one comprehensive outcome.
 
-Only then may ChatGPT submit the guarded `Status = Review` transition. For a canonical issue it includes
-`reviewPullRequest.number/head`; for a canonical PR it guards target plus `expected.head`. The control plane may repair a remaining
-draft as a final invariant, but ChatGPT must not rely on that repair instead of completing publication deliberately.
+If the reviewer is independent, blockers receive one formal `REQUEST_CHANGES`. If the active identity authored the PR, publish the
+same complete blocking findings as an ordinary PR comment and state the identity limitation. The technical Review outcome is still
+completed in the same tick:
 
-After the command's terminal reaction, ChatGPT re-reads both the PR as non-draft at the same exact head and the canonical Project
-fields. It updates and verifies assignment separately. A green workflow, successful push, or `+1` reaction without matching PR
-state is not a complete Review handoff.
+- implementation/code/design defect -> `Implementation / Ready` after deliberately selecting an Implementer;
+- requirements/architecture/canonicalization defect -> `Planning / Ready / ChatGPT`;
+- exact Dmitry action -> `Blocked / Human`;
+- technically acceptable -> required Verification or `Approval / Ready / Human`.
 
-## ChatGPT Scheduled Tasks
+Never leave the reviewed exact head in `Review / Ready / ChatGPT` merely because formal self-review is unavailable.
 
-Current limitations materially affect the adapter:
+## Monitoring and telemetry
 
-- a Scheduled Task cannot run more than once per hour;
-- Pro and Enterprise users may have up to 15 active tasks;
-- deleting the associated chat pauses its task;
-- a task created in a ChatGPT Project that has files cannot access those files;
-- Scheduled Tasks cannot create child Scheduled Tasks;
-- Scheduled Tasks and Codex automations are distinct product mechanisms.
+After starting a worker/operation, observe after 15 minutes, another 15 minutes, then hourly. Store `nextObservationAt` durably.
+Routine waiting remains In progress.
 
-Use four hourly tasks at `:00`, `:15`, `:30`, and `:45`. Create each task from a separate empty defining chat inside the fileless
-`AI Delivery Event Loop` Project. The exact setup and shared prompt live in
-[`.chatgpt/scheduled-task-prompt.md`](../../../.chatgpt/scheduled-task-prompt.md).
+Every tick records start/end/duration, scheduler, model/reasoning when exposed, snapshot run, candidate, outcome, and exact provider
+token counters when exposed. Otherwise use null counters and `usageSource: unavailable`; never invent billing precision.
 
-Product testing on 2026-07-30 showed that recurrences append to the defining chat rather than reliably starting a fresh chat. Each
-occurrence must therefore be stateless by procedure:
+## Boundaries
 
-- ignore previous-run conclusions;
-- read current GitHub and repository-owned policy from scratch;
-- request and validate the configured status-snapshot read barrier;
-- canonicalize arbitrary PRs before queue selection;
-- reconcile configured Ready routes that are unclaimable because their Assignee belongs to another executor pool;
-- perform at most one reconciliation, lifecycle turn, or supported dispatch, including a Ready Codex Cloud route for which
-  ChatGPT is the configured dispatch owner;
-- make no work-item, Project, source, or worker mutation for `NO_CHANGE`; the status-refresh request is read telemetry;
-- keep durable state outside the chat.
-
-The four persistent transcripts are telemetry. Replace a long defining chat deliberately using
-[`../chat-retention.md`](../chat-retention.md); do not delete an active task chat before its replacement is smoke-tested.
-
-Worker and PR-operation monitoring is not another Scheduled Task. Due 15-minute, second-15-minute, and hourly observations are
-selected by these same event-loop ticks before new work.
-
-Codex Cloud has no Project polling loop. When the current profile routes bounded fresh Implementation to
-`Implementation / Ready / Codex Cloud`, a ChatGPT tick must claim that route without changing Executor, post exactly one supported
-Cloud trigger, require durable acknowledgement, and record the first 15-minute observation point. If acknowledgement is absent,
-release the provisional claim to Ready only when the trigger was not submitted or was definitively rejected. A submitted trigger
-with uncertain acknowledgement remains one provisional generation for targeted recovery and must not be dispatched again. The
-same ChatGPT loop monitors acknowledged or provisional Cloud `In progress` routes after 15 minutes, again after 15 minutes, then
-hourly. Do not wait for Cloud to discover the Project item. Do not use this bridge for arbitrary existing-PR adoption; route that
-continuation to Local Codex unless the existing Cloud branch is explicitly recoverable.
-
-## ChatGPT Project bootstrap
-
-For ordinary repository Projects, keep Project instructions short and point to repository-owned policy:
-
-```text
-For every sniffy/sniffy task, first read the current repository policy at
-https://github.com/sniffy/sniffy/blob/develop/AGENTS.md and the AI delivery map at
-https://github.com/sniffy/sniffy/blob/develop/docs/ai-delivery/README.md .
-
-Treat the canonical GitHub issue or pull request, linked PR exact head and draft state, Project fields, reviews, CI, artifacts, and
-central control protocol as the source of truth. Never claim that a checkout, command, build, browser session, publication,
-deployment, or settings change occurred unless it completed and its output was inspected. Never merge or enable auto-merge
-without Dmitry's explicit command.
-```
-
-Re-read current-`develop` policy at the start of each repository task. Review evidence remains pinned to the immutable PR head.
-Project context may describe Sniffy's purpose and Dmitry's preferences, but must not duplicate engineering policy or store
-credentials and generated artifacts.
-
-## Direct execution versus delegation
-
-Prefer direct ChatGPT implementation when:
-
-- canonical repository state can be read accurately through available tools;
-- edits and publication are focused and supported;
-- a same-repository existing PR can be safely continued without complex checkout/service state;
-- required checks can run with present source/dependencies, or exact-head CI/artifacts provide the intended proof;
-- browser/system verification can be performed truthfully;
-- formal review remains honest about PR-author identity.
-
-Otherwise follow [`../routing.md`](../routing.md): bounded well-specified fresh work normally goes first to Codex Cloud; complex,
-persistent, cross-version, service/browser, existing-PR, or non-converging work goes to Local Codex Sol/extra-high; privileged or
-unresolved decisions go to Dmitry.
-
-For same-repository correction, preserve the exact branch and PR. For a fork, leave contributor-facing findings and wait for a new
-head or create a deliberately routed internal replacement. For Dependabot, use documented bot commands or linked replacement work.
-
-A PR with empty Implementer may still be reviewed, monitored, verified, approved, superseded, or closed. If new code is required,
-choose a supported Implementer before entering Implementation.
-
-## Review convergence
-
-When Review returns work to Implementation and the corrected head comes back with substantive blockers again, ChatGPT pauses
-serial patching and performs the convergence checkpoint. It may continue the same executor, adopt/escalate the exact existing PR
-to Local Codex, return to Planning, or block for Dmitry. This is a Review decision inside the ordinary event loop, not a new timer.
-
-## Review identity limitation
-
-A PR authored by `bedrin-gpt` cannot be formally approved or receive formal `REQUEST_CHANGES` from the same identity. This limits
-the GitHub review submission, not the technical Review outcome or ChatGPT's lifecycle authority. For an independent author,
-ChatGPT publishes one complete formal `REQUEST_CHANGES` when blockers remain. For its own PR, it publishes the same complete
-blocking feedback as an ordinary PR comment and states the identity limitation. Both paths perform the guarded durable route in
-the same tick; they never leave that exact head in `Review / Ready / ChatGPT` or wait for the formal-review return adapter.
-
-Implementation, code, or design defects return to `Implementation / Ready` only after ChatGPT deliberately selects an eligible
-Implementer and preserves the same same-repository branch, PR, and head. Requirements, architecture, or canonicalization defects
-return to `Planning / Ready / ChatGPT`; `Blocked / Human` requires one exact Dmitry decision or action. If the self-authored PR is
-technically acceptable, ChatGPT routes it to required Verification or `Approval / Ready / Human` rather than parking it in
-Review. A Dmitry-, Dependabot-, external-contributor-, IDE-, or independently-agent-authored PR may receive an honest formal
-ChatGPT review. Identity is determined from the actual PR author, not the optional Project Implementer field.
-
-## Website verification
-
-The command sandbox may lack outbound DNS while GitHub connector access and managed Chromium remain available. Prefer exact-head
-CI artifacts rather than inventing a checkout. Follow [`../../chatgpt-site-preview.md`](../../chatgpt-site-preview.md) for artifact
-identity, localhost serving, reversible browser policy, Playwright evidence, screenshots, and truthful reporting.
+Use the strongest truthful evidence and say exactly what was not run. Never merge, enable auto-merge, bypass protection, rewrite
+shared history, expose credentials, deploy, or change privileged settings without Dmitry's explicit instruction.

--- a/docs/ai-delivery/executors/chatgpt.md
+++ b/docs/ai-delivery/executors/chatgpt.md
@@ -1,72 +1,52 @@
 # ChatGPT supervisor and executor
 
-ChatGPT is the default delivery supervisor and may plan, implement, review, or verify when the active chat has the required GitHub,
-sandbox, artifact, browser, identity, and publication capabilities.
+ChatGPT is the default delivery supervisor and may also plan, implement, review, or verify when the active chat has the required
+GitHub, sandbox, artifact, browser, identity, and publication capabilities.
 
 ## Recurring scheduler
 
 Create recurring heartbeats in **Chat**, not **Work**. Work is reserved for a selected long-running investigation or lifecycle turn.
 The scheduler reads only `.chatgpt/status-snapshot-instructions.md`, `runtime-contract.md`, and one current generated dispatch view.
-It does not repeatedly preload the entire AI-delivery documentation set.
 
-Use either:
+Use one hourly budget task or four compact hourly tasks at `:00`, `:15`, `:30`, and `:45` for 15-minute queue latency. Persistent
+scheduler chats are telemetry, not durable state; repository changes do not rewrite their embedded prompts.
 
-- one hourly budget Chat task; or
-- four compact hourly Chat tasks at `:00`, `:15`, `:30`, and `:45` for 15-minute queue latency.
-
-The exact task text lives in [`.chatgpt/scheduled-task-prompt.md`](../../../.chatgpt/scheduled-task-prompt.md). Persistent task chats
-are telemetry, not durable state. Repository changes do not rewrite embedded task prompts; replace and smoke-test them manually.
-
-A tick chooses at most the first programmatically generated attention candidate, live-reads only that target, performs one guarded
-reconciliation/lifecycle turn/external dispatch, and stops. Empty ticks return `NO_CHANGE` plus telemetry without work-item,
-Project, source, worker, target-comment, or control mutation.
+A tick chooses at most the first generated candidate, live-reads only that target, performs one guarded reconciliation/lifecycle
+turn/external dispatch, and stops. Empty ticks return `NO_CHANGE` plus telemetry.
 
 ## Supervisor responsibilities
 
-ChatGPT owns:
-
-- universal base-branch PR intake and deterministic issue/PR canonicalization;
-- duplicate representation suppression;
-- stale exact-head and route/assignee reconciliation;
-- Planning and deliberate Implementer/Verifier selection;
-- supervised Codex Cloud dispatch and 15/15/hourly observation;
-- exact-head Review and verification coordination;
-- convergence checkpoints after repeated substantive blockers;
-- control-log rotation;
-- clear human handoff and no-merge enforcement.
-
-It does not copy PR author/provider identity into Implementer. It preserves an explicitly routed same-repository PR and never adopts
-a fork or Dependabot branch for direct correction.
+ChatGPT owns universal PR intake/canonicalization, duplicate suppression, exact-head and route reconciliation, Planning, deliberate
+Implementer/Verifier selection, supervised Codex Cloud dispatch, stale-lease recovery, exact-head Review, verification coordination,
+convergence checkpoints, control-log rotation, and clear Human handoff. It never infers Implementer from PR authorship and never
+adopts a fork or Dependabot branch for direct correction.
 
 ## Capabilities and delegation
 
-Treat GitHub connector, arbitrary network, command sandbox, installed runtimes/dependencies, artifact access, browser, credentials,
-branch write permission, and formal review identity as separate capabilities. Run a targeted capability preflight after candidate
-selection. Delegate missing obligations rather than claiming unsupported proof.
+Treat GitHub connector, arbitrary network, command sandbox, runtimes/dependencies, artifact access, browser, credentials, branch
+write permission, and formal review identity as separate capabilities. Run a targeted preflight after selection and delegate missing
+obligations.
 
-Focused connector-backed implementation is allowed when ChatGPT can honestly edit, test/inspect, publish, and verify. Bounded fresh
-work may go to Codex Cloud. Complex/persistent/cross-version/service/browser or exact existing-PR work normally goes to Local Codex.
-Privileged or unresolved product/risk decisions go to Dmitry.
+Focused connector-backed implementation is allowed when ChatGPT can truthfully edit, test/inspect, publish, and verify. Bounded
+fresh work may go to Codex Cloud. Complex/persistent/cross-version/service/browser or exact existing-PR work normally goes to Local
+Codex. Privileged or unresolved product/risk decisions go to Dmitry.
 
-## Common Project control path
+## Common control path
 
-ChatGPT uses `delivery-control/v1` on the newest active `ai-delivery-control` issue. Every new autonomous command uses the
-human-readable Markdown wrapper from `control-plane.md`, exact markers, and lowercase `json` fence. The authoritative marked JSON,
-not display prose, drives automation. Never post bare JSON, field commands, claim arbitration, leases, or polling messages on the
-target item.
+ChatGPT uses `delivery-control/v1` on the active `ai-delivery-control` issue. Every autonomous command uses the human-readable Markdown wrapper from `control-plane.md`, exact start/end markers, and lowercase `json` fence. The marked JSON is authoritative;
+never emit bare JSON or post field/claim/lease/polling commands on the target item.
 
-A claim guards current canonical type, Status, `Execution = Ready`, Executor, and exact PR head when applicable; it sets a unique
-worker token/owner/lease/reference/next observation. A handoff is complete only after the terminal reaction and re-read Project,
+A claim guards canonical type, Status, `Execution = Ready`, Executor, and exact PR head when applicable; it sets token/generation,
+owner, worker reference, `claimedAt`, and `leaseUntil`. A handoff is complete only after terminal reaction and re-read Project,
 assignment, and coupled PR state.
 
 ## PR intake and Review publication
 
-Programmatic snapshot projections cover every open PR targeting `develop` regardless of author/label/provider. ChatGPT live-reads
-only a selected attention candidate.
+Generated projections cover every open PR targeting `develop` regardless of author/label/provider:
 
 - one formal closing issue -> issue canonical;
 - no formal closing issue -> PR canonical;
-- multiple formal closing issues -> PR Planning;
+- several formal closing issues -> PR Planning;
 - draft PR -> no Review.
 
 Implementation publication is complete only when the intended PR is open, targets develop, is ready for review/non-draft, matches
@@ -75,19 +55,28 @@ the exact inspected remote head, and has synchronized evidence. A canonical issu
 
 ## Supervised Codex Cloud
 
-The profile marks Codex Cloud `dispatchMode: supervised` with ChatGPT as dispatch owner. ChatGPT claims
-`Implementation / Ready / Codex Cloud` while preserving Executor, submits exactly one supported trigger, requires durable
-acknowledgement, records the generation and first 15-minute observation, then stops. A definitely rejected/non-submitted trigger is
-released to Ready. An uncertain acknowledged generation remains provisional and is recovered without duplicate dispatch.
+Codex Cloud does not poll Project 2. ChatGPT claims `Implementation / Ready / Codex Cloud` while preserving Executor, submits one
+exact trigger, requires durable acknowledgement, records generation plus lease, and stops. A definitely rejected/non-submitted
+trigger is released. An uncertain submission remains one provisional generation under a shorter lease and is never duplicated.
+
+## Lease-based stale recovery
+
+A normal scheduler tick ignores `In progress` ownership with a valid future `leaseUntil`; it does not query the worker or provider
+task inventory. The worker owns completion signalling and performs its own guarded handoff. It may renew the same claim/generation
+before expiry.
+
+Only missing/invalid worker evidence or expired lease creates stale recovery. Re-read that exact worker/task/branch/PR, extend the
+lease if still active, finish a lost handoff if evidence is complete, recover the same workspace when possible, or release only when
+nothing active/recoverable remains. Never create a duplicate. CI/contributor/bot/draft waits use bounded operation leases too.
 
 ## Review identity and durable outcome
 
-Review inspects the complete exact-head diff, canonical requirements, generated/unrelated files, tests actually run, unresolved
-threads, and matching-head CI/artifacts. Prefer one comprehensive outcome.
+Review inspects the complete exact-head diff, requirements, generated/unrelated files, tests actually run, unresolved threads, and
+matching-head evidence. Prefer one comprehensive outcome.
 
-If the reviewer is independent, blockers receive one formal `REQUEST_CHANGES`. If the active identity authored the PR, publish the
-same complete blocking findings as an ordinary PR comment and state the identity limitation. The technical Review outcome is still
-completed in the same tick:
+If the reviewer is independent, blockers receive `REQUEST_CHANGES`. If the active identity authored the PR, publish the same
+complete findings as an ordinary PR comment and state the identity limitation. The technical Review outcome and durable route
+complete in the same tick:
 
 - implementation/code/design defect -> `Implementation / Ready` after deliberately selecting an Implementer;
 - requirements/architecture/canonicalization defect -> `Planning / Ready / ChatGPT`;
@@ -96,15 +85,10 @@ completed in the same tick:
 
 Never leave the reviewed exact head in `Review / Ready / ChatGPT` merely because formal self-review is unavailable.
 
-## Monitoring and telemetry
+## Telemetry and boundaries
 
-After starting a worker/operation, observe after 15 minutes, another 15 minutes, then hourly. Store `nextObservationAt` durably.
-Routine waiting remains In progress.
+Every tick records start/end/duration, scheduler, model/reasoning when exposed, snapshot run, candidate, outcome, and provider token
+counters when exposed. Otherwise use null counters and `usageSource: unavailable`; never invent billing precision.
 
-Every tick records start/end/duration, scheduler, model/reasoning when exposed, snapshot run, candidate, outcome, and exact provider
-token counters when exposed. Otherwise use null counters and `usageSource: unavailable`; never invent billing precision.
-
-## Boundaries
-
-Use the strongest truthful evidence and say exactly what was not run. Never merge, enable auto-merge, bypass protection, rewrite
-shared history, expose credentials, deploy, or change privileged settings without Dmitry's explicit instruction.
+Use the strongest truthful evidence and say what was not run. Never merge, enable auto-merge, bypass protection, rewrite shared
+history, expose credentials, deploy, or change privileged settings without Dmitry's explicit instruction.

--- a/docs/ai-delivery/executors/codex-cloud.md
+++ b/docs/ai-delivery/executors/codex-cloud.md
@@ -1,163 +1,96 @@
 # Codex Cloud executor
 
 Use Codex Cloud for clean, isolated, fully specified tasks whose context and deterministic proof are available in the Cloud
-environment. Shared engineering policy lives in `AGENTS.md`; this document covers Cloud-specific setup, credentials,
-publication, lifecycle handoff, and failure handling.
+environment. Shared engineering policy lives in `AGENTS.md`; this document covers Cloud-specific routing, setup, publication,
+handoff, and recovery.
 
-Codex Cloud may be selected as Implementer or Verifier. It does not Review its own implementation unless a separate independent
-reviewer identity and explicit route exist. Its model is recorded as `provider-managed` unless the product exposes and the task
-explicitly selects a verified value; do not assume Cloud means Terra or Sol.
+Codex Cloud may implement or verify. Its model is `provider-managed` unless the product exposes and the task records a verified
+selection.
 
-## Route to Cloud when
+## Route to Cloud
 
-- work starts from current `develop` on a fresh branch, or an explicitly re-queued existing **Cloud-owned** branch can be recovered;
-- product, architecture, compatibility, module placement, canonical item, and negative scope are resolved;
-- dependencies are public or prepared by setup/cache;
-- required tests fit available JDKs, tools, network policy, and task window;
-- no local service, device, private network, unusual history surgery, or persistent interactive artifact inspection is required;
-- parallel asynchronous implementation or verification is useful.
+Prefer Cloud when work is bounded fresh work from current `develop`, or an explicitly recoverable Cloud-owned continuation;
+requirements and architecture are resolved; dependencies are public/prepared; proof fits the Cloud environment; and no private
+network, local service/device, persistent interactive state, or history surgery is required.
 
-Cloud is the preferred first external implementation executor for suitable bounded **fresh work** after ChatGPT's
-direct-capability check. That is an environment/routing decision, not a model claim.
+Do not route an arbitrary existing PR to Cloud. Cloud must not open a duplicate branch/PR. Same-repository existing-PR continuation
+normally goes to Local Codex; forks and Dependabot remain contributor/bot-owned.
 
-Do not route an arbitrary existing PR from Dmitry, ChatGPT, an IDE agent, external contributor, Dependabot, or another worker to
-Cloud as if it were a fresh task. Cloud must not open a duplicate branch/PR. Unless the branch is an explicitly recoverable
-Cloud-owned continuation, return routing to the supervisor; same-repository existing-PR continuation normally goes to Local Codex.
+## Repository environment and credentials
 
-Several interacting risk axes require the preflight and proof matrix in [`../routing.md`](../routing.md). When corrected Cloud work
-returns to Review and still has substantive blockers, ChatGPT performs the convergence checkpoint before another dispatch. The
-checkpoint may keep Cloud with rewritten guidance, preserve the branch/PR and escalate continuation to Local Codex, return to
-Planning, or block for Dmitry.
+Use `.codex/cloud/setup.sh`, `maintenance.sh`, `use-jdk.sh`, and `warm-maven-cache.sh` as documented. Preserve the canonical
+`origin` push URL and verify `gh auth status` before publication.
 
-## Repository environment
+Prefer a dedicated revocable fine-grained repository token. Ordinary autonomous publication needs Metadata read, Contents
+read/write, Pull requests read/write, and Issues read/write. Grant Workflows write only for explicitly authorized workflow edits.
+Never expose credentials in URLs, commands, logs, commits, fixtures, or summaries. Repository protection remains the final boundary.
 
-The supported environment uses:
-
-- `.codex/cloud/setup.sh` for initial setup, GitHub CLI authentication, and canonical `origin` push configuration;
-- `.codex/cloud/maintenance.sh` to restore the toolchain and canonical `origin` push URL when a cached environment resumes on
-  another branch;
-- `.codex/cloud/use-jdk.sh <8|11|17|21|25>` for toolchain selection;
-- platform-provided Maven and JDK 11/17/21/25;
-- repository-installed Temurin JDK 8;
-- `GH_TOKEN` plus GitHub CLI as the publication credential path.
-
-Do not replace platform Maven or modern JDKs. Their proxy/TLS integration is part of the Cloud environment. Historical failure
-modes and expected setup logs are documented in `../../codex-cloud-troubleshooting.md`.
-
-Reset the Codex environment cache after setup-script, secret, token-approval, or network-policy changes.
-
-## Credentials and network
-
-Prefer a dedicated, revocable, fine-grained PAT owned by a `sniffy` organization member and restricted to the repository.
-Ordinary autonomous publication needs Metadata read, Contents read/write, Pull requests read/write, and Issues read/write.
-Grant Workflows read/write only for explicitly authorized `.github/workflows/` edits.
-
-Agent internet policy must allow the actual GitHub methods required by publication. Read-only access or setup dry-run may look
-healthy while `git-receive-pack` or API writes remain blocked.
-
-Persisted credentials are readable by repository code, build plugins, dependencies, and agent processes. Never put tokens in
-URLs, commands, logs, commits, summaries, or fixtures. Revoke and reset cache after suspected exposure. Server-side protection
-must block direct/force writes to `develop`; automation identities must not bypass it.
-
-## Environment validation
-
-Before relying on a new or changed environment, run a small reversible validation task that:
-
-- reads `AGENTS.md`, [`../profile.yml`](../profile.yml), and this runbook;
-- reports Java, Maven, Node when relevant, and `gh` versions;
-- checks `gh auth status`;
-- confirms `origin` has `https://github.com/sniffy/sniffy.git` as its push URL;
-- performs and removes a reversible remote-ref write;
-- switches between JDK 8 and JDK 25;
-- runs one focused test and `git diff --check`;
-- leaves no implementation branch or PR.
-
-A dry-run push is not proof of effective write permission.
+Before relying on a changed environment, prove versions/auth/remote, one reversible remote-ref write, required JDKs, one focused
+test, and `git diff --check` without leaving a branch or PR.
 
 ## Common control protocol
 
-Cloud uses the same [`../control-plane.md`](../control-plane.md) protocol as every executor. It locates the active technical
-control issue, posts one guarded `delivery-control/v1` command for a claim or handoff, inspects the reaction, and re-reads Project
-state. Every new command comment uses the control-plane document's human-readable Markdown wrapper with exact markers and a
-lowercase `json` fence; its prose is derived display text and the marked JSON remains authoritative. Cloud must not emit bare JSON
-for autonomous issue comments, update Project fields through a private Cloud-only GraphQL path, or post field/claim comments on
-the target item.
+Cloud uses the active control issue and one guarded `delivery-control/v1` command per claim or handoff. Every autonomous command
+uses the human-readable Markdown wrapper from `control-plane.md`, exact start/end markers, and a lowercase `json` fence. The marked JSON is authoritative; never emit bare JSON or use a private Cloud-only Project mutation path.
 
-The canonical target may be an issue or PR. For fresh work it is normally an issue; for an explicitly recoverable Cloud-owned PR
-continuation the worker reference must name the exact branch/head and no duplicate PR may be created. A command setting
-`Status = Review` must identify the exact PR: target plus `expected.head` when the PR is canonical, or structured
-`reviewPullRequest.number/head` when an issue is canonical.
+A Review transition identifies the exact PR through target plus `expected.head` for a canonical PR, or
+`reviewPullRequest.number/head` for a canonical issue. GitHub assignment, publication, PR state, reviews, CI, and Project mutation
+remain separately verified facts.
 
-GitHub assignment, source publication, PR creation, reviews, and CI remain separately verified operations. The control plane's
-draft-to-ready repair is a final invariant, not a substitute for Cloud completing publication itself.
+## Implementation contract
 
-## Implementation lifecycle contract
+A Cloud implementation worker:
 
-A Cloud implementation task reads the canonical issue/PR, every linked requirement, lifecycle/routing fields, current `develop`,
-applicable `AGENTS.md`, and delivery docs before editing. It must:
+1. verifies canonical target, claim/generation/lease, fresh or recoverable-continuation mode, and intended branch/PR;
+2. rejects arbitrary existing-PR adoption rather than creating duplicate fresh work;
+3. implements the smallest coherent approved scope and maps acceptance criteria to proof;
+4. runs focused checks first, broader applicable checks separately, and inspects the complete final diff;
+5. runs `git diff --check`, commits, and pushes the intended branch;
+6. creates one intended PR for fresh work or updates the exact recoverable Cloud-owned PR;
+7. keeps it draft only while implementation or Cloud-available proof is incomplete;
+8. when complete, marks it ready for review and re-reads it as open, targeting `develop`, non-draft, and at the exact published head;
+9. synchronizes the PR description and publishes exact evidence;
+10. performs its own guarded handoff to `Review / Ready / ChatGPT`, clearing Cloud claim/lease ownership;
+11. verifies terminal reaction, Project fields, bedrin-gpt assignment, and the non-draft exact-head PR;
+12. never reviews its own implementation, merges, or enables auto-merge.
 
-1. verify intended canonical target, fresh/continuation mode, claim, branch, and PR;
-2. reject arbitrary existing-PR adoption and return to supervisor instead of creating a duplicate;
-3. convert each acceptance criterion to implementer-owned proof and implement only approved scope;
-4. run focused checks first, broader applicable checks separately, and available runtime/browser checks;
-5. inspect final diff, generated output, dependencies, documentation, and test discovery;
-6. run `git diff --check`, commit, and push the intended branch;
-7. create the intended PR for fresh work or update the explicitly recoverable Cloud-owned PR; use draft only while implementation
-   or Cloud-available proof is incomplete;
-8. verify remote branch, full SHA, PR URL, base/head refs, draft state, and matching PR head;
-9. when implementation and Cloud-available proof are complete, mark the PR ready for review, then re-read and verify it is open,
-   targets `develop`, has `draft = false`, and still points at the exact published head;
-10. reconcile the PR description with current head, commands, limitations, artifacts, and CI;
-11. publish human-useful implementation evidence on the canonical target;
-12. hand off the canonical item with one guarded command to `Status = Review`, `Execution = Ready`, `Executor = ChatGPT`, recording
-    PR URL/exact head and clearing Cloud worker ownership. If an issue is canonical, include `reviewPullRequest.number/head`;
-13. inspect the terminal reaction, then re-read the PR as non-draft at the same exact head and the canonical Project fields. Update
-    the ChatGPT Assignee separately and verify assignment before reporting handoff;
-14. never review/approve its own implementation, merge, or enable auto-merge.
+A missing `origin` is recoverable checkout configuration. Restore the canonical remote, verify authentication, and attempt the
+authorized push before reporting a real network/permission/protection blocker. Preserve the existing workspace and commit.
 
-A missing `origin` is recoverable checkout configuration, not evidence that setup authentication failed. Setup persists `gh`
-authentication for the agent phase, while the repository URL contains no credential. Before reporting a publication blocker,
-restore the canonical remote, verify auth, and attempt the authorized push:
+## Verification contract
 
-```bash
-if git remote get-url origin >/dev/null 2>&1; then
-  git remote set-url --push origin https://github.com/sniffy/sniffy.git
-else
-  git remote add origin https://github.com/sniffy/sniffy.git
-fi
-gh auth status --hostname github.com
-git push --set-upstream origin HEAD
-```
-
-Only an actual authentication, network-policy, permission, or branch-protection failure after that attempt is a publication
-blocker. Preserve/recover the existing workspace or commit instead of recreating implementation.
-
-## Verification lifecycle contract
-
-When selected as Verifier, Cloud uses the exact published implementation head or artifact named by Review. It performs
-outcome-centric proof the Cloud environment genuinely supports, such as same-artifact compatibility, service/browser journey,
-packaging behavior, or failure/rollback path, and records exact environment/actions/results.
-
-It then publishes evidence and uses one guarded handoff command on the canonical item:
+Cloud Verification uses the exact published head/artifact named by Review and performs outcome-centric proof the environment
+actually supports. Publish environment/actions/results and route:
 
 - pass -> `Approval / Ready / Human`;
-- implementation defect -> `Implementation / Ready / Executor := Implementer` only when a deliberate Implementer is selected;
-- verification harness/evidence defect -> `Verification / Ready / Executor := Verifier`;
-- requirement/architecture/canonicalization defect -> `Planning / Ready / ChatGPT`;
-- capability unavailable in Cloud but available elsewhere -> keep `Ready` and reroute Executor/Verifier;
-- Dmitry action required -> `Verification / Blocked / Human` with exact request.
+- implementation defect -> deliberate `Implementation / Ready / <Implementer>`;
+- evidence/harness defect -> `Verification / Ready / <Verifier>`;
+- requirements/architecture/canonicalization defect -> `Planning / Ready / ChatGPT`;
+- unavailable capability -> reroute Verification to a capable executor;
+- exact Dmitry action -> `Verification / Blocked / Human`.
 
 Do not modify production code inside Verification as an unrecorded shortcut.
 
-## Corrections and supervision
+## Supervised dispatch and lease recovery
 
-A formal review or PR mention may not dispatch Cloud implementation. Use the proven explicit continuation trigger, then apply the
-15-minute, second-15-minute, and hourly monitoring cadence from [`../supervision.md`](../supervision.md). Those observations are
-performed by the normal event loop; do not create a separate monitoring scheduler.
+Codex Cloud does not poll Project 2. ChatGPT supervises `Implementation / Ready / Codex Cloud` by claiming while preserving
+Executor, posting one exact implementation trigger, requiring durable acknowledgement, and recording the concrete generation and
+`leaseUntil`.
 
-Verify a connector acknowledgement or new commit before saying work resumed. If the corrected head returns to Review with
-substantive blockers, stop automatic serial correction and wait for the convergence checkpoint route. Arbitrary existing-PR
-continuation should be preserved and routed to Local Codex rather than recreated in Cloud.
+The Cloud worker owns completion signalling: it publishes evidence and performs the guarded handoff itself. A normal 15-minute
+scheduler tick ignores an acknowledged Cloud worker while its lease is valid; it does not ask the worker whether it is still
+running.
 
-The exact canonical item, GitHub branch, PR, SHA, draft state, reviews, checks, control-command result, and Project state are
-authoritative. Codex UI associations are useful metadata but do not prove publication or completion.
+If Cloud is still legitimately working near expiry, it renews the same claim/generation before `leaseUntil`. If the trigger was not
+submitted or was definitively rejected, release to Ready. If submission succeeded but acknowledgement is uncertain, preserve one
+provisional generation under the shorter provisional lease and never redispatch it.
+
+Only a missing/invalid/expired lease creates stale recovery. The next ordinary scheduler tick targets that exact generation: verify
+worker/task/branch/PR evidence, extend the lease if the same worker is active, complete a lost handoff if publication is sufficient,
+recover the same branch/workspace if possible, or release only when no active/recoverable work remains. Never create a duplicate.
+
+After substantive corrected work returns to Review with blockers again, stop serial patch dispatch and apply the convergence
+checkpoint. Preserve the exact branch/PR if routing moves to Local Codex.
+
+Never merge, enable auto-merge, bypass protection, rewrite shared history, or perform privileged operations without Dmitry's
+explicit instruction.

--- a/docs/ai-delivery/executors/codex-local.md
+++ b/docs/ai-delivery/executors/codex-local.md
@@ -1,170 +1,111 @@
 # Local Codex executors
 
-Local Codex has two supported shapes:
+Local Codex supports an app-native dispatcher/worker topology and a headless CLI topology. Both follow root/nested `AGENTS.md`, the
+compact runtime contract, the shared lifecycle/control protocol, exact PR continuity, truthful proof, and the no-merge boundary.
 
-1. **app-native Local Codex** for app-owned conversations, worktrees, automations, and optional mobile Remote visibility;
-2. **headless Local Codex CLI** for unattended Linux scheduling, persistent caches/services, and scalable worker processes.
+## Model profiles
 
-Both follow `AGENTS.md`, universal issue/PR canonicalization, the shared lifecycle, guarded control protocol, verification contract,
-and no-merge boundary. Current Sniffy configuration in [`../profile.yml`](../profile.yml) uses **Sol** with **extra-high** reasoning
-for Local Codex.
+- persistent dispatcher/heartbeat: `gpt-5.6-luna` / low;
+- normal implementation or verification worker: `gpt-5.6-terra` / medium;
+- explicit difficult-task escalation: `gpt-5.6-sol` / high;
+- xhigh only for an exceptional recorded need.
 
-## Route to Local Codex when
+The dispatcher is intentionally cheap because it performs deterministic queue selection, not code reasoning. Changing model does
+not change authority, claim ownership, branch continuity, review independence, or proof obligations.
 
-Prefer Local Codex for:
+## Route to Local Codex
 
-- complex architecture, concurrency, lifecycle, cleanup, or failure composition;
-- cross-version Java and same-artifact compatibility;
-- persistent dependencies, Docker, services, browsers, or representative local environments;
-- existing same-repository branch/PR continuation, adoption, and recovery;
-- verification requiring local state or long-lived artifacts;
-- a convergence checkpoint that identifies Cloud context/environment/capability limits.
+Prefer Local Codex for complex architecture/concurrency/lifecycle/failure composition, cross-version Java, persistent dependencies
+or services, Docker/browser/local environments, exact same-repository existing-PR continuation, representative Verification, and
+non-convergence caused by environment/context limitations.
 
-Do not route an unresolved product, canonicalization, or architecture decision merely because the local model/profile is strong.
-Planning and maintainer authority still precede implementation.
-
-Do not adopt a fork or Dependabot branch for direct autonomous correction. Those remain contributor/bot-owned or are superseded by
-a deliberately routed internal task.
-
-## Fixed model/profile
-
-The local scheduled automation selects its model and reasoning for the automation as a whole. The current Sniffy dispatcher and
-workers therefore use Sol / extra-high consistently. Do not label Codex Cloud as Terra and do not pretend the local dispatcher can
-switch models per item unless a future product capability is explicitly smoke-tested and the profile is changed.
-
-The app-native dispatcher currently permits one concurrent Local Codex worker. It derives used capacity from `ownedInProgress` in
-the one retained Project snapshot. This is a scheduling policy for the single persistent dispatcher, not a distributed semaphore.
+Do not send unresolved product, architecture, canonicalization, credential, or privilege decisions to a stronger model. Do not
+adopt fork or Dependabot branches for direct autonomous correction.
 
 ## App-native topology
 
 ```text
-persistent dispatcher conversation (Sol / extra-high)
-  -> empty queue: NO_CHANGE, no task/chat/worktree
-  -> eligible canonical issue or PR: guarded claim through central control issue
-       -> one one-time standalone worker task
-       -> one dedicated canonical-item conversation
-       -> one isolated app-managed worktree
-       -> fresh branch or exact adopted existing PR branch
-       -> worker publishes evidence and guarded lifecycle handoff
+persistent Luna/low dispatcher
+  -> one normalized Project snapshot
+  -> empty: NO_CHANGE + telemetry
+  -> selected canonical candidate + guarded claim
+      -> one standalone Terra/medium worker and isolated worktree
+      -> optional explicit Sol/high escalation
+      -> exact branch/PR evidence and guarded handoff
 ```
 
-Use app-native when durable Codex conversation, interactive steering, app-managed worktree, or Remote visibility adds real value.
-The Windows app runs on the disposable VM; code, terminal, GitHub CLI, Java, Maven, Node, Docker, and tests run in WSL2.
+The dispatcher reads its compact prompt, `runtime-contract.md`, profile, worker template, and one queue snapshot. It does not read
+complete discussions/diffs/reviews/CI or detailed policy before selection. Normal capacity comes from `ownedInProgress` plus
+`maxConcurrentWorkers`; provider-wide task inventory is only targeted recovery for one ambiguous already-claimed generation.
 
-Before enabling app dispatch, smoke-test:
+Canonical prompts are `.codex/local/scheduled-task-prompt.md` and `.codex/local/worker-task-prompt.md`. Repository merges do not
+rewrite embedded Codex automations; replace and smoke-test them manually.
 
-- an empty tick creates no worker conversation or worktree;
-- a claimed issue item creates exactly one standalone worker;
-- an explicitly routed same-repository PR continuation reuses the exact branch/PR without a duplicate;
-- fork and Dependabot PRs cannot be adopted for direct correction;
-- a completed Implementation marks its PR ready and verifies non-draft exact-head state before Project Review;
-- the worker uses the expected project/worktree and Sol / extra-high profile;
-- failed child creation releases the guarded claim;
-- repeated automation returns to the intended persistent dispatcher;
-- concurrent dispatchers produce one successful claim and one conflict without target-item claim comments.
-
-Canonical prompts are `.codex/local/scheduled-task-prompt.md` and `.codex/local/worker-task-prompt.md`. Do not assume nested
-one-time task creation survives a product update without retesting.
-
-## Headless Linux topology
+## Headless topology
 
 ```text
 systemd timer or cron
-  -> flock / host-local dispatcher lock
-  -> load docs/ai-delivery/profile.yml
-  -> query canonical Status + Execution + Executor
-  -> central guarded claim
-  -> isolated git worktree
-  -> codex exec with rendered lifecycle prompt
-  -> update exact branch/PR, tests, evidence, guarded handoff
+  -> flock prevents host overlap
+  -> one normalized queue snapshot and guarded claim
+  -> isolated worktree
+  -> codex exec with rendered Terra/medium lifecycle prompt
+  -> exact branch/PR publication and guarded handoff
 ```
 
-Use headless CLI when unattended reliability, Docker/services, persistent caches, several isolated workers, and machine-readable
-logs matter more than app conversation visibility. A five- or fifteen-minute local timer avoids ChatGPT's hourly task limit.
-Host-local `flock` prevents same-host overlap; the GitHub transition workflow serializes cross-provider claims by target item.
-
-Each worker owns:
-
-- one canonical issue or PR and every linked requirement/evidence object;
-- one verified claim token and lifecycle generation;
-- one isolated worktree;
-- one fresh branch/intended PR or exact adopted existing branch/PR;
-- one rendered prompt for the current lifecycle status;
-- one structured log/evidence directory;
-- a bounded process timeout and cleanup path.
-
-A host may run several workers only when capacity, memory, disk, Maven/npm/Docker contention, and repository ownership are
-explicitly configured. Never let two workers own the same canonical item or branch.
+`.codex/local/run-issue.sh` defaults to Terra/medium. Override explicitly for an exceptional task, for example
+`CODEX_MODEL=gpt-5.6-sol CODEX_REASONING_EFFORT=high`; record why normal worker capability was insufficient.
 
 ## Dispatcher contract
 
-Both adapters:
+The Local Codex dispatcher:
 
-- read canonical `Execution = Ready` items routed to Local Codex;
-- accept issue and PR Project items;
-- respect directed Assignee or empty pool ownership;
-- inspect canonicalization, lifecycle, profile, access, capacity, exact branch/PR/head, current worker, and due monitoring;
-- derive normal capacity and duplicate-generation decisions from the retained Project snapshot plus the guarded claim, without a
-  provider-wide Codex project/task inventory before claiming `Ready` work;
-- use provider inventory only for targeted recovery of one provisional `In progress` claim after ambiguous child creation;
-- exclude duplicate representations and linked issues suppressed by an open canonical multi-issue PR;
-- use the one active technical control issue and one guarded `delivery-control/v1` command per claim/transition, posting every new
-  command with the control-plane document's human-readable Markdown wrapper, exact markers, and lowercase `json` fence while
-  treating its marked JSON—not its derived display prose—as authoritative and never emitting bare JSON autonomously;
-- inspect the reaction and re-read Project state before spawning;
-- record concrete conversation/task or process/worktree and exact PR references;
-- release to `Ready` when spawn fails;
-- set `Blocked` only when Dmitry must decide or act;
-- create no source or GitHub mutation for an empty queue.
+- selects issue or PR canonical items routed `Execution = Ready`, `Executor = Local Codex`, and empty/local assignee;
+- checks due owned work before Ready work;
+- uses the retained normalized snapshot once and deterministic ordering;
+- derives capacity from current owned items;
+- live-reads only the selected target's type/open state, formal links, exact PR branch/head/draft/ownership, route, worker reference,
+  and active control issue;
+- suppresses duplicate representations and multi-issue linked work;
+- claims through one guarded command before spawning;
+- creates exactly one worker/generation;
+- releases a definitely failed spawn, preserves an ambiguous generation for targeted recovery, and blocks only for Dmitry;
+- creates no source/Project/worker mutation for an empty queue.
 
-Worker observation after 15 minutes, another 15 minutes, then hourly is part of this same dispatcher loop. Do not add a separate
-monitoring scheduler.
+Every new command uses the control-plane human-readable Markdown wrapper, exact markers, and lowercase `json` fence; the marked JSON
+is authoritative. Never emit bare JSON. Inspect reaction and re-read current Project state before worker creation or handoff.
 
-## Fresh versus adopted continuation
+## Existing PR continuation
 
-Fresh Implementation starts from current `origin/develop` only when no existing branch/PR owns the canonical item.
+An adopted continuation is valid only when an open same-repository PR exists and the canonical Project route deliberately selects
+Local Codex. Worker evidence names the exact PR/branch/head; push permission and competing ownership are checked. Reuse the exact
+branch and PR even if Dmitry, ChatGPT, an IDE agent, or another configured worker created it.
 
-An adopted continuation is valid when all are true:
-
-- an open same-repository PR already contains the intended implementation;
-- the canonical Project item explicitly routes `Implementer = Local Codex`, `Executor = Local Codex`;
-- the worker reference names the exact PR, branch, and head;
-- effective push permission and absence of competing ownership are verified;
-- the correction request is complete enough for one implementation turn.
-
-The worker then fetches and updates the exact existing branch. It does not reset, rebase, force-push, discard useful commits,
-open a replacement PR, or silently narrow the PR to only its latest review comments. Branch authorship by Dmitry, ChatGPT, or an
-IDE agent is neither a blocker nor sufficient authorization; the guarded Project route is authoritative.
+Never reset, rebase, force-push, discard useful commits, open a replacement PR, or silently narrow scope. Fork and Dependabot PRs
+receive contributor/bot operations or a deliberate internal replacement task.
 
 ## Worker contract
 
-A Local Codex worker performs only the routed lifecycle status:
+A worker performs one routed lifecycle status:
 
-- Planning is unusual and normally remains ChatGPT/human-owned;
-- Implementation changes code, runs implementer-owned checks, inspects the full diff, commits, pushes, and verifies publication;
-- Verification runs outcome-centric system/integration/browser proof when selected;
-- Review is performed only with an independent configured identity and explicit route.
+- Implementation converts acceptance criteria to proof, changes the repository, tests, inspects the complete diff, commits/pushes,
+  and publishes one intended PR;
+- Verification proves observable behavior in a representative environment;
+- Review requires an independent configured identity and explicit route;
+- Planning normally remains ChatGPT/human-owned.
 
-For fresh work, create one branch and intended PR. For continuation, use the exact existing same-repository PR branch. Keep the PR
-draft only while implementation or locally available proof is incomplete. When complete, mark it ready for review and re-read it
-as open, targeting `develop`, `draft = false`, and at the exact remote head. A successful push or green CI alone is not a Review
-handoff.
+For fresh work create one branch/PR. For continuation update the exact existing branch/PR. When Implementation is complete, mark the
+PR ready for review and re-read it as open, targeting develop, non-draft, and at the exact published head. Then publish evidence and
+use one guarded handoff to `Review / Ready / ChatGPT`; a canonical issue includes `reviewPullRequest.number/head`, while a canonical
+PR guards `expected.head`. Verify reaction, Project state, bedrin-gpt assignment, and exact-head PR state.
 
-Publish human-useful evidence on the canonical item and synchronize the PR description. Then use one guarded command to hand the
-canonical item to `Review / Ready / ChatGPT`, recording the PR URL/head and clearing worker ownership. For a canonical issue the
-command must include `reviewPullRequest.number/head`; for a canonical PR it guards target plus `expected.head`. The control plane
-may repair a remaining draft, but the worker must not depend on that repair.
+Routine waiting remains In progress. Observe after 15 minutes, again 15 minutes later, then hourly. Store the next observation in
+Worker reference. Leave no finished/missing worker In progress.
 
-After the command receives its terminal reaction, re-read both the PR as non-draft at the same exact head and the canonical Project
-state. Assign `bedrin-gpt` separately and verify assignment. Do not report completion until all three surfaces agree.
+## Telemetry and security
 
-Never merge or enable auto-merge without Dmitry's explicit instruction.
+Every dispatcher/worker records start/end/duration, model/reasoning, snapshot/candidate, outcome, and exact provider token counters
+when exposed. Otherwise counters are null with `usageSource: unavailable`; never fabricate exact usage.
 
-## Security
-
-Host policy defines filesystem, network, credentials, Docker, services, browsers, and sandbox/approval mode. Treat Docker group
-or full filesystem/network access as privileged. Use a dedicated low-value VM or host account with repository-scoped GitHub
-credentials and no unrelated personal/employer data.
-
-Codex CLI still needs network access for model calls even when task-process network is restricted. External integration tests and
-package downloads need separately configured policy. GitHub rulesets remain the final write boundary.
+Use a dedicated low-value VM/account with repository-scoped credentials. Docker/full filesystem/network access is privileged host
+policy. Never merge, enable auto-merge, bypass protection, rewrite shared history, or perform privileged operations without
+Dmitry's explicit instruction.

--- a/docs/ai-delivery/executors/codex-local.md
+++ b/docs/ai-delivery/executors/codex-local.md
@@ -1,17 +1,16 @@
 # Local Codex executors
 
 Local Codex supports an app-native dispatcher/worker topology and a headless CLI topology. Both follow root/nested `AGENTS.md`, the
-compact runtime contract, the shared lifecycle/control protocol, exact PR continuity, truthful proof, and the no-merge boundary.
+compact runtime contract, shared lifecycle/control protocol, exact PR continuity, truthful proof, and the no-merge boundary.
 
 ## Model profiles
 
-- persistent dispatcher/heartbeat: `gpt-5.6-luna` / low;
+- persistent dispatcher: `gpt-5.6-luna` / low;
 - normal implementation or verification worker: `gpt-5.6-terra` / medium;
 - explicit difficult-task escalation: `gpt-5.6-sol` / high;
 - xhigh only for an exceptional recorded need.
 
-The dispatcher is intentionally cheap because it performs deterministic queue selection, not code reasoning. Changing model does
-not change authority, claim ownership, branch continuity, review independence, or proof obligations.
+Model choice does not change authority, claim ownership, branch continuity, review independence, or proof obligations.
 
 ## Route to Local Codex
 
@@ -19,8 +18,8 @@ Prefer Local Codex for complex architecture/concurrency/lifecycle/failure compos
 or services, Docker/browser/local environments, exact same-repository existing-PR continuation, representative Verification, and
 non-convergence caused by environment/context limitations.
 
-Do not send unresolved product, architecture, canonicalization, credential, or privilege decisions to a stronger model. Do not
-adopt fork or Dependabot branches for direct autonomous correction.
+Do not send unresolved product/architecture/canonicalization/credential/privilege decisions to a stronger model. Never adopt fork
+or Dependabot branches for direct autonomous correction.
 
 ## App-native topology
 
@@ -28,18 +27,19 @@ adopt fork or Dependabot branches for direct autonomous correction.
 persistent Luna/low dispatcher
   -> one normalized Project snapshot
   -> empty: NO_CHANGE + telemetry
-  -> selected canonical candidate + guarded claim
+  -> selected Ready or stale-lease candidate
+      -> targeted live read + guarded claim/recovery
       -> one standalone Terra/medium worker and isolated worktree
       -> optional explicit Sol/high escalation
       -> exact branch/PR evidence and guarded handoff
 ```
 
 The dispatcher reads its compact prompt, `runtime-contract.md`, profile, worker template, and one queue snapshot. It does not read
-complete discussions/diffs/reviews/CI or detailed policy before selection. Normal capacity comes from `ownedInProgress` plus
-`maxConcurrentWorkers`; provider-wide task inventory is only targeted recovery for one ambiguous already-claimed generation.
+complete discussions/diffs/reviews/CI before selection. Provider-wide task inventory is only targeted recovery for one selected
+missing/invalid/expired lease.
 
 Canonical prompts are `.codex/local/scheduled-task-prompt.md` and `.codex/local/worker-task-prompt.md`. Repository merges do not
-rewrite embedded Codex automations; replace and smoke-test them manually.
+rewrite embedded automations; replace and smoke-test them manually.
 
 ## Headless topology
 
@@ -48,58 +48,57 @@ systemd timer or cron
   -> flock prevents host overlap
   -> one normalized queue snapshot and guarded claim
   -> isolated worktree
-  -> codex exec with rendered Terra/medium lifecycle prompt
+  -> codex exec with Terra/medium lifecycle prompt
   -> exact branch/PR publication and guarded handoff
 ```
 
-`.codex/local/run-issue.sh` defaults to Terra/medium. Override explicitly for an exceptional task, for example
-`CODEX_MODEL=gpt-5.6-sol CODEX_REASONING_EFFORT=high`; record why normal worker capability was insufficient.
+`.codex/local/run-issue.sh` defaults to Terra/medium. Override to Sol/high only for an exceptional task and record why normal worker
+capability was insufficient.
 
 ## Dispatcher contract
 
-The Local Codex dispatcher:
+The dispatcher:
 
-- selects issue or PR canonical items routed `Execution = Ready`, `Executor = Local Codex`, and empty/local assignee;
-- checks due owned work before Ready work;
+- selects canonical issue/PR work routed `Execution = Ready`, `Executor = Local Codex`, with empty/local assignee;
+- counts every owned `In progress` item against capacity;
+- ignores owned work with a valid future lease without opening its worker;
+- selects stale recovery only for missing/invalid worker evidence or expired `leaseUntil`;
 - uses the retained normalized snapshot once and deterministic ordering;
-- derives capacity from current owned items;
-- live-reads only the selected target's type/open state, formal links, exact PR branch/head/draft/ownership, route, worker reference,
-  and active control issue;
+- live-reads only the selected target;
 - suppresses duplicate representations and multi-issue linked work;
-- claims through one guarded command before spawning;
-- creates exactly one worker/generation;
-- releases a definitely failed spawn, preserves an ambiguous generation for targeted recovery, and blocks only for Dmitry;
+- claims Ready work before spawning exactly one worker/generation;
+- preserves an ambiguous spawn as one provisional generation rather than redispatching;
 - creates no source/Project/worker mutation for an empty queue.
 
-Every new command uses the control-plane human-readable Markdown wrapper, exact markers, and lowercase `json` fence; the marked JSON
-is authoritative. Never emit bare JSON. Inspect reaction and re-read current Project state before worker creation or handoff.
+Every autonomous command uses the control-plane human-readable Markdown wrapper, exact start/end markers, and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Inspect the terminal reaction and re-read Project state before
+worker creation, recovery, or handoff.
 
 ## Existing PR continuation
 
-An adopted continuation is valid only when an open same-repository PR exists and the canonical Project route deliberately selects
-Local Codex. Worker evidence names the exact PR/branch/head; push permission and competing ownership are checked. Reuse the exact
-branch and PR even if Dmitry, ChatGPT, an IDE agent, or another configured worker created it.
-
-Never reset, rebase, force-push, discard useful commits, open a replacement PR, or silently narrow scope. Fork and Dependabot PRs
-receive contributor/bot operations or a deliberate internal replacement task.
+An existing same-repository PR may be an adopted continuation only when the canonical Project route deliberately selects Local
+Codex. Reuse the exact same-repository open PR branch and PR even if Dmitry, ChatGPT, an IDE agent, or another worker created it.
+Do not create a fresh branch or duplicate PR. Never reset, rebase, force-push, discard useful commits, or silently narrow scope.
+Never adopt a fork or Dependabot branch.
 
 ## Worker contract
 
-A worker performs one routed lifecycle status:
+A worker performs one routed status. Implementation maps acceptance criteria to proof, changes code, tests, inspects the complete
+diff, commits/pushes, and publishes one intended PR. Verification proves observable behavior in a representative environment.
+Review requires an independent configured identity.
 
-- Implementation converts acceptance criteria to proof, changes the repository, tests, inspects the complete diff, commits/pushes,
-  and publishes one intended PR;
-- Verification proves observable behavior in a representative environment;
-- Review requires an independent configured identity and explicit route;
-- Planning normally remains ChatGPT/human-owned.
+For fresh work create one branch/PR. For continuation update the exact existing branch/PR. When Implementation is complete, mark
+the PR ready for review and re-read it as open, targeting develop, non-draft, and at the exact published head. Then publish evidence
+and use one guarded handoff to `Review / Ready / ChatGPT`; a canonical issue includes `reviewPullRequest.number/head`, while a
+canonical PR guards `expected.head`. Verify reaction, Project state, bedrin-gpt assignment, and exact-head PR state.
 
-For fresh work create one branch/PR. For continuation update the exact existing branch/PR. When Implementation is complete, mark the
-PR ready for review and re-read it as open, targeting develop, non-draft, and at the exact published head. Then publish evidence and
-use one guarded handoff to `Review / Ready / ChatGPT`; a canonical issue includes `reviewPullRequest.number/head`, while a canonical
-PR guards `expected.head`. Verify reaction, Project state, bedrin-gpt assignment, and exact-head PR state.
+The worker owns completion signalling. It may renew the same claim/generation before lease expiry if still legitimately running; it
+must not merely wait for the dispatcher to discover completion.
 
-Routine waiting remains In progress. Observe after 15 minutes, again 15 minutes later, then hourly. Store the next observation in
-Worker reference. Leave no finished/missing worker In progress.
+## Lease recovery
+
+Normal ticks do not poll active workers. If a lease is missing/invalid/expired, target that exact generation. Extend only after
+proving the same worker remains active; complete a lost handoff when publication is sufficient; recover the same worktree/branch
+where possible; release only when no active/recoverable work remains. Never duplicate the task, generation, branch, or PR.
 
 ## Telemetry and security
 

--- a/docs/ai-delivery/instruction-audit.md
+++ b/docs/ai-delivery/instruction-audit.md
@@ -1,0 +1,127 @@
+# Instruction and scheduler audit
+
+Baseline reviewed: `develop` at `790a990b9a7f1a51403ee43148a3c8daa3085233` (`gptflow-v1` candidate).
+
+## Entry points before this refactor
+
+| Adapter | Scheduler entry point | Worker entry point | Effective recurring load |
+| --- | --- | --- | --- |
+| ChatGPT Scheduled Tasks | `.chatgpt/scheduled-task-prompt.md` | the same scheduled occurrence or supervised Codex Cloud | the embedded event-loop prompt plus `AGENTS.md`, 10 AI-delivery documents, the ChatGPT runbook, and the snapshot supplement on every tick |
+| Local Codex app | `.codex/local/scheduled-task-prompt.md` | `.codex/local/worker-task-prompt.md` | `AGENTS.md`, nine AI-delivery documents, dispatcher prompt, worker template, Project snapshot, then a Sol/extra-high worker |
+| Local Codex CLI | `.codex/local/run-issue.sh` | its inline prompt plus repository instructions discovered by Codex | Sol/xhigh by default for every issue |
+| Codex Cloud | GitHub `@codex`/connector dispatch plus `docs/ai-delivery/executors/codex-cloud.md` | Cloud task | bounded fresh implementation, provider-managed model |
+| GitHub status workflow | `.github/workflows/delivery-status.yml` | `.github/scripts/delivery-status*.js` | programmatic Project, issue, PR, formal-closing-link, and mergeability snapshot |
+
+The largest avoidable cost was not the lifecycle itself. It was repeating human documentation and asking an LLM to perform queue
+filtering that the status workflow or a local snapshot helper can perform deterministically.
+
+## Instruction layers after this refactor
+
+### Always loaded by a dispatcher
+
+- the scheduler's short adapter prompt;
+- `docs/ai-delivery/runtime-contract.md`;
+- one normalized snapshot or local queue projection;
+- `profile.yml` only when a concrete adapter setting cannot be carried in the generated snapshot.
+
+### Loaded only after candidate selection
+
+- current canonical issue/PR and formal links;
+- current exact branch/head/draft/ownership and Project route;
+- active control issue;
+- the selected executor's short runbook or worker template.
+
+### Loaded only by the lifecycle worker
+
+- nearest `AGENTS.md` files;
+- complete relevant issue/PR discussion;
+- full exact-head diff, reviews, threads, CI, artifacts;
+- only the lifecycle, routing, supervision, verification, or environment sections needed for that status.
+
+### Human/reference documentation
+
+`README.md`, `lifecycle.md`, `control-plane.md`, `pull-request-intake.md`, `routing.md`, `supervision.md`, `verification.md`,
+retrospectives, architecture notes, and setup guides remain valuable. They are not a mandatory repeated prompt prefix.
+
+## What `profile.yml` really does
+
+The profile is useful and should stay. It is the project-specific declarative configuration for repository, Project, identities,
+routes, executor capacity, model defaults, snapshot settings, and scheduler policy. Before this refactor it was only partly consumed:
+several values were read by humans/prompts or protected by tests, while prompts still duplicated the same choices in prose.
+
+The realistic path is:
+
+1. keep shared lifecycle semantics in Markdown;
+2. keep project-specific values in `profile.yml`;
+3. have repository automation compile normalized queue and PR-attention projections into the status artifact;
+4. let each adapter consume those generated projections rather than interpreting raw Project state;
+5. later extract the generic scripts and schema into a reusable repository/tool, with one profile per project.
+
+This PR deliberately does not add a home-grown YAML parser to every dispatcher. The GitHub workflow currently passes the small
+runtime identity map explicitly, while the profile remains the reviewed source of configuration. A later framework extraction can
+compile YAML once in trusted automation and publish a versioned runtime JSON profile beside the queue snapshot.
+
+## Scheduler setup
+
+### ChatGPT
+
+Create recurring dispatcher tasks in **Chat**, not **Work**. Work is reserved for a selected long-running investigation or
+lifecycle turn, not the heartbeat.
+
+Two supported clocks:
+
+- budget clock: one compact Chat task hourly;
+- 15-minute clock: four compact Chat tasks hourly at `:00`, `:15`, `:30`, and `:45` when the faster queue latency justifies the
+  extra usage.
+
+Both use the same short prompt and generated snapshot. Do not copy the detailed documentation into the task definition. The
+15-minute worker-supervision rule still applies after a real dispatch; when using the budget clock, use explicit two 15-minute
+follow-up checks for the selected worker and then return to hourly monitoring.
+
+### Local Codex
+
+- dispatcher/heartbeat: `gpt-5.6-luna`, low reasoning;
+- normal implementation or verification worker: `gpt-5.6-terra`, medium reasoning;
+- explicit difficult-task escalation: `gpt-5.6-sol`, high reasoning;
+- xhigh is exceptional and requires a recorded reason.
+
+Model selection is an operational cost/capability setting, not a lifecycle role. Existing branches, claims, review independence,
+and proof requirements do not change when the model changes.
+
+## Telemetry and token accounting
+
+Every tick and worker should report start/end time, duration, model/reasoning, snapshot generation, selected candidate, and outcome.
+Exact token counters should be included when the product/runtime exposes them. Otherwise report `null`; do not manufacture billing
+precision. Duration and candidate counts are always available and are sufficient to find runaway no-op loops.
+
+Recommended aggregation dimensions:
+
+- scheduler/adapter and repository profile;
+- no-op versus productive outcome;
+- model and reasoning effort;
+- number of full snapshots and targeted live reads;
+- selected lifecycle status/executor;
+- provider token counters when exposed;
+- failures, rate limits, guarded conflicts, and duplicate-generation recoveries.
+
+## Preserved behavior
+
+The compact runtime contract retains universal PR intake, canonical issue/PR selection, exact-head validity, guarded Project
+mutations, non-draft Review publication, independent-review rules, existing same-repository PR continuation, fork/Dependabot
+boundaries, Codex Cloud supervised dispatch, 15/15/hourly monitoring, convergence checkpoints, truthful verification, human-only
+privileged actions, and the explicit no-merge boundary.
+
+## Baseline tag
+
+Create the baseline annotated tag after verifying the target SHA:
+
+```bash
+git fetch origin develop
+test "$(git rev-parse origin/develop)" = 790a990b9a7f1a51403ee43148a3c8daa3085233
+git tag -a gptflow-v1 790a990b9a7f1a51403ee43148a3c8daa3085233 \
+  -m "GPTFlow v1 before token-efficiency refactor"
+git push origin refs/tags/gptflow-v1
+```
+
+The connected GitHub tool used for this audit can create branches and commits but does not expose tag-ref creation, so the tag is a
+maintainer command rather than being silently approximated by a branch.

--- a/docs/ai-delivery/instruction-audit.md
+++ b/docs/ai-delivery/instruction-audit.md
@@ -4,116 +4,94 @@ Baseline reviewed: `develop` at `790a990b9a7f1a51403ee43148a3c8daa3085233` (`gpt
 
 ## Entry points before this refactor
 
-| Adapter | Scheduler entry point | Worker entry point | Effective recurring load |
+| Adapter | Scheduler entry point | Worker entry point | Previous recurring load |
 | --- | --- | --- | --- |
-| ChatGPT Scheduled Tasks | `.chatgpt/scheduled-task-prompt.md` | the same scheduled occurrence or supervised Codex Cloud | the embedded event-loop prompt plus `AGENTS.md`, 10 AI-delivery documents, the ChatGPT runbook, and the snapshot supplement on every tick |
-| Local Codex app | `.codex/local/scheduled-task-prompt.md` | `.codex/local/worker-task-prompt.md` | `AGENTS.md`, nine AI-delivery documents, dispatcher prompt, worker template, Project snapshot, then a Sol/extra-high worker |
-| Local Codex CLI | `.codex/local/run-issue.sh` | its inline prompt plus repository instructions discovered by Codex | Sol/xhigh by default for every issue |
-| Codex Cloud | GitHub `@codex`/connector dispatch plus `docs/ai-delivery/executors/codex-cloud.md` | Cloud task | bounded fresh implementation, provider-managed model |
-| GitHub status workflow | `.github/workflows/delivery-status.yml` | `.github/scripts/delivery-status*.js` | programmatic Project, issue, PR, formal-closing-link, and mergeability snapshot |
+| ChatGPT Scheduled Tasks | `.chatgpt/scheduled-task-prompt.md` | same occurrence or supervised Codex Cloud | embedded event-loop policy plus many AI-delivery documents on every tick |
+| Local Codex app | `.codex/local/scheduled-task-prompt.md` | `.codex/local/worker-task-prompt.md` | many policy documents, full Project read, then Sol/xhigh worker |
+| Local Codex CLI | `.codex/local/run-issue.sh` | inline worker prompt | Sol/xhigh by default |
+| Codex Cloud | connector/GitHub trigger | Cloud task | bounded fresh implementation, provider-managed model |
+| GitHub status workflow | `.github/workflows/delivery-status.yml` | `.github/scripts/delivery-status*.js` | deterministic Project/issue/PR snapshot |
 
-The largest avoidable cost was not the lifecycle itself. It was repeating human documentation and asking an LLM to perform queue
-filtering that the status workflow or a local snapshot helper can perform deterministically.
+The largest avoidable cost was repeating human documentation and asking an LLM to perform queue filtering that trusted automation
+can perform deterministically. Periodic “is the worker still running?” polling was another avoidable cost once workers already own
+completion handoff.
 
 ## Instruction layers after this refactor
 
 ### Always loaded by a dispatcher
 
-- the scheduler's short adapter prompt;
+- short adapter prompt;
 - `docs/ai-delivery/runtime-contract.md`;
-- one normalized snapshot or local queue projection;
-- `profile.yml` only when a concrete adapter setting cannot be carried in the generated snapshot.
+- one normalized snapshot/local queue projection;
+- `profile.yml` only for adapter settings not already compiled into runtime data.
 
-### Loaded only after candidate selection
+### Loaded after candidate selection
 
-- current canonical issue/PR and formal links;
-- current exact branch/head/draft/ownership and Project route;
+- current canonical item and formal links;
+- exact branch/head/draft/ownership and Project route;
 - active control issue;
-- the selected executor's short runbook or worker template.
+- selected executor's short runbook/template.
 
-### Loaded only by the lifecycle worker
+### Loaded by the lifecycle worker
 
 - nearest `AGENTS.md` files;
-- complete relevant issue/PR discussion;
-- full exact-head diff, reviews, threads, CI, artifacts;
-- only the lifecycle, routing, supervision, verification, or environment sections needed for that status.
+- complete relevant discussion;
+- full exact-head diff, reviews, threads, CI, and artifacts;
+- only the detailed lifecycle/routing/verification/environment sections needed for that status.
 
-### Human/reference documentation
+Human/reference documents remain normative but are not a recurring dispatcher prefix.
 
-`README.md`, `lifecycle.md`, `control-plane.md`, `pull-request-intake.md`, `routing.md`, `supervision.md`, `verification.md`,
-retrospectives, architecture notes, and setup guides remain valuable. They are not a mandatory repeated prompt prefix.
+## What `profile.yml` does
 
-## What `profile.yml` really does
-
-The profile is useful and should stay. It is the project-specific declarative configuration for repository, Project, identities,
-routes, executor capacity, model defaults, snapshot settings, and scheduler policy. Before this refactor it was only partly consumed:
-several values were read by humans/prompts or protected by tests, while prompts still duplicated the same choices in prose.
-
-The realistic path is:
-
-1. keep shared lifecycle semantics in Markdown;
-2. keep project-specific values in `profile.yml`;
-3. have repository automation compile normalized queue and PR-attention projections into the status artifact;
-4. let each adapter consume those generated projections rather than interpreting raw Project state;
-5. later extract the generic scripts and schema into a reusable repository/tool, with one profile per project.
-
-This PR deliberately does not add a home-grown YAML parser to every dispatcher. The GitHub workflow currently passes the small
-runtime identity map explicitly, while the profile remains the reviewed source of configuration. A later framework extraction can
-compile YAML once in trusted automation and publish a versioned runtime JSON profile beside the queue snapshot.
+The profile remains useful as project-specific declarative configuration for repository, Project, identities, routes, capacity,
+model defaults, leases, snapshot settings, and scheduler policy. Shared lifecycle semantics remain Markdown. Trusted automation
+should compile the profile once into versioned runtime JSON beside the generated queue rather than asking every dispatcher to parse
+YAML and prose independently.
 
 ## Scheduler setup
 
 ### ChatGPT
 
-Create recurring dispatcher tasks in **Chat**, not **Work**. Work is reserved for a selected long-running investigation or
-lifecycle turn, not the heartbeat.
+Create recurring dispatcher tasks in **Chat**, not **Work**. Use one hourly budget clock or four compact hourly tasks at `:00`,
+`:15`, `:30`, and `:45` for 15-minute queue latency. Both use the same short prompt and generated snapshot.
 
-Two supported clocks:
-
-- budget clock: one compact Chat task hourly;
-- 15-minute clock: four compact Chat tasks hourly at `:00`, `:15`, `:30`, and `:45` when the faster queue latency justifies the
-  extra usage.
-
-Both use the same short prompt and generated snapshot. Do not copy the detailed documentation into the task definition. The
-15-minute worker-supervision rule still applies after a real dispatch; when using the budget clock, use explicit two 15-minute
-follow-up checks for the selected worker and then return to hourly monitoring.
+The 15-minute clock checks for new actionable GitHub/Project state. It does not poll every active worker. Valid leased ownership is
+ignored until the worker hands off or the lease becomes missing, invalid, or expired.
 
 ### Local Codex
 
-- dispatcher/heartbeat: `gpt-5.6-luna`, low reasoning;
-- normal implementation or verification worker: `gpt-5.6-terra`, medium reasoning;
-- explicit difficult-task escalation: `gpt-5.6-sol`, high reasoning;
-- xhigh is exceptional and requires a recorded reason.
+- dispatcher: `gpt-5.6-luna` / low;
+- normal worker: `gpt-5.6-terra` / medium;
+- explicit difficult-task escalation: `gpt-5.6-sol` / high;
+- xhigh only for an exceptional recorded reason.
 
-Model selection is an operational cost/capability setting, not a lifecycle role. Existing branches, claims, review independence,
-and proof requirements do not change when the model changes.
+Model selection is an operational cost/capability setting, not a lifecycle role.
+
+## Lease-based stale recovery
+
+Every claim records a concrete worker/task/process/branch reference, token/generation, `claimedAt`, and `leaseUntil`. The worker owns
+normal completion signalling and guarded handoff. It may renew the same claim before expiry.
+
+A dispatcher does not query a healthy worker. Only missing/invalid worker evidence or expired lease enters the attention queue.
+Targeted recovery preserves the exact generation and either extends the active lease, completes a lost handoff, recovers the same
+workspace/branch, or releases only when no active/recoverable work remains. There is no per-worker observation schedule and no
+separate monitoring task.
 
 ## Telemetry and token accounting
 
-Every tick and worker should report start/end time, duration, model/reasoning, snapshot generation, selected candidate, and outcome.
-Exact token counters should be included when the product/runtime exposes them. Otherwise report `null`; do not manufacture billing
-precision. Duration and candidate counts are always available and are sufficient to find runaway no-op loops.
-
-Recommended aggregation dimensions:
-
-- scheduler/adapter and repository profile;
-- no-op versus productive outcome;
-- model and reasoning effort;
-- number of full snapshots and targeted live reads;
-- selected lifecycle status/executor;
-- provider token counters when exposed;
-- failures, rate limits, guarded conflicts, and duplicate-generation recoveries.
+Every tick/worker reports start/end, duration, model/reasoning, snapshot generation, selected candidate, outcome, and provider token
+counters when exposed. Otherwise counters are `null`; billing precision is never manufactured. Useful aggregation dimensions are
+adapter/profile, no-op versus productive outcome, model/reasoning, snapshot/live-read counts, lifecycle/executor, failures,
+rate limits, guarded conflicts, and stale-recovery results.
 
 ## Preserved behavior
 
-The compact runtime contract retains universal PR intake, canonical issue/PR selection, exact-head validity, guarded Project
-mutations, non-draft Review publication, independent-review rules, existing same-repository PR continuation, fork/Dependabot
-boundaries, Codex Cloud supervised dispatch, 15/15/hourly monitoring, convergence checkpoints, truthful verification, human-only
-privileged actions, and the explicit no-merge boundary.
+The compact contract retains universal PR intake, canonical issue/PR selection, exact-head validity, guarded Project mutations,
+non-draft Review publication, independent-review rules, same-repository PR continuation, fork/Dependabot boundaries, Codex Cloud
+supervised dispatch, convergence checkpoints, truthful verification, human-only privileged actions, and the explicit no-merge
+boundary.
 
 ## Baseline tag
-
-Create the baseline annotated tag after verifying the target SHA:
 
 ```bash
 git fetch origin develop
@@ -123,5 +101,5 @@ git tag -a gptflow-v1 790a990b9a7f1a51403ee43148a3c8daa3085233 \
 git push origin refs/tags/gptflow-v1
 ```
 
-The connected GitHub tool used for this audit can create branches and commits but does not expose tag-ref creation, so the tag is a
-maintainer command rather than being silently approximated by a branch.
+The connected GitHub tool can create branches/commits/PRs but does not expose tag-ref creation, so the exact tag remains a
+maintainer command rather than being approximated by a branch.

--- a/docs/ai-delivery/profile.yml
+++ b/docs/ai-delivery/profile.yml
@@ -106,9 +106,15 @@ routing:
   mergeExecutor: Human
 
 supervision:
-  initialObservationMinutes: 15
-  secondObservationMinutes: 15
-  incompleteObservationMinutes: 60
+  mode: lease-based-stale-recovery
+  schedulerChecksOnlyExpiredOrInvalidLease: true
+  workerMayRenewBeforeExpiry: true
+  leaseMinutes:
+    ChatGPT: 60
+    Codex Cloud: 120
+    Local Codex: 240
+    externalOperation: 60
+    provisionalDispatch: 30
 
 telemetry:
   required: true

--- a/docs/ai-delivery/profile.yml
+++ b/docs/ai-delivery/profile.yml
@@ -1,4 +1,4 @@
-schemaVersion: 1
+schemaVersion: 2
 
 project:
   repository: sniffy/sniffy
@@ -6,6 +6,13 @@ project:
   githubProject:
     organization: sniffy
     number: 2
+
+runtime:
+  contract: docs/ai-delivery/runtime-contract.md
+  instructionAudit: docs/ai-delivery/instruction-audit.md
+  # Detailed policy is loaded after selection, not as a recurring dispatcher prefix.
+  dispatcherLoadsDetailedPolicy: false
+  oneCandidatePerTick: true
 
 controlPlane:
   protocol: delivery-control/v1
@@ -34,6 +41,7 @@ statusSnapshot:
   refreshCommand: "/ai-delivery-status refresh"
   refreshActors: [bedrin, bedrin-gpt]
   refreshTimeoutSeconds: 120
+  dispatchProjection: true
 
 fields:
   status: Status
@@ -44,10 +52,22 @@ fields:
   executor: Executor
   workerReference: Worker reference
 
+schedulers:
+  ChatGPT:
+    surface: Chat
+    forbiddenSurface: Work
+    budgetSlots: [0]
+    fullCadenceSlots: [0, 15, 30, 45]
+    prompt: .chatgpt/scheduled-task-prompt.md
+  Local Codex:
+    prompt: .codex/local/scheduled-task-prompt.md
+    snapshotHelper: .codex/local/project-queue-snapshot.sh
+
 executors:
   ChatGPT:
     assignee: bedrin-gpt
     model: provider-managed
+    reasoning: provider-managed
     dispatchMode: direct
   Codex Cloud:
     assignee: bedrin-codex-cloud
@@ -57,8 +77,12 @@ executors:
     dispatchOwner: ChatGPT
   Local Codex:
     assignee: bedrin-codex-local
-    model: Sol
-    reasoning: extra-high
+    dispatcherModel: gpt-5.6-luna
+    dispatcherReasoning: low
+    workerModel: gpt-5.6-terra
+    workerReasoning: medium
+    escalationModel: gpt-5.6-sol
+    escalationReasoning: high
     dispatchMode: polling
     # App-native dispatch derives this scheduling limit from the retained Project snapshot.
     # Provider-wide Codex project/task inventory is recovery evidence, not a normal capacity source.
@@ -80,6 +104,32 @@ routing:
     doNotAutoDispatchAnotherPatchRound: true
     preferredEscalationExecutor: Local Codex
   mergeExecutor: Human
+
+supervision:
+  initialObservationMinutes: 15
+  secondObservationMinutes: 15
+  incompleteObservationMinutes: 60
+
+telemetry:
+  required: true
+  fields:
+    - startedAt
+    - finishedAt
+    - durationSeconds
+    - adapter
+    - scheduler
+    - model
+    - reasoning
+    - snapshotRunId
+    - selectedCandidate
+    - outcome
+    - usageSource
+    - inputTokens
+    - cachedInputTokens
+    - outputTokens
+    - reasoningTokens
+  unavailableTokenValue: null
+  forbidFabricatedExactUsage: true
 
 intake:
   pullRequests:

--- a/docs/ai-delivery/routing.md
+++ b/docs/ai-delivery/routing.md
@@ -1,245 +1,105 @@
 # Task routing
 
-Dmitry and ChatGPT choose planned roles during Planning or when Review discovers new implementation work. Routing is a risk,
-capability, evidence, latency, continuity, and cost decision. Current Sniffy defaults are editable in [`profile.yml`](profile.yml);
-this document defines the semantics and decision process.
+Routing is a capability, risk, continuity, evidence, latency, and cost decision. Role, executor, model, GitHub identity, and PR
+provenance are separate axes.
 
-## Separate axes: role, executor, model, identity, provenance
+## Axes
 
-Do not collapse these independent choices:
+- **Role:** supervisor, implementer, reviewer, verifier, privileged operator, merger.
+- **Executor:** ChatGPT, Codex Cloud, Local Codex, IDE agent, automation, human.
+- **Model/profile:** provider-managed or an explicit Local Codex model/reasoning pair.
+- **Identity:** account performing comments, commits, or formal reviews.
+- **Provenance:** who created the branch/PR and whether it is same-repository, fork, or managed automation.
 
-- **Role** — supervisor, implementer, reviewer, verifier, privileged operator, or merger.
-- **Executor** — ChatGPT, Codex Cloud, Local Codex, IDE agent, automation, or human.
-- **Model/profile** — provider-managed, Sol, reasoning effort, or another executor-specific setting.
-- **GitHub identity** — the account that publishes, comments, or formally reviews.
-- **Provenance** — who created the current PR/branch and whether it is same-repository, fork, or managed automation.
+PR authorship does not populate Implementer automatically. A strong model does not grant authority, branch ownership, credentials,
+review independence, or permission to merge.
 
-Codex Cloud is not assumed to be Terra, Sol, or any other model. Its current model is recorded as `provider-managed` unless the
-product exposes and the task explicitly selects a verified value. The current Local Codex profile is intentionally fixed to Sol
-with extra-high reasoning; the dispatcher does not pretend to choose a cheaper model dynamically for that automation.
+## Current model profiles
 
-## Roles
+Model selection is proportional to work, not fixed to the strongest model:
 
-A task may assign responsibilities independently:
+| Purpose | Default |
+| --- | --- |
+| Local queue heartbeat/dispatcher | `gpt-5.6-luna` / low |
+| Normal Local Codex implementation or verification | `gpt-5.6-terra` / medium |
+| Explicit difficult-task escalation | `gpt-5.6-sol` / high |
+| Exceptional unresolved frontier task | xhigh only with a recorded reason |
+| Codex Cloud | provider-managed unless the product exposes a verified selection |
+| ChatGPT scheduler | provider-managed Chat surface; never Work merely for heartbeat |
 
-- **Supervisor/router:** canonicalizes issues and PRs, refines Planning, proposes routing, tracks delivery, rotates the control log,
-  and coordinates corrections. ChatGPT is the default.
-- **Implementer:** changes code/docs and proves the change in its own environment after Sniffy deliberately routes an
-  `Implementation` turn.
-- **Reviewer:** inspects the complete exact-head diff, scope, tests, review threads, and CI evidence. ChatGPT is the default.
-- **Verifier:** validates the observable result against the issue/PR in a representative environment.
-- **Formal reviewer:** submits APPROVE or REQUEST_CHANGES using an identity independent from the PR author.
-- **Privileged operator:** changes DNS, domains, repository settings, secrets, rulesets, Pages, or protected infrastructure.
-- **Merger:** merges only after Dmitry's explicit instruction.
-
-The same executor may hold several roles when independence is unnecessary. ChatGPT may implement through `bedrin-gpt`, but that
-identity cannot formally approve its own PR. A Dmitry-, Dependabot-, IDE-, or contributor-authored PR remains provenance; it is not
-automatically copied into the Project Implementer field.
-
-## Routing fields
-
-Planning records future routes when they are actually needed:
-
-- `Implementer` — optional planned implementation executor. Empty means unknown, not applicable to the already-published change,
-  or not yet deliberately selected;
-- `Verifier` — planned verification executor.
-
-The current lifecycle materializes:
-
-- `Executor` — product/runtime responsible for the next action;
-- `Assignee` — concrete GitHub identity or human responsible now;
-- `Worker reference` — concrete canonical item, chat, task, process, worktree, branch, PR, exact head, or direct tick ownership.
-
-Universal PR intake does not infer `Implementer` from author, bot, IDE, or provider identity. All flows must tolerate an empty value
-and route from current `Status`, `Execution`, and `Executor`. Before entering Implementation, Planning or Review must deliberately
-select a supported Implementer and copy that route into `Executor`.
-
-The canonical Project item may be an issue or PR. Routing must first apply the canonicalization rules in
-[`pull-request-intake.md`](pull-request-intake.md); do not send two executors to an issue and its PR as if they were independent
-implementations.
-
-All executors mutate Project fields through [`control-plane.md`](control-plane.md). Assignment and source/review operations remain
-separate verified GitHub actions.
+Escalation preserves the same canonical item, claim generation, branch, PR, proof, and no-merge boundary. It is not permission to
+restart from develop or open a duplicate PR.
 
 ## Executor matrix
 
-| Executor | Prefer when | Avoid or escalate when |
+| Executor | Prefer | Avoid/escalate |
 | --- | --- | --- |
-| ChatGPT | issue/PR canonicalization, Planning, GitHub state, focused connector-backed edits, CI diagnosis, exact-head artifacts, Review, browser verification from available artifacts | required source/dependencies cannot be obtained, long writable checkout or service state is needed, or formal self-review would be dishonest |
-| Codex Cloud | bounded, well-specified fresh-branch implementation; public dependencies; deterministic Cloud-available proof; useful parallelism; explicitly recoverable existing Cloud branch | arbitrary existing-PR adoption, branch surgery, persistent services/artifacts, private/local access, unresolved architecture, or repeated non-convergence |
-| Local Codex app/CLI | complex architecture, lifecycle/concurrency, cross-version Java, persistent caches/services/Docker/browser, existing same-repository PR continuation/adoption, representative local verification, or Cloud escalation | fork/Dependabot branch adoption, unsafe host credentials/network, sandbox ambiguity, or a simpler executor can finish truthfully |
-| IDE agent | Dmitry intentionally wants interactive pair programming in VS Code/IntelliJ | unattended ownership, independent review, or reproducible publication is required but not configured |
-| Human | product/risk decisions, privileged operations, subjective acceptance, credentials/secrets, destructive migration, merge | routine bounded implementation or proof another executor can perform safely |
+| ChatGPT | canonicalization, Planning, GitHub state, focused edits, CI diagnosis, exact-head Review, connector/artifact/browser proof | long writable checkout/services, unavailable dependencies, complex existing branch, formal self-review |
+| Codex Cloud | bounded well-specified fresh work with Cloud-available proof and useful parallelism | arbitrary existing-PR adoption, private/local state, unresolved architecture, persistent services, repeated non-convergence |
+| Local Codex | complex/cross-version architecture, concurrency/lifecycle, persistent caches/services/Docker/browser, exact same-repository existing-PR continuation, representative local Verification | fork/Dependabot adoption, unsafe host policy, unresolved product/authority decision |
+| IDE agent | deliberate interactive pair programming | unattended ownership or independent reproducible publication is required but unconfigured |
+| Human | product/risk/privilege decisions, credentials, subjective acceptance, merge | routine bounded work another executor can prove safely |
 
-Dependabot normally supplies an already-published implementation rather than serving as current Executor. The PR itself records
-that fact. ChatGPT owns Review and bot-operation monitoring, while the chosen Verifier owns outcome proof. Project 2 retains a
-`Dependabot` Implementer option for manual/historical use; normal intake leaves it empty.
+Dependabot supplies a published implementation. ChatGPT reviews/monitors bot operations; a selected Verifier proves outcomes.
 
 ## Capability preflight
 
-Before routing, confirm the exact environment can:
+Before routing, verify the selected environment can obtain the canonical item/source/exact revision; use dependencies and required
+network/services/browser/hardware; access credentials safely; preserve the intended branch/PR; publish commits/PR/artifacts/evidence;
+and satisfy independent-review requirements.
 
-- obtain the canonical item, required source, and exact revision;
-- use installed or downloadable dependencies;
-- reach required network endpoints;
-- start required runtimes, containers, browsers, or services;
-- access credentials without exposing them;
-- preserve or continue the required branch/PR;
-- publish expected commits, PR updates, artifacts, and evidence;
-- provide independent review identity when required.
+For existing PR continuation additionally verify same-repository ownership, exact remote branch/head, push permission, no competing
+owner, and an explicit continuation/adoption route. Never infer capability from a product/model name.
 
-For existing PR continuation also confirm:
+## Default implementation route
 
-- same-repository ownership rather than fork/managed-bot branch;
-- the exact remote head branch and SHA;
-- effective push permission for the selected executor;
-- no competing worker or user session currently owns the branch;
-- the route explicitly says continuation/adoption rather than fresh work.
+1. Require a deliberate Implementer before entering a new Implementation turn.
+2. Classify fresh work versus exact existing-PR continuation.
+3. Use ChatGPT directly only when it can truthfully edit, test, inspect, publish, and verify the focused change.
+4. Prefer Codex Cloud for bounded well-specified fresh work.
+5. Prefer Local Codex for complexity, persistent environments, cross-version proof, non-convergence, or same-repository existing PRs.
+6. Route product/risk/privilege/credential decisions to Dmitry.
+7. Choose Luna/Terra/Sol reasoning after executor/environment selection; do not use Sol merely because the worker is Local Codex.
 
-Do not infer capability from a product name. ChatGPT's GitHub connector, web access, command sandbox, browser, and local runtimes
-are separate capabilities. Codex Cloud's clean environment does not make an ambiguous task well specified. Local persistence does
-not repair a missing product decision or grant permission to modify a contributor branch.
+Fork and Dependabot branches remain contributor/bot-owned. Use contributor-facing findings, bot commands, or a deliberately linked
+internal replacement task rather than direct autonomous adoption.
 
-## Risk-axis routing
+## Existing PR continuity
 
-Count independent decisions and proof obligations, not changed lines. Relevant axes include:
+An adopted continuation preserves the canonical item and exact same-repository PR. The Project route deliberately selects the new
+Implementer/Executor and Worker reference remains pinned to PR/branch/head. The worker fetches and updates that branch without
+reset, rebase, force-push, discarded useful commits, replacement PR, or silent scope narrowing. After publication, the same
+canonical item returns to `Review / Ready / ChatGPT` at the new exact head.
 
-- public APIs or published artifacts;
-- global state, concurrency, ownership, cleanup, and failure composition;
-- several JDK, framework, engine, OS, or architecture versions;
-- module/reactor placement and same-artifact compatibility;
-- first-of-kind architecture or test patterns;
-- browser, visual, local-service, hardware, credential, or network proof;
-- dependency/security compatibility;
-- migration and rollback;
-- Git history, branch ownership, existing PR, or fork constraints;
-- publication and review identity.
+Changing executor or model never means discarding published work.
 
-Several interacting axes require a read-only design/proof preflight. Local Codex is the current strong execution route after the
-preflight because it is configured for Sol/extra-high and a persistent environment, but executor strength is not permission to
-invent unresolved decisions.
+## Risk axes and escalation
 
-## Default implementation routing
+Count independent decisions/proof obligations, not changed lines: public API/artifact, global state/concurrency/cleanup/failure
+composition, multiple JDK/framework/OS variants, module placement, first-of-kind architecture/test, browser/service/hardware/network,
+dependency/security compatibility, migration/rollback, branch/provenance, publication/review identity.
 
-Use this order for a new Implementation turn:
-
-1. **Require a deliberate route.** If `Implementer` is empty, first choose a supported implementation executor through Planning or
-   Review. Never derive it from the current PR author.
-2. **Classify fresh versus continuation.** A published same-repository PR normally continues on its exact branch and PR. A fork or
-   managed-bot PR normally remains contributor/bot-owned or is superseded by a linked internal task.
-3. **ChatGPT direct capability check.** Can the current ChatGPT execution truthfully edit, test, inspect, publish, and verify the
-   focused change with available source, dependencies, connectors, branch access, and identity? If yes, it may implement directly.
-4. **Codex Cloud first for suitable fresh work.** Prefer Cloud for well-specified fresh-branch fixes, tests, documentation,
-   dependency updates, CI follow-ups, and localized refactors whose proof fits the Cloud environment. Do not send an arbitrary
-   existing PR to Cloud merely because Cloud is available.
-5. **Local Codex for complexity, persistence, or existing PRs.** Route complex/cross-version/service/browser work and
-   same-repository existing-PR continuation to Local Codex by default. The worker reuses the exact branch/PR even when Dmitry,
-   ChatGPT, or an IDE agent originally created it.
-6. **Human for authority or privilege.** Route unresolved product/risk decisions and privileged operations to Dmitry.
-
-“Cloud first” is an executor/environment decision for fresh suitable work, not a model claim. “Local Sol/extra-high” is explicit
-current Sniffy configuration, not a generic rule for all repositories.
-
-## Existing PR adoption and continuity
-
-A same-repository PR may enter the delivery process after being created outside it. Adoption means the canonical Project item
-explicitly routes correction to a configured Implementer; it does not mean opening a new issue/branch/PR.
-
-For an adopted continuation:
-
-- identify the canonical issue or PR and every formal closing issue;
-- guard current lifecycle state and exact PR head when the PR itself is canonical;
-- set `Status = Implementation`, `Execution = Ready`, `Implementer = <selected executor>`, and matching `Executor`;
-- keep Worker reference pinned to the exact existing PR and branch;
-- selected worker fetches and updates that branch without reset, rebase, force-push, or replacement PR;
-- all useful user/agent commits and unrelated-but-intentional changes are preserved;
-- after publication, the same canonical item returns to `Review / Ready / ChatGPT` with the new exact head.
-
-Do not adopt fork or Dependabot branches for direct autonomous correction. Use contributor-facing Request Changes, provider bot
-commands, or a linked internal replacement task. A future policy may relax this only with explicit trust/permission rules.
+Several interacting axes require a read-only design/proof preflight. Sol/high may help after the preflight; it must not invent
+missing requirements or maintainer decisions.
 
 ## Review convergence checkpoint
 
-Worker activity monitoring and review convergence are different mechanisms. The 15-minute/15-minute/hourly cadence observes an
-already dispatched worker. It does not decide whether repeated code changes are conceptually converging.
+When Review returns substantive changes, corrected work returns, and the next complete Review still has substantive blockers, stop
+serial narrow patching. Re-evaluate issue precision, architecture, acceptance/proof matrix, executor context/capability, branch
+continuity, and whether another patch would preserve a flawed direction.
 
-Trigger a **convergence checkpoint** when all are true:
+Choose one:
 
-1. Review returned the task to Implementation with substantive Request Changes;
-2. the implementer published a corrected head and handed it back to Review;
-3. the next complete Review still finds substantive blockers.
+- continue the same executor with one coherent superseding correction;
+- preserve/adopt the existing PR and escalate to Local Codex, with Terra or Sol selected deliberately;
+- return to `Planning / Ready / ChatGPT` for re-baselining;
+- use `Blocked / Human` for one exact Dmitry decision/action.
 
-Before sending another implementation request, ChatGPT must critically re-evaluate:
+Infrastructure noise is not a substantive correction round.
 
-- Is the authoritative issue/PR still correct and sufficiently precise?
-- Did the implementation follow the intended architecture, or is the direction itself wrong?
-- Are the remaining findings local mistakes, misunderstood acceptance criteria, or an executor capability/context gap?
-- Would another narrow patch preserve a flawed design or accumulate contradictory instructions?
-- Does the proof matrix require a different environment?
-- Should the task return to Planning, remain with the same implementer, adopt/escalate the existing PR to Local Codex, or block?
+## Editable profile values
 
-The checkpoint produces one explicit result:
-
-- **Continue same executor:** direction is sound; supersede ambiguous guidance and issue one coherent correction request.
-- **Adopt/escalate existing PR:** preserve the exact branch/PR and route continuation to Local Codex.
-- **Return to Planning:** architecture, requirements, canonicalization, scope, or proof strategy must be re-baselined.
-- **Block for Dmitry:** a product, risk, privilege, or branch-ownership decision is required.
-
-Do not count infrastructure-only noise as a substantive correction cycle. Do not mechanically escalate merely because a test
-failed; the checkpoint is about repeated substantive Review blockers.
-
-## Executor change and continuity
-
-Changing executor does not mean discarding published work:
-
-- keep the same canonical item and linked requirements;
-- continue the exact existing same-repository branch and PR when safe;
-- preserve useful commits and evidence;
-- explicitly mark superseded guidance;
-- update `Implementer` only when a new implementation route is deliberately selected, update `Executor`, Worker reference, and
-  correction metadata through one guarded control command;
-- start the normal worker-monitoring cadence only after the new dispatch is concretely acknowledged.
-
-Do not reset, rebase, force-push, open a duplicate PR, or restart from `develop` merely because work moved between ChatGPT, IDE,
-Cloud, and Local Codex.
-
-## Editable Sniffy defaults
-
-Use [`profile.yml`](profile.yml) for operational choices Dmitry may tune without redefining shared policy, including:
-
-- executor identities;
-- direct-ChatGPT preference;
-- first external implementation executor for fresh work;
-- complex/persistent and existing-PR continuation executor;
-- Local Codex model and reasoning effort;
-- universal PR intake and canonicalization behavior;
-- implementer inference policy;
-- convergence trigger and preferred escalation executor;
-- control-log rotation thresholds.
-
-If a profile value conflicts with an explicit current issue or Dmitry's instruction, the issue/instruction wins. If a desired
-change alters lifecycle meaning, claim safety, review independence, canonicalization, or merge authority, update the policy rather
-than hiding it in the profile.
-
-## Issue routing block
-
-```md
-## Delivery routing
-
-- Supervisor: ChatGPT
-- Canonical Project item: <Issue URL | PR URL>
-- Existing PR/branch/head: <URL | none> / <branch | none> / <SHA | none>
-- Work mode: <fresh | continuation | adopted-continuation>
-- Implementer: <ChatGPT | Codex Cloud | Local Codex | IDE Agent | Human>
-- Verifier: <ChatGPT | Codex Cloud | Local Codex | Human | Mixed>
-- Default reviewer: ChatGPT
-- Formal reviewer: <independent identity or human>
-- Privileged operator: <none or named human>
-- GitHub author identity: <account>
-- Executor model/profile: <provider-managed | Sol / extra-high | other verified value>
-- Capability assumptions: <source, dependencies, network, services, browser, credentials, branch permissions>
-- Rationale: <risk axes, evidence, continuity, latency, and cost>
-```
-
-This block selects an Implementer before a new Implementation turn. Universal PR intake may leave it empty because no correction
-has yet been routed.
+`profile.yml` contains identities, scheduler surface/cadence, dispatcher/worker/escalation models, capacity, fresh/continuation
+executor defaults, intake/canonicalization settings, convergence policy, supervision cadence, telemetry fields, and control/status
+settings. Update shared policy only when lifecycle meaning, claim safety, canonicalization, review independence, verification, or
+merge authority changes.

--- a/docs/ai-delivery/runtime-contract.md
+++ b/docs/ai-delivery/runtime-contract.md
@@ -1,7 +1,7 @@
 # Compact AI delivery runtime contract
 
-This is the only shared policy document that a dispatcher reads on every tick. Detailed documents in this directory are normative
-reference material for humans, tests, and a selected lifecycle worker; they are not a mandatory dispatcher preamble.
+This is the only shared policy document a dispatcher reads on every tick. Detailed documents in this directory remain normative
+reference for humans, tests, and a selected lifecycle worker; they are not a mandatory recurring prompt prefix.
 
 ## Sources of truth
 
@@ -24,7 +24,7 @@ A tick is selection and coordination, not lifecycle work. It must:
    - fork or Dependabot conflict requiring contributor feedback or a documented bot operation, never branch adoption;
    - PR intake/canonicalization or duplicate representation;
    - exact-head drift or invalid current route/assignee;
-   - due owned `In progress` observation;
+   - stale owned `In progress` recovery caused by a missing, invalid, or expired lease;
    - `Ready` work for an executor this supervisor dispatches;
    - `Ready` work for this dispatcher;
 5. only after selection, perform the minimum live reads needed for that candidate: current target, formal closing links, exact
@@ -62,24 +62,42 @@ the target and `expected.head` identify it.
 Every new autonomous control comment uses the human-readable Markdown wrapper from `control-plane.md`, its exact start/end markers,
 and a lowercase `json` fence. The marked JSON is authoritative; never emit bare JSON as a new autonomous command.
 
-A claim guards current type, Status, `Execution = Ready`, Executor, and exact PR head when applicable, then sets `Execution = In
-progress` with a unique token, owner, lease, concrete worker reference, and next observation point. A conflict means another actor
-won or state changed; make no work mutation from the stale view.
+A claim guards current type, Status, `Execution = Ready`, Executor, and exact PR head when applicable, then sets
+`Execution = In progress` with a unique token, owner, concrete worker/task/process/branch reference, `claimedAt`, and `leaseUntil`.
+Choose the lease from `profile.yml` or a deliberately recorded task-specific budget. A worker may renew its own lease before expiry
+when it is still legitimately running. A conflict means another actor won or state changed; make no work mutation from the stale
+view.
 
 A configured unclaimable `Execution = Ready` route whose Assignee belongs to a different executor pool is a reconciliation
 candidate. Never silently filter out that mismatch. `Blocked / Human` is reserved for an exact Dmitry decision or action; routine
 waiting remains `In progress`.
 
-## Supervision cadence
+## Lease-based stale recovery
 
-After a worker, CI run, contributor operation, bot command, or draft publication is started, observe it after 15 minutes, again 15
-minutes later, then hourly while incomplete. Store the next observation time in durable worker evidence. Do not create a separate
-per-item hourly monitor before the two 15-minute observations.
+Normal `In progress` ownership is not polled. The worker is responsible for publishing evidence and performing the guarded lifecycle
+handoff when its turn completes. A dispatcher ignores an item while its lease is valid and does not query provider-wide task or
+conversation inventory merely to ask whether it is still running.
+
+An `In progress` item becomes a recovery candidate only when its Worker reference is missing, its lease is missing/invalid, or
+`leaseUntil` has passed. The next normal scheduler tick then performs one targeted recovery:
+
+1. re-read the canonical item, exact branch/PR/head, current reviews/CI when relevant, and the concrete worker/task reference;
+2. if the lifecycle handoff already completed, make no duplicate mutation;
+3. if the same worker is demonstrably still active, preserve the generation and extend the lease through a guarded update;
+4. if completion evidence exists but the handoff was lost, finish the deterministic handoff without spawning another worker;
+5. if the worker failed or disappeared, recover the same branch/workspace/generation where possible;
+6. release to `Ready` only when no active work or recoverable publication remains;
+7. never redispatch the same generation speculatively.
+
+CI waits, contributor updates, bot commands, rebases, and draft publication use the same lease mechanism. They receive a bounded
+operation lease and are inspected only after expiry unless a GitHub event has already produced a new actionable snapshot state.
+No separate monitoring scheduler or per-worker observation cadence exists.
 
 For a supervised Codex Cloud dispatch: `Status = Implementation`, `Execution = Ready`, `Executor = Codex Cloud`. Codex Cloud does
 not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement, and
-record the first 15-minute observation point. If the trigger was not submitted or was definitively rejected, release to Ready. If
-submission succeeded but acknowledgement is uncertain, preserve that provisional generation and never redispatch it.
+record the concrete generation plus lease. If the trigger was not submitted or was definitively rejected, release to Ready. If
+submission succeeded but acknowledgement is uncertain, keep one provisional generation with the shorter provisional lease and
+never redispatch it before targeted recovery.
 
 ## Lifecycle worker loading
 
@@ -111,7 +129,7 @@ Every non-interactive tick and worker emits one final JSON object or one compact
 - adapter, scheduler/task identity, model, and reasoning effort when known;
 - snapshot generation/run ID;
 - selected candidate kind and canonical target, or `none`;
-- outcome: `NO_CHANGE`, `CLAIMED`, `DISPATCHED`, `HANDOFF`, `BLOCKED`, `RATE_LIMITED`, `CONFLICT`, or `FAILED`;
+- outcome: `NO_CHANGE`, `CLAIMED`, `DISPATCHED`, `HANDOFF`, `RECOVERED`, `BLOCKED`, `RATE_LIMITED`, `CONFLICT`, or `FAILED`;
 - exact provider token counters when the runtime exposes them.
 
 Use `null` and `usageSource: "unavailable"` when token counters are not exposed. Never invent an exact token count. A separately

--- a/docs/ai-delivery/runtime-contract.md
+++ b/docs/ai-delivery/runtime-contract.md
@@ -33,8 +33,9 @@ A tick is selection and coordination, not lifecycle work. It must:
 7. publish human-useful evidence and one guarded handoff when work finishes;
 8. emit compact telemetry and stop.
 
-Do not read complete issue discussions, full diffs, review threads, CI logs, proof matrices, or executor runbooks before a candidate
-is selected. The selected worker owns those reads. Do not re-read the full snapshot during selection.
+Live-read only the selected candidate. Do not read complete issue discussions, full diffs, review threads, CI logs, proof matrices,
+or executor runbooks before a candidate is selected. The selected worker owns those reads. Do not re-read the full snapshot during
+selection.
 
 When no candidate needs action, perform no Project, source, worker, target-comment, or control-command mutation and return
 `NO_CHANGE` plus telemetry.
@@ -112,6 +113,6 @@ Every non-interactive tick and worker emits one final JSON object or one compact
 - outcome: `NO_CHANGE`, `CLAIMED`, `DISPATCHED`, `HANDOFF`, `BLOCKED`, `RATE_LIMITED`, `CONFLICT`, or `FAILED`;
 - exact provider token counters when the runtime exposes them.
 
-Use `null` and `usageSource: "unavailable"` when token counters are not exposed. Do not invent an exact token count. A separately
+Use `null` and `usageSource: "unavailable"` when token counters are not exposed. Never invent an exact token count. A separately
 labelled estimate may be emitted only from measured prompt/context bytes using a documented formula; it must never be presented as
 provider billing data.

--- a/docs/ai-delivery/runtime-contract.md
+++ b/docs/ai-delivery/runtime-contract.md
@@ -21,6 +21,7 @@ A tick is selection and coordination, not lifecycle work. It must:
 3. use the snapshot's `dispatch` projections instead of asking the model to rescan or re-sort the whole Project and every PR;
 4. choose at most one candidate in this order:
    - conflicting same-repository PR requiring deliberate continuation routing;
+   - fork or Dependabot conflict requiring contributor feedback or a documented bot operation, never branch adoption;
    - PR intake/canonicalization or duplicate representation;
    - exact-head drift or invalid current route/assignee;
    - due owned `In progress` observation;

--- a/docs/ai-delivery/runtime-contract.md
+++ b/docs/ai-delivery/runtime-contract.md
@@ -1,0 +1,117 @@
+# Compact AI delivery runtime contract
+
+This is the only shared policy document that a dispatcher reads on every tick. Detailed documents in this directory are normative
+reference material for humans, tests, and a selected lifecycle worker; they are not a mandatory dispatcher preamble.
+
+## Sources of truth
+
+Use, in order: Dmitry's explicit current decision; the canonical GitHub issue or pull request and later comments; the exact linked
+PR head, reviews, CI, and artifacts; the nearest `AGENTS.md`; root `AGENTS.md`; this contract and `profile.yml`; the selected
+executor runbook; the concrete task prompt. Historical chats and snapshots are telemetry, not authority.
+
+The repository-owned status snapshot is a materialized selection view. It never authorizes a mutation. Every Project claim and
+handoff uses the guarded `delivery-control/v1` protocol and a live target re-read.
+
+## Dispatcher tick
+
+A tick is selection and coordination, not lifecycle work. It must:
+
+1. record `startedAt`, model/profile, and scheduler identity;
+2. obtain exactly one current normalized snapshot using the adapter's documented read path;
+3. use the snapshot's `dispatch` projections instead of asking the model to rescan or re-sort the whole Project and every PR;
+4. choose at most one candidate in this order:
+   - conflicting same-repository PR requiring deliberate continuation routing;
+   - PR intake/canonicalization or duplicate representation;
+   - exact-head drift or invalid current route/assignee;
+   - due owned `In progress` observation;
+   - `Ready` work for an executor this supervisor dispatches;
+   - `Ready` work for this dispatcher;
+5. only after selection, perform the minimum live reads needed for that candidate: current target, formal closing links, exact
+   branch/head/draft/ownership, current Project route, worker reference, and the newest active control issue;
+6. claim or reconcile through one guarded control command, verify the terminal reaction, and then either perform one bounded
+   lifecycle turn or create one durably acknowledged external worker;
+7. publish human-useful evidence and one guarded handoff when work finishes;
+8. emit compact telemetry and stop.
+
+Do not read complete issue discussions, full diffs, review threads, CI logs, proof matrices, or executor runbooks before a candidate
+is selected. The selected worker owns those reads. Do not re-read the full snapshot during selection.
+
+When no candidate needs action, perform no Project, source, worker, target-comment, or control-command mutation and return
+`NO_CHANGE` plus telemetry.
+
+## Canonical PR invariants
+
+Scan every open pull request in the snapshot targeting the configured base branch, regardless of author, label, bot/provider, or
+branch creator, but live-read only a programmatically selected attention candidate.
+
+- Exactly one formal closing issue: that issue is the canonical lifecycle item.
+- No formal closing issue: the non-draft PR itself is the canonical lifecycle item.
+- Multiple formal closing issues: the non-draft PR is the canonical coordination item in Planning.
+- Draft PR: do not start Review.
+- Never review both an issue and its implementation PR as separate lifecycle work.
+- Reuse an explicitly routed same-repository branch/PR. Never adopt a fork or Dependabot branch for direct correction.
+
+A transition to Review requires an open PR targeting the configured base branch at the exact published head and non-draft/ready
+for review. For a canonical issue, the command includes `reviewPullRequest.number` and `reviewPullRequest.head`; for a canonical PR,
+the target and `expected.head` identify it.
+
+## Control and ownership
+
+Every new autonomous control comment uses the human-readable Markdown wrapper from `control-plane.md`, its exact start/end markers,
+and a lowercase `json` fence. The marked JSON is authoritative; never emit bare JSON as a new autonomous command.
+
+A claim guards current type, Status, `Execution = Ready`, Executor, and exact PR head when applicable, then sets `Execution = In
+progress` with a unique token, owner, lease, concrete worker reference, and next observation point. A conflict means another actor
+won or state changed; make no work mutation from the stale view.
+
+A configured unclaimable `Execution = Ready` route whose Assignee belongs to a different executor pool is a reconciliation
+candidate. Never silently filter out that mismatch. `Blocked / Human` is reserved for an exact Dmitry decision or action; routine
+waiting remains `In progress`.
+
+## Supervision cadence
+
+After a worker, CI run, contributor operation, bot command, or draft publication is started, observe it after 15 minutes, again 15
+minutes later, then hourly while incomplete. Store the next observation time in durable worker evidence. Do not create a separate
+per-item hourly monitor before the two 15-minute observations.
+
+For a supervised Codex Cloud dispatch: `Status = Implementation`, `Execution = Ready`, `Executor = Codex Cloud`. Codex Cloud does
+not poll Project 2. Claim while preserving Executor, post one exact implementation trigger, require durable acknowledgement, and
+record the first 15-minute observation point. If the trigger was not submitted or was definitively rejected, release to Ready. If
+submission succeeded but acknowledgement is uncertain, preserve that provisional generation and never redispatch it.
+
+## Lifecycle worker loading
+
+After selection and claim, the worker reads:
+
+- the complete canonical item and relevant comments;
+- formally linked issues and the exact PR;
+- nearest applicable `AGENTS.md` files;
+- current reviews, unresolved threads, matching-head CI, and required artifacts;
+- only the detailed lifecycle/runbook sections relevant to its current status and executor.
+
+Implementation produces the smallest coherent change and implementer-owned proof. Review inspects the complete exact-head diff and
+publishes one comprehensive outcome. Verification proves observable behavior in a representative environment. Approval and merge
+remain human-owned unless Dmitry explicitly says otherwise.
+
+When the reviewer is independent and blockers remain, submit comprehensive REQUEST_CHANGES. When the reviewer is the PR author,
+publish the same findings as an ordinary PR comment with the identity limitation. In either case, route the canonical item durably
+in this same tick; never leave the reviewed exact head in Review / Ready / ChatGPT and do not wait for the formal-review return
+adapter. A technically acceptable self-authored PR proceeds to Verification or Approval / Ready / Human.
+
+Never merge, enable auto-merge, bypass protection, rewrite shared history, expose credentials, or perform privileged operations
+without Dmitry's explicit instruction.
+
+## Telemetry
+
+Every non-interactive tick and worker emits one final JSON object or one compact line containing:
+
+- `startedAt`, `finishedAt`, and `durationSeconds`;
+- adapter, scheduler/task identity, model, and reasoning effort when known;
+- snapshot generation/run ID;
+- selected candidate kind and canonical target, or `none`;
+- outcome: `NO_CHANGE`, `CLAIMED`, `DISPATCHED`, `HANDOFF`, `BLOCKED`, `RATE_LIMITED`, `CONFLICT`, or `FAILED`;
+- exact provider token counters when the runtime exposes them.
+
+Use `null` and `usageSource: "unavailable"` when token counters are not exposed. Do not invent an exact token count. A separately
+labelled estimate may be emitted only from measured prompt/context bytes using a documented formula; it must never be presented as
+provider billing data.

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -70,10 +70,14 @@ Project and PR list:
 - `readyByExecutor`;
 - `inProgressByExecutor` and due observations when `nextObservationAt` is available;
 - Ready route/assignee mismatches;
-- conflicting same-repository PRs;
+- conflicting same-repository PRs requiring deliberate continuation routing;
+- managed fork/Dependabot conflicts requiring contributor feedback or a documented bot operation, never branch adoption;
 - PR intake/canonicalization and duplicate-representation candidates;
 - downstream lifecycle state pinned to an older exact PR head;
 - `orderedCandidates`, the normal one-candidate attention queue.
+
+An already routed `Implementation / Ready|In progress` correction is left to its selected executor instead of being reclassified as
+PR intake or generic conflict handling.
 
 The projection contains compact target evidence only. It is not a substitute for complete issue/PR discussion, diff, review, CI,
 or artifacts; those are loaded after selection by the worker that needs them.

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -16,95 +16,60 @@ Project 2 + repository issues/PRs/formal links
   -> +1/-1 on the exact refresh request
 ```
 
-The issue is discovered by label, never hardcoded by number. Technical `ai-delivery-status` and `ai-delivery-control` issues are
-excluded from delivery work.
+The status issue is discovered by label, never hardcoded. Technical status/control issues are excluded from delivery work.
 
 ## Triggers and read barrier
 
 `.github/workflows/delivery-status.yml` runs hourly at minute 5, on an exact allowlisted refresh comment, through maintainer
-`workflow_dispatch`, and in validation-only mode for relevant PRs. Publication is serialized with queued concurrency and always
-checks out trusted `develop`.
+`workflow_dispatch`, and in validation-only mode for relevant PRs. Publication is serialized and checks out trusted `develop`.
 
 A scheduled ChatGPT tick posts exactly `/ai-delivery-status refresh` and waits for a terminal reaction:
 
-- `+1`: artifact and pointer were published;
+- `+1`: artifact/pointer published;
 - `-1`: publication failed;
-- timeout/no reaction: unavailable.
+- timeout: unavailable.
 
-A failed/unacknowledged request blocks snapshot-dependent selection. Do not retry in the same tick or use the pre-request pointer.
-After `+1`, require matching protocol/repository/Project/artifact identity, acceptable age, `generatedAt` later than the request,
-and normally exact refresh-comment provenance. A later serialized successful pointer is acceptable only when demonstrably newer.
+Failure blocks snapshot-dependent selection. Do not retry in the same tick or use the pre-request pointer. After `+1`, require
+matching protocol/repository/Project/artifact identity, acceptable age, `generatedAt` later than the request, and matching or
+demonstrably newer serialized provenance.
 
 ## Artifact
 
-The artifact `ai-delivery-status-project-2` contains:
+`ai-delivery-status-project-2` contains normalized `project-2-status.json` plus diagnostic raw Project, issue, and PR exports. The
+normalizer fails closed on incomplete pagination or missing live state. Explicit absent Project field values are `null`; clients do
+not infer them from prose, authorship, earlier chats, or defaults.
 
-- `project-2-status.json` — normalized active items, field definitions, open PR observations, and `dispatch` projection;
-- `project-fields.raw.json` — diagnostic raw Project fields;
-- `project-items.raw.json` — diagnostic raw Project items;
-- `repository-issues.raw.json` — diagnostic live issue metadata;
-- `repository-pull-requests.raw.json` — diagnostic live PR metadata.
-
-The normalizer fails closed on incomplete pagination or missing live source state. Explicit absent Project field values are `null`;
-clients must not infer them from prose, authorship, prior chats, or defaults.
-
-## Open PR observations
-
-Top-level `pullRequests` includes every open repository PR independently of canonical Project representation: number/URL/author,
-same-repository or fork ownership, draft/base/branch/exact head, mergeability hint, merge-state hint, and formal closing issue
-numbers. A PR observation does not create a second lifecycle item.
-
-Canonical identity remains:
-
-```text
-one closing issue -> issue
-no closing issue  -> PR
-multiple issues   -> PR in Planning
-```
+Top-level `pullRequests` includes every open repository PR independently of canonical Project representation: author, ownership,
+draft/base/branch/exact head, mergeability hints, and formal closing issues. A PR observation does not create a second lifecycle
+item.
 
 ## Dispatch projection
 
-`.github/scripts/delivery-dispatch-view.js` adds deterministic runtime views so an LLM does not rescan or re-sort the entire
-Project and PR list:
+`.github/scripts/delivery-dispatch-view.js` adds deterministic runtime views:
 
 - `readyByExecutor`;
-- `inProgressByExecutor` and due observations when `nextObservationAt` is available;
+- `inProgressByExecutor`;
+- `activeInProgressByExecutor` for valid future leases;
+- `staleInProgressByExecutor` for missing/invalid worker evidence or expired lease;
 - Ready route/assignee mismatches;
-- conflicting same-repository PRs requiring deliberate continuation routing;
-- managed fork/Dependabot conflicts requiring contributor feedback or a documented bot operation, never branch adoption;
-- PR intake/canonicalization and duplicate-representation candidates;
-- downstream lifecycle state pinned to an older exact PR head;
-- `orderedCandidates`, the normal one-candidate attention queue.
+- same-repository and managed PR conflicts;
+- PR intake/canonicalization and duplicate candidates;
+- downstream state pinned to an older exact PR head;
+- `orderedCandidates`.
 
-An already routed `Implementation / Ready|In progress` correction is left to its selected executor instead of being reclassified as
-PR intake or generic conflict handling.
+Active leased ownership is diagnostic/capacity state, not an attention candidate. It is not polled. Stale ownership becomes one
+`stale-owned-recovery` candidate for targeted recovery of the exact generation.
 
-The projection contains compact target evidence only. It is not a substitute for complete issue/PR discussion, diff, review, CI,
-or artifacts; those are loaded after selection by the worker that needs them.
+An already routed `Implementation / Ready|In progress` correction remains with its selected executor instead of being reclassified
+as generic intake/conflict handling.
 
-## Active-item semantics
+## Active-item and consistency semantics
 
 The normalized view keeps open issues/PRs, Project draft issues, and source-closed items whose Project Status is not Done, exposing
-lifecycle/source drift. It excludes technical control/status items and other repositories from the Sniffy active view. Raw exports
-remain available for diagnosis.
-
-## Pointer
-
-The newest open status issue body is one JSON pointer with schema/kind, generated time, source repository/Project/workflow run,
-optional refresh request, numeric artifact ID/name/digest/file names/retention, and counts. Readers reject unknown schema/kind,
-wrong identity, nonnumeric artifact ID, stale/mismatched provenance, or inconsistent counts.
-
-## ChatGPT procedure
-
-The exact compact procedure lives in
-[`.chatgpt/status-snapshot-instructions.md`](../../.chatgpt/status-snapshot-instructions.md): request one fresh barrier; validate and
-download the artifact; select at most the first `dispatch.orderedCandidates` entry; live-read only that target; construct guarded
-expected values; stop without work mutation when no candidate remains actionable.
-
-## Consistency and mutation boundary
+lifecycle/source drift. It excludes technical items and other repositories from the Sniffy active view.
 
 The snapshot is eventually consistent and safe only for discovery/selection. Every claim/handoff still goes through
-`delivery-control/v1`, whose serialized workflow live-reads ProjectV2 and rejects stale expected state.
+`delivery-control/v1`, whose serialized workflow live-reads ProjectV2 and rejects stale expected state:
 
 - `confused`: state/head lost a race; make no work mutation from that snapshot;
 - `-1`: unexpected control failure; inspect the run;
@@ -113,14 +78,20 @@ The snapshot is eventually consistent and safe only for discovery/selection. Eve
 A later dependent Project transition requires a snapshot generated after the preceding successful command. Avoid speculative
 refresh fan-out.
 
-No client may mutate Project fields directly from the snapshot, use the status issue as a control-command channel, bypass guarded
-exact-head checks, or treat generated candidates as claim ownership.
+## ChatGPT procedure
+
+The compact procedure lives in [`.chatgpt/status-snapshot-instructions.md`](../../.chatgpt/status-snapshot-instructions.md): request
+one fresh barrier; validate/download the artifact; select at most the first `dispatch.orderedCandidates` entry; live-read only that
+target; construct guarded expected values; stop without work mutation when no candidate remains actionable.
+
+No client may mutate Project fields directly from the snapshot, use the status issue as a control channel, bypass guarded exact-head
+checks, or treat a generated candidate as claim ownership.
 
 ## Permissions and failures
 
-The workflow begins with `permissions: {}`. Validation receives contents read. Publication receives contents read, issues write,
-and pull-requests read; Project reads use the existing repository secret. It receives no branch write, merge, deployment, secret,
-or Project mutation permission.
+The workflow begins with `permissions: {}`. Validation receives contents read. Publication receives contents read, issues write, and
+pull-requests read; Project reads use the repository secret. It receives no branch write, merge, deployment, secret, or Project
+mutation permission.
 
-On failure inspect Project-token access, GitHub CLI output/schema/pagination, trusted checkout, normalizer/projection tests, artifact
-upload, pointer update, and reaction write. Until a fresh valid pointer exists, snapshot-dependent autonomous selection stops.
+On failure inspect Project-token access, CLI schema/pagination, trusted checkout, normalizer/projection tests, artifact upload,
+pointer update, and reaction write. Until a fresh valid pointer exists, snapshot-dependent autonomous selection stops.

--- a/docs/ai-delivery/status-snapshot.md
+++ b/docs/ai-delivery/status-snapshot.md
@@ -1,225 +1,122 @@
 # AI delivery status snapshot
 
-The status snapshot is a repository-owned, read-only materialized view of Sniffy organization Project 2 for clients that can read
-repository issues and Actions artifacts but cannot reliably query organization ProjectV2 directly. It complements, and never
-replaces, the guarded mutation protocol in [`control-plane.md`](control-plane.md).
+The status snapshot is a repository-owned, read-only materialized view of Sniffy Project 2. It complements and never replaces the
+guarded mutation protocol in [`control-plane.md`](control-plane.md).
 
-## Components
+## Publication flow
 
 ```text
-Project 2
-  -> scheduled tick posts /ai-delivery-status refresh
-  -> AI delivery status workflow
-      -> raw field and item exports
-      -> normalized active-item JSON
-      -> short-retention Actions artifact
-      -> newest open issue labeled ai-delivery-status
-           contains the latest artifact pointer as JSON
-      -> terminal reaction on the exact request comment
+Project 2 + repository issues/PRs/formal links
+  -> hourly or exact /ai-delivery-status refresh trigger
+  -> trusted develop workflow
+  -> normalized active items + open PR observations
+  -> deterministic dispatch projection
+  -> short-retention Actions artifact
+  -> newest open issue labeled ai-delivery-status contains JSON pointer
+  -> +1/-1 on the exact refresh request
 ```
 
-The status issue is discovered by label. Its number is intentionally not configuration. The workflow creates the label and issue
-when no open labeled issue exists and otherwise updates the newest open labeled issue. Older duplicates are not silently deleted;
-the workflow warns in its summary and readers still choose the newest open issue by number.
+The issue is discovered by label, never hardcoded by number. Technical `ai-delivery-status` and `ai-delivery-control` issues are
+excluded from delivery work.
 
-The status issue is technical control-plane metadata. It is not a delivery work item, must not be claimed, and is excluded from the
-normalized active queue together with issues labeled `ai-delivery-control`. Its discussion is a narrow refresh-request audit log;
-delivery-control commands and ordinary work discussion do not belong there.
+## Triggers and read barrier
 
-## Workflow triggers and freshness
+`.github/workflows/delivery-status.yml` runs hourly at minute 5, on an exact allowlisted refresh comment, through maintainer
+`workflow_dispatch`, and in validation-only mode for relevant PRs. Publication is serialized with queued concurrency and always
+checks out trusted `develop`.
 
-[`.github/workflows/delivery-status.yml`](../../.github/workflows/delivery-status.yml) runs:
+A scheduled ChatGPT tick posts exactly `/ai-delivery-status refresh` and waits for a terminal reaction:
 
-- at minute `5` of every hour as a best-effort dashboard and recovery fallback;
-- on an exact `/ai-delivery-status refresh` issue comment on an `ai-delivery-status` issue from an actor allowlisted in
-  [`profile.yml`](profile.yml);
-- through `workflow_dispatch` for maintainer-authorized diagnosis or recovery;
-- in validation-only mode for pull requests changing this adapter.
+- `+1`: artifact and pointer were published;
+- `-1`: publication failed;
+- timeout/no reaction: unavailable.
 
-The workflow deliberately does not publish after every delivery-control completion. A busy lifecycle turn may use several guarded
-commands, and exporting the complete Project after each one amplifies GraphQL cost until the shared token is rate-limited. A later
-dependent transition requests one explicit on-demand barrier instead. The hourly run remains a dashboard and recovery fallback.
+A failed/unacknowledged request blocks snapshot-dependent selection. Do not retry in the same tick or use the pre-request pointer.
+After `+1`, require matching protocol/repository/Project/artifact identity, acceptable age, `generatedAt` later than the request,
+and normally exact refresh-comment provenance. A later serialized successful pointer is acceptable only when demonstrably newer.
 
-The publish job is serialized with `queue: max` and `cancel-in-progress: false`. GitHub may keep up to 100 pending publications in
-FIFO order instead of replacing an older pending request when another trigger arrives. This preserves each on-demand request until
-it can reach a terminal reaction while still keeping pointer updates sequential. The job always checks out trusted `develop`,
-including for `issue_comment`, so comment content cannot inject untrusted code into the secret-bearing publication job. The
-comment trigger accepts only the exact configured command, status
-label, and actors `bedrin` or `bedrin-gpt`; all other issue comments produce a skipped publication job.
+## Artifact
 
-After the artifact and latest pointer are published, the workflow adds `+1` to the exact request comment. A publication failure
-adds `-1` when the runner can still execute the failure step. The reaction is deliberately last: `+1` is a read barrier proving
-that this request produced a usable pointer, while `-1` or no terminal reaction tells the tick to stop. The request comment ID,
-issue number, and actor are preserved as `source.workflowRun.refreshRequest` in both pointer and normalized snapshot.
+The artifact `ai-delivery-status-project-2` contains:
 
-A scheduled ChatGPT tick first requests a snapshot and waits up to the configured timeout for the terminal reaction. It then
-accepts only the protocol, repository, Project number, artifact name, and files configured in [`profile.yml`](profile.yml). The
-pointer and snapshot `generatedAt` timestamps must be strictly later than the request comment's creation time and no older than the
-configured maximum age. Normally the pointer names the exact request comment; a later serialized successful trigger may replace
-it and is necessarily at least as fresh. A failed request or stale, missing, malformed, expired, or inaccessible snapshot blocks
-snapshot-dependent autonomous Project selection. It does not justify guessing Project fields from prior chats, issue prose, or
-remembered state.
+- `project-2-status.json` — normalized active items, field definitions, open PR observations, and `dispatch` projection;
+- `project-fields.raw.json` — diagnostic raw Project fields;
+- `project-items.raw.json` — diagnostic raw Project items;
+- `repository-issues.raw.json` — diagnostic live issue metadata;
+- `repository-pull-requests.raw.json` — diagnostic live PR metadata.
 
-## Artifact contents
+The normalizer fails closed on incomplete pagination or missing live source state. Explicit absent Project field values are `null`;
+clients must not infer them from prose, authorship, prior chats, or defaults.
 
-Every successful run uploads one artifact named `ai-delivery-status-project-2` with two-day retention:
+## Open PR observations
 
-- `project-2-status.json` — normalized active items and complete field definitions;
-- `project-fields.raw.json` — unmodified `gh project field-list` JSON;
-- `project-items.raw.json` — unmodified `gh project item-list` JSON;
-- `repository-issues.raw.json` — live issue state and metadata from `gh issue list --state all`;
-- `repository-pull-requests.raw.json` — live pull-request state, draft/head/base/ownership metadata, and labels from `gh pr list --state all`.
+Top-level `pullRequests` includes every open repository PR independently of canonical Project representation: number/URL/author,
+same-repository or fork ownership, draft/base/branch/exact head, mergeability hint, merge-state hint, and formal closing issue
+numbers. A PR observation does not create a second lifecycle item.
 
-The normalized snapshot also contains a top-level `pullRequests` collection for every open repository PR, whether the PR or one
-of its formal closing issues is the canonical Project item. Each observation records number, URL, author, same-repository/fork
-ownership, draft/base/branch/exact-head identity, mergeability, merge-state status, and formal closing issue numbers. This is the
-pre-queue discovery surface for merge-conflict reconciliation; it does not make the PR a second lifecycle item.
+Canonical identity remains:
 
-The normalizer fails when GitHub reports more fields or items than were returned, rather than publishing a silently truncated view.
-Each normalized item contains:
+```text
+one closing issue -> issue
+no closing issue  -> PR
+multiple issues   -> PR in Planning
+```
 
-- Project item ID;
-- source type, repository, number, URL, title, state, draft flag, author, timestamps, and labels when available;
-- a `fields` object with every current Project field name represented, using `null` when the item has no value;
-- a `fieldValues` array preserving each field ID, name, data type, and value.
+## Dispatch projection
 
-Field definitions preserve IDs, data types, options, and configuration returned by GitHub CLI. Readers use field names for policy
-semantics and retain IDs/options for diagnosis; they must not invent values for missing fields.
+`.github/scripts/delivery-dispatch-view.js` adds deterministic runtime views so an LLM does not rescan or re-sort the entire
+Project and PR list:
+
+- `readyByExecutor`;
+- `inProgressByExecutor` and due observations when `nextObservationAt` is available;
+- Ready route/assignee mismatches;
+- conflicting same-repository PRs;
+- PR intake/canonicalization and duplicate-representation candidates;
+- downstream lifecycle state pinned to an older exact PR head;
+- `orderedCandidates`, the normal one-candidate attention queue.
+
+The projection contains compact target evidence only. It is not a substitute for complete issue/PR discussion, diff, review, CI,
+or artifacts; those are loaded after selection by the worker that needs them.
 
 ## Active-item semantics
 
-The normalized file includes:
+The normalized view keeps open issues/PRs, Project draft issues, and source-closed items whose Project Status is not Done, exposing
+lifecycle/source drift. It excludes technical control/status items and other repositories from the Sniffy active view. Raw exports
+remain available for diagnosis.
 
-- open issues;
-- open pull requests, including drafts as source telemetry;
-- Project draft issues;
-- closed or merged source items whose Project `Status` is not `Done`, so lifecycle/source drift remains visible;
-- open source items even when their Project status is terminal, so inverse drift remains visible.
+## Pointer
 
-`Done` is the only terminal Project lifecycle status for this filter. In particular, a closed source issue that remains in Project
-`Draft`, `Planning`, `Implementation`, `Review`, `Verification`, or `Approval` stays visible for reconciliation.
+The newest open status issue body is one JSON pointer with schema/kind, generated time, source repository/Project/workflow run,
+optional refresh request, numeric artifact ID/name/digest/file names/retention, and counts. Readers reject unknown schema/kind,
+wrong identity, nonnumeric artifact ID, stale/mismatched provenance, or inconsistent counts.
 
-It excludes technical items labeled `ai-delivery-control` or `ai-delivery-status`. The complete raw export remains available for
-incident investigation.
+## ChatGPT procedure
 
-The normalized snapshot is scoped to `sniffy/sniffy`. Project 2 may later contain other repositories; those items remain in the raw
-export but are not eligible in the Sniffy active view.
-
-## Pointer format
-
-The status issue body is one JSON object:
-
-```json
-{
-  "schemaVersion": 1,
-  "kind": "ai-delivery-status/v1",
-  "generatedAt": "2026-08-01T00:05:00Z",
-  "source": {
-    "repository": "sniffy/sniffy",
-    "project": {"owner": "sniffy", "number": 2},
-    "workflowRun": {
-      "id": 123456789,
-      "attempt": 1,
-      "event": "schedule",
-      "upstreamRunId": null,
-      "headSha": "...",
-      "refreshRequest": null
-    }
-  },
-  "artifact": {
-    "id": 987654321,
-    "name": "ai-delivery-status-project-2",
-    "url": "...",
-    "digest": "sha256:...",
-    "snapshotFile": "project-2-status.json",
-    "rawFieldsFile": "project-fields.raw.json",
-    "rawItemsFile": "project-items.raw.json",
-    "rawIssuesFile": "repository-issues.raw.json",
-    "rawPullRequestsFile": "repository-pull-requests.raw.json",
-    "retentionDays": 2
-  },
-  "counts": {
-    "fieldCount": 8,
-    "exportedItemCount": 100,
-    "activeItemCount": 12
-  }
-}
-```
-
-For a comment-driven publication, `source.workflowRun.event` is `issue_comment` and `refreshRequest` is populated:
-
-```json
-{
-  "commentId": 5152000000,
-  "issueNumber": 778,
-  "actor": "bedrin-gpt"
-}
-```
-
-Readers parse the body as JSON, reject unknown `kind` or `schemaVersion`, validate repository and Project identity, and use the
-numeric artifact ID with the default GitHub connector's artifact download operation. The artifact URL is diagnostic; it is not a
-credential and is not the primary download mechanism.
-
-## ChatGPT read procedure
-
-The exact Scheduled Task supplement lives in
-[`.chatgpt/status-snapshot-instructions.md`](../../.chatgpt/status-snapshot-instructions.md). In summary, every stateless tick:
-
-1. searches open `sniffy/sniffy` issues with label `ai-delivery-status` and selects the newest issue by number;
-2. posts exactly one `/ai-delivery-status refresh` comment, records its ID/time, and waits at most 120 seconds for `+1`;
-3. after `+1`, rediscovers the newest status issue and validates that its pointer is newer than the request and normally names the
-   exact request comment in `source.workflowRun.refreshRequest`;
-4. downloads the artifact by `artifact.id` through the default GitHub connector;
-5. reads `project-2-status.json`, validates its identity, timestamp, provenance, and counts, and then uses its explicit fields for Project
-   selection and guarded expected values;
-6. re-reads live issue/PR, branch, head, review, assignment, and CI state from GitHub before any claim or source mutation.
-
-The snapshot is not a lease and does not prove current ownership. A candidate may have changed after generation.
+The exact compact procedure lives in
+[`.chatgpt/status-snapshot-instructions.md`](../../.chatgpt/status-snapshot-instructions.md): request one fresh barrier; validate and
+download the artifact; select at most the first `dispatch.orderedCandidates` entry; live-read only that target; construct guarded
+expected values; stop without work mutation when no candidate remains actionable.
 
 ## Consistency and mutation boundary
 
-The snapshot is eventually consistent. It is safe for discovery and deterministic candidate selection because every Project
-mutation still goes through `delivery-control/v1`, whose serialized workflow re-reads live ProjectV2 and rejects stale expected
-values before changing anything.
+The snapshot is eventually consistent and safe only for discovery/selection. Every claim/handoff still goes through
+`delivery-control/v1`, whose serialized workflow live-reads ProjectV2 and rejects stale expected state.
 
-For a snapshot-backed client:
+- `confused`: state/head lost a race; make no work mutation from that snapshot;
+- `-1`: unexpected control failure; inspect the run;
+- `+1`: requested final state was applied/observed and verified.
 
-- `confused` means the snapshot/expected state lost a race; perform no work mutation and refresh later;
-- `-1` means an unexpected control failure; inspect the control run and do not infer final state;
-- `+1` means the control workflow applied or observed the requested final values and verified them internally.
+A later dependent Project transition requires a snapshot generated after the preceding successful command. Avoid speculative
+refresh fan-out.
 
-After a control-command `+1`, a later dependent Project transition must use a status snapshot generated after that command. Work
-that does not require another immediate Project write may proceed from the verified claim reaction plus live source state. The
-tick requests one on-demand comment barrier before the dependent transition rather than exporting after every control completion
-or waiting for best-effort cron. Scheduled runs remain a non-deterministic dashboard/recovery signal and are not the freshness
-guarantee for a tick.
+No client may mutate Project fields directly from the snapshot, use the status issue as a control-command channel, bypass guarded
+exact-head checks, or treat generated candidates as claim ownership.
 
-No client may mutate Project fields directly from the snapshot, treat the status issue as a delivery-control/Project-mutation
-channel, or bypass exact-head and expected-field guards. Its only accepted command is the configured read-only refresh request.
+## Permissions and failures
 
-## Permissions and failure response
+The workflow begins with `permissions: {}`. Validation receives contents read. Publication receives contents read, issues write,
+and pull-requests read; Project reads use the existing repository secret. It receives no branch write, merge, deployment, secret,
+or Project mutation permission.
 
-The workflow starts with `permissions: {}`:
-
-- validation receives `contents: read` only;
-- publication receives `contents: read`, `issues: write`, and `pull-requests: read` only;
-- Project reads use the existing `PROJECT_TOKEN` through GitHub CLI;
-- artifact upload uses the Actions runtime and does not grant branch, merge, deployment, secret, or Project mutation authority.
-
-On repeated failure, inspect:
-
-- missing, expired, unapproved, or insufficient `PROJECT_TOKEN` Project access;
-- GitHub CLI Project output/schema changes;
-- pagination/truncation failures;
-- artifact upload failure;
-- repository issue, label, pointer, or reaction write failure.
-
-The snapshot workflow is a non-required operational signal, not source CI. A failed run prevents snapshot-dependent autonomous
-selection until a fresh pointer exists. A scheduled tick reports `-1` or an unacknowledged request and stops; maintainers may use
-`workflow_dispatch` after correcting the cause.
-
-## Removal condition
-
-Remove this adapter when the default connected client can reliably read complete organization ProjectV2 state and discover the
-latest artifact directly, or when another repository-owned read model provides equivalent freshness, least privilege, auditability,
-and guarded-mutation compatibility.
+On failure inspect Project-token access, GitHub CLI output/schema/pagination, trusted checkout, normalizer/projection tests, artifact
+upload, pointer update, and reaction write. Until a fresh valid pointer exists, snapshot-dependent autonomous selection stops.

--- a/docs/ai-delivery/supervision.md
+++ b/docs/ai-delivery/supervision.md
@@ -12,238 +12,127 @@ Status:    Draft -> Planning -> Implementation -> Review -> Verification? -> App
 Execution: Ready | In progress | Blocked
 ```
 
-`Ready` applies to the next action in the current lifecycle status. `Review` is a lifecycle status. `Blocked` preserves where
-work should resume, stops autonomous processing, and routes the next action to Dmitry.
+A local commit is not publication; publication is not lifecycle handoff; handoff is not Review; Review is not Verification;
+Verification is not merge. `Blocked / Human` is reserved for one exact Dmitry decision or action.
 
-Do not replace lifecycle fields with optimistic prose. Track supporting facts independently:
+## Canonical issue and PR
 
-- canonical issue/PR decision;
-- guarded claim/transition result;
-- concrete dispatch acknowledgement;
-- local completion and local proof;
-- remote publication at an exact branch/SHA/PR;
-- PR open/base/draft state at handoff;
-- code review outcome;
-- verification outcome;
-- actual merge or deliberate closure.
+Apply [`pull-request-intake.md`](pull-request-intake.md) before supervising a PR:
 
-A local commit is not publication; publication is not lifecycle handoff; handoff is not review; review is not verification;
-verification is not merge.
+- one formal closing issue -> the issue is canonical and the PR is exact-head implementation evidence;
+- no closing issue -> the PR is canonical;
+- several closing issues -> the PR is canonical in Planning;
+- draft PR -> do not start Review;
+- issue and PR both in Project -> keep one canonical active item and make the duplicate non-claimable.
 
-## Canonical issue and PR supervision
-
-Before supervising a PR, apply [`pull-request-intake.md`](pull-request-intake.md):
-
-- one formal closing issue -> supervise lifecycle on that issue and keep the PR exact head in Worker reference;
-- no closing issue -> supervise lifecycle on the PR itself;
-- several closing issues -> supervise Planning on the PR and suppress duplicate linked-issue work until scope is resolved.
-
-If both an issue and its PR appear in Project 2, do not start two workers or Reviews. Preserve one canonical active item and make
-the duplicate non-claimable through a guarded reconciliation. Every status report names both the canonical item and exact PR head
-when implementation exists.
+Every report names the canonical item and the exact implementation PR head when one exists.
 
 ## Lifecycle handoff
 
-A worker completes one lifecycle turn and writes the next route through the common guarded protocol in
-[`control-plane.md`](control-plane.md):
+A worker owns one lifecycle turn and must publish its own completion signal through the common guarded protocol:
 
-- Planning records `Implementer` when a future Implementation turn is needed and records `Verifier`; handoff to Dmitry stays
-  `Planning / Ready / Human`.
-- Planning approval may write `Implementation / Ready / Executor := Implementer` only when Implementer is non-empty and
-  deliberately selected.
-- Implementation publication marks the PR ready when local proof is complete, re-reads open/develop/non-draft/exact-head state,
-  then writes the canonical item to `Review / Ready / Executor = ChatGPT` with PR URL and exact head in Worker reference.
-- The guarded Review command identifies that PR structurally: target plus `expected.head` for a canonical PR, or
-  `reviewPullRequest.number/head` for a canonical issue.
-- Universal PR intake performs the same Review handoff only for a non-draft PR that appeared outside the delivery system, leaving
-  Implementer unchanged/empty.
-- A multi-issue PR enters `Planning / Ready / ChatGPT` before Review.
-- Successful Review writes `Verification / Ready / Executor := Verifier` or `Approval / Ready / Human` when evidence is already
-  sufficient.
-- Successful Verification writes `Approval / Ready / Human`.
-- Approval becomes `Done` only after actual merge or deliberate closure.
+- Planning records deliberate future Implementer/Verifier routes;
+- Implementation publishes one intended PR, marks it ready for review, verifies open/develop/non-draft/exact-head state, and hands
+  the canonical item to `Review / Ready / ChatGPT`;
+- Review routes to Verification, Approval, a deliberate correction route, Planning, or Human;
+- Verification routes to Approval or a precisely classified correction;
+- Approval becomes Done only after actual merge or deliberate closure.
 
-Once a claimed Review concludes, its technical outcome and durable lifecycle route are one logical outcome in the same tick.
-GitHub review or comment publication, the guarded Project mutation, and assignment remain separate operations and each must be
-verified, but failure or inability to submit a formal review does not permit the exact head to remain `Review / Ready / ChatGPT`.
+A command setting Review identifies the exact PR structurally: target plus `expected.head` for a canonical PR, or
+`reviewPullRequest.number/head` for a canonical issue. Every handoff clears stale claim/lease ownership. Assignment and PR state are
+updated and verified separately.
 
-The control plane re-checks the review PR after all expected-state guards pass and marks it ready if an executor left it draft. That
-is a final invariant and recovery mechanism, not permission for executors to skip publication. It verifies the same exact head
-before Project Review is written.
-
-A blank Implementer is valid outside a routed Implementation turn. It must not prevent canonicalization, intake, Review, rebase or
-contributor monitoring, Verification, Approval, blocking, supersession, or closure. When Review or Verification discovers that new
-code is needed and Implementer is empty, deliberately choose a supported executor before entering Implementation.
-
-Every handoff clears stale worker ownership and lease data. GitHub assignment is updated separately and verified; a Project field
-transition does not prove assignment succeeded. A Review handoff additionally re-reads PR draft/head state after the terminal
-control reaction.
+Every autonomous control command uses the human-readable Markdown wrapper from [`control-plane.md`](control-plane.md), its exact
+start/end markers, and a lowercase `json` fence. The marked JSON is authoritative. Never use target-item polling or lease comments
+as a substitute for the central control protocol.
 
 ## Dispatch proof
 
-- A Cloud implementation is dispatched only after the proven trigger has a connector reaction, task link, or equivalent durable
-  acknowledgement. A review mention alone is not implementation dispatch.
-- Codex Cloud does not poll Project 2. ChatGPT owns dispatch for a valid `Implementation / Ready / Codex Cloud` route: claim while
-  preserving Executor, issue exactly one supported trigger, record durable acknowledgement and the first observation point, or
-  release the provisional claim to Ready when the trigger was not submitted or was definitively rejected. A submitted trigger
-  with uncertain acknowledgement remains one provisional generation for targeted recovery; never redispatch it blindly.
-- An app-native Local Codex item is dispatched only after a verified claim plus a concrete worker task/chat/worktree.
-- A headless Local Codex item is dispatched only after a verified claim plus process/worktree/branch record.
-- An adopted existing PR is dispatched only after the canonical Project item explicitly routes the exact same-repository PR,
-  branch, and head to the selected executor.
-- An IDE agent is working only while the human explicitly owns the interactive session or remote evidence proves activity.
-- A ChatGPT scheduled tick is working only after its guarded claim succeeded and it began the exact lifecycle operation.
-- A ChatGPT direct-execution task is working only after the exact GitHub or sandbox operation began.
+`In progress` is valid only with a successful guarded claim and a concrete worker or external-operation reference:
 
-`In progress` with no verified claim/current worker or observable external-operation reference is invalid. When execution or
-external dispatch cannot start, release to `Ready`. Set `Blocked` only when Dmitry must decide or act; set `Executor = Human`,
-assign `bedrin`, and record the exact requested action.
+- Codex Cloud: exact trigger plus durable acknowledgement or one preserved provisional generation;
+- Local Codex app: concrete task/chat/worktree;
+- Local Codex CLI: concrete process/worktree/branch;
+- adopted continuation: exact same-repository PR/branch/head selected by the canonical route;
+- contributor/bot operation: exact PR/head plus the concrete requested operation.
 
-## Queue polling, PR intake, and worker monitoring
+For supervised Cloud dispatch, claim while preserving Executor and record the exact trigger generation plus lease.
+When a trigger was not submitted or was definitively rejected, release the provisional claim to Ready. When submission succeeded
+but acknowledgement is uncertain, preserve one provisional generation under a short lease; never redispatch it blindly.
 
-Queue polling and worker follow-up are responsibilities of the same event loop:
+## Lease-based stale recovery
 
-- **Universal PR intake** scans every open PR targeting `develop`, canonicalizes issue versus PR, and materializes reviewable work
-  before ordinary queue selection.
-- **Queue polling** finds canonical `Ready` work and claims it. Desired logical cadence is every 15 minutes.
-- **Supervised external dispatch** lets the ChatGPT loop select configured `Ready / Codex Cloud` work even though ChatGPT is not
-  the Implementer. The acknowledged dispatch, not the Ready route alone, starts worker monitoring.
-- **Ready-route reconciliation** repairs a non-Human Ready item whose Assignee belongs to a different executor pool; such an item
-  must not disappear from every dispatcher's eligibility filter.
-- **Worker/operation monitoring** observes an existing implementation, correction, CI wait, contributor update, bot rebase, or
-  draft publication after 15 minutes, again 15 minutes later, then hourly while incomplete. It includes ChatGPT-supervised Codex
-  Cloud `In progress` routes even though their Executor field remains Codex Cloud.
-- **Control-log maintenance** rotates the active technical issue when a needed command would exceed the documented threshold.
+The scheduler checks the queue every 15 minutes, but it does **not** poll healthy workers every 15 minutes. A worker is responsible
+for updating the canonical issue/PR and performing the guarded lifecycle handoff when it finishes.
 
-Do not create an additional monitoring Scheduled Task. A normal dispatcher tick first checks whether an existing owned worker or
-PR operation is due for observation; only then may it claim unrelated work.
+Every claim records at least:
 
-Every new delegated task, retry, continuation, adopted PR, executor change, or Request Changes return starts the normal
-observation cycle:
+```text
+claimToken
+generation
+claimedAt
+leaseUntil
+worker/task/process/branch/PR reference
+```
 
-1. observe after 15 minutes;
-2. if incomplete, observe 15 minutes later;
-3. if still incomplete, observe hourly.
+A valid future `leaseUntil` means ownership is active. Normal dispatcher ticks:
 
-Each observation re-reads canonical fields, linked issues/PR, intended executor and assignee, worker record, exact branch/head,
-acknowledgement or new head, draft state, review threads, and current CI. `Implementer` may be empty; current ownership comes from
-`Executor`, `Assignee`, and Worker reference. Notify the target conversation only on meaningful progress, completion, or a real
-blocker. Routine “still running” telemetry remains in the scheduler/worker transcript.
+- count it against executor capacity;
+- do not open the worker conversation/task;
+- do not query provider-wide inventory;
+- do not post “still running” comments;
+- do not schedule a second monitor.
 
-A dispatch comment does not prove work started. Verify acknowledgement, process/task reference, or new remote evidence. Stop
-monitoring when lifecycle handoff completes or Dmitry owns a blocked next action.
+A worker that legitimately needs more time renews the same claim/generation before expiry through a guarded update. Completion is
+signalled by its normal evidence plus guarded handoff, which clears claim and lease data.
+
+An item becomes a stale-recovery candidate only when the Worker reference is missing, the lease is missing/invalid, or
+`leaseUntil` has expired. The next ordinary scheduler tick performs one targeted recovery:
+
+1. re-read the canonical item, exact worker reference, branch/PR/head, and relevant GitHub evidence;
+2. if the lifecycle handoff already completed, do nothing;
+3. if the same worker is demonstrably active, preserve its generation and extend the lease;
+4. if completion evidence exists but the handoff was lost, finish the deterministic handoff;
+5. if the worker failed or disappeared, recover the same workspace/branch/generation where possible;
+6. release to Ready only when no active work or recoverable publication remains;
+7. never create a duplicate generation, branch, or PR.
+
+CI waits, contributor updates, Dependabot operations, rebases, and draft publication use bounded operation leases too. They are
+revisited after lease expiry, or earlier only when a GitHub event has already produced a new actionable lifecycle state. There is no
+staged periodic per-worker observation cycle and no separate monitoring scheduler.
 
 ## Branch and PR continuity
 
-- Fresh work uses one new branch from current `develop` and one intended PR unless independently useful slices were approved.
-- Continuation/adopted-continuation work reuses the exact open same-repository branch and PR, regardless of whether Dmitry,
-  ChatGPT, Codex, or an IDE agent originally created it.
-- The canonical route, effective push permission, and absence of competing ownership authorize adoption; author identity alone does
-  not.
-- Changing executor preserves useful published work; do not reset to `develop`, rebase, force-push, or create a duplicate PR.
-- When `develop` moves materially before handoff, normally merge current `origin/develop` into the feature branch and rerun
-  exact-head proof. Do not use a stale green run as final evidence.
-- Preserve completed work when publication fails. Recover the existing commit/workspace rather than rebuilding by default.
-- Implementation publication is incomplete until the PR is open, targets `develop`, is ready for review (`draft = false`) at the
-  exact published head, and the canonical item has a verified guarded `Review / Ready / ChatGPT` handoff.
+Fresh work uses one branch and one intended PR. Continuation reuses the exact open same-repository branch and PR regardless of who
+created it. Changing executor preserves useful commits and evidence; never reset to develop, rebase, force-push, or open a duplicate
+PR merely because ownership changed.
 
-For fork PRs:
-
-- review the contributor's exact head without privileged execution of untrusted code;
-- submit contributor-facing Request Changes and monitor for a new head;
-- do not autonomously push to the fork or adopt the branch;
-- create a linked internal replacement task only after an explicit routing decision.
-
-For Dependabot and other managed automation PRs:
-
-- review the bot's exact head directly when the update is self-contained;
-- request the documented rebase rather than rewriting its branch for a stale base or conflict;
-- keep `Executor = ChatGPT` while waiting and record old head plus next observation point;
-- do not require or set Implementer merely to monitor the external operation;
-- do not normally push compatibility fixes onto the bot branch;
-- create a linked issue and agent-owned replacement PR when implementation changes are required;
-- keep the source PR blocked/superseded with explicit links and rationale.
+Fork PRs remain contributor-owned. Dependabot and other managed automation branches remain bot-owned. Use contributor feedback,
+documented bot operations, or a deliberate internal replacement task instead of autonomous branch adoption.
 
 ## Review and correction
 
-Review audits the whole acceptance-to-proof matrix, not only the visible delta. Inspect:
+Review inspects the complete exact-head diff, authoritative requirements, tests actually run, generated/unrelated files, unresolved
+threads, and matching-head CI/artifacts. Publish one comprehensive result.
 
-- complete exact-head diff and scope;
-- every authoritative/closing issue and later decision;
-- architecture, module/API ownership, compatibility, lifecycle, and resource safety;
-- test design, discovery, and implementer proof;
-- dependencies, workflows, permissions, and standard-tooling rationale;
-- generated/unrelated files, documentation, migration, rollback, and PR-body accuracy;
-- unresolved comments and threads;
-- exact-head CI statuses and relevant logs.
+Formal review requires an identity independent from the PR author. When blockers remain:
 
-Report independent findings together. One comprehensive Request Changes is better than serial discovery of unrelated blockers.
+- independent reviewer -> comprehensive `REQUEST_CHANGES`;
+- PR author identity -> the same complete findings as an ordinary PR comment, explicitly stating the identity limitation.
 
-A Request Changes result does not justify assigning the PR author as Implementer. Choose among:
+The technical Review outcome and durable route complete in the same tick. Route code/design defects to `Implementation / Ready`
+after choosing an eligible Implementer; requirements/architecture/canonicalization defects to `Planning / Ready / ChatGPT`; and
+one exact maintainer action to `Blocked / Human`. A technically acceptable self-authored PR proceeds to Verification or
+`Approval / Ready / Human` rather than remaining in Review.
 
-- same-repository focused correction by ChatGPT on the exact branch;
-- same-repository complex/persistent correction by Local Codex adopted continuation;
-- contributor-owned correction for a fork PR;
-- documented bot operation for Dependabot/managed automation;
-- linked internal replacement task when direct branch correction is unsafe or inappropriate;
-- return to Planning when scope, canonicalization, architecture, or proof is unresolved.
+If corrected work returns to Review and still has substantive blockers, perform the convergence checkpoint in [`routing.md`](routing.md)
+before another implementation dispatch. Continue coherently, preserve and escalate the existing PR, return to Planning, or request
+one exact Dmitry decision. Infrastructure noise is not a substantive correction round.
 
-After correction, the implementation worker publishes a new exact head, marks the PR ready, verifies non-draft exact-head state,
-and hands the same canonical item back to Review. Do not create a second issue or PR solely because ownership changed.
+## Target-comment noise and merge boundary
 
-### Convergence checkpoint
+The canonical issue/PR contains human-useful plans, reviews, proof, blockers, and handoffs. Technical commands, claims, leases, and
+recovery details stay in the rotating control log and scheduler telemetry.
 
-The checkpoint is not a timer and does not create another process. It is a required Review decision inside the normal lifecycle.
-
-Trigger it when a substantive Request Changes returned work to Implementation, the corrected head came back to Review, and the
-next complete Review still finds substantive blockers. Before another correction dispatch, ChatGPT performs the critical analysis
-in [`routing.md`](routing.md): verify the canonical item, architecture, acceptance criteria, proof strategy, executor capability,
-branch continuity, and whether another narrow patch would converge.
-
-The checkpoint must explicitly choose one route:
-
-- continue the same executor with coherent superseding guidance;
-- preserve/adopt the branch and PR and escalate continuation to Local Codex;
-- return to Planning and re-baseline architecture/requirements/canonicalization/proof;
-- block for one exact Dmitry decision or action.
-
-Do not automatically send a third list of local edits. Do not automatically escalate for infrastructure noise or an ordinary
-failing check. Record substantive correction rounds separately from CI/provider noise.
-
-After an executor change, start the normal 15-minute observation cycle only when the replacement dispatch is concretely
-acknowledged. The convergence checkpoint itself needs no schedule.
-
-## Review identities
-
-Formal review must use an identity independent from the PR author.
-
-- When independent review is available and proof passes, submit `APPROVE`.
-- When blockers remain and the identity is independent, submit one precise `REQUEST_CHANGES`, then explicitly route the canonical
-  item in the same Review tick.
-- When blockers remain and the active identity is the PR author, publish the same complete blocking feedback as an ordinary PR
-  comment, state the identity limitation, and explicitly route the canonical item in the same Review tick. Do not wait for the
-  formal-review return adapter.
-- Route an implementation, code, or design defect to `Implementation / Ready` only after deliberately selecting an eligible
-  Implementer and preserving the same same-repository branch, PR, and exact head. Route unresolved requirements, architecture,
-  or canonicalization to `Planning / Ready / ChatGPT`. Use `Blocked / Human` only when one exact Dmitry decision or action is
-  required.
-- When proof passes but the identity is the PR author, continue to required Verification or `Approval / Ready / Human`; inability
-  to self-approve must not park the exact head in Review.
-
-A Dmitry-, Dependabot-, external-contributor-, or other independently authored PR may receive a formal `bedrin-gpt` review.
-A `bedrin-gpt`-authored PR cannot. That identity rule comes from the PR author, not the optional Project Implementer field.
-
-## Target-comment noise policy
-
-The central control issue stores technical Project transition commands. Do not post claim intents, field commands, lease
-arbitration, polling notices, or winner/loser messages on the target item.
-
-The canonical issue/PR should contain only human-useful plans, review decisions, publication/verification evidence, real blockers,
-and meaningful handoffs. Linked PR review conversations remain the right place for formal reviews and inline findings. Preserve
-technical control commands for troubleshooting in the rotating log rather than deleting them.
-
-## Merge and privileged boundaries
-
-No agent or supervising workflow may merge, enable auto-merge, bypass protection, rewrite shared history, or perform privileged
-repository/hosting operations without Dmitry's explicit instruction. `Approval / Ready` is the human acceptance queue. This
-boundary applies to all PR sources.
+No agent may merge, enable auto-merge, bypass protection, rewrite shared history, or perform privileged repository/hosting
+operations without Dmitry's explicit instruction.


### PR DESCRIPTION
## Summary

Refactor the Sniffy AI delivery adapters so recurring dispatch is mostly deterministic data processing rather than repeated LLM policy interpretation.

- add a compact runtime contract and an instruction/entry-point audit;
- create ChatGPT Scheduled Tasks in Chat rather than Work;
- support one-hour budget cadence or four compact 15-minute queue slots;
- use `dispatch.orderedCandidates` generated by the status workflow;
- add deterministic Ready, active/stale In progress, PR intake/conflict, route-mismatch, and stale exact-head projections;
- replace periodic worker polling with lease-based stale recovery: workers own completion handoff, valid leases are ignored, and only missing/invalid/expired leases trigger targeted recovery of the exact generation;
- keep fork and Dependabot conflicts visible while routing them to contributor feedback or `@dependabot rebase`, never branch adoption;
- use Luna/low for the Local Codex dispatcher, Terra/medium for normal workers, and explicit Sol/high escalation;
- change the headless Codex helper default from Sol/xhigh to Terra/medium;
- add duration/model/outcome/token-counter telemetry without fabricating unavailable usage;
- retain canonical PR intake, guarded Project transitions, exact-head Review, existing-PR continuity, review identity rules, verification, and no-merge boundaries;
- add prompt byte-budget, model-profile, and lease-recovery tests.

## Baseline

Reviewed `develop` at `790a990b9a7f1a51403ee43148a3c8daa3085233` as the `gptflow-v1` candidate baseline.

The connected GitHub action can create branches/commits/PRs but does not expose Git tag creation. The exact annotated-tag command is documented in `docs/ai-delivery/instruction-audit.md`; no branch was substituted for the requested tag.

## Design

Detailed Markdown remains normative human/worker reference. A recurring dispatcher loads only:

1. its short adapter prompt;
2. `docs/ai-delivery/runtime-contract.md`;
3. one current normalized queue/status projection.

Only a selected lifecycle worker loads complete discussions, diffs, reviews, CI, artifacts, nearest `AGENTS.md`, and relevant detailed policy.

A worker publishes evidence and performs its own guarded lifecycle handoff. While `leaseUntil` is valid, scheduler ticks count the item against capacity but do not query its task/conversation. Missing worker evidence or a missing, invalid, or expired lease creates one `stale-owned-recovery` candidate. Recovery preserves the exact claim/generation/task/branch/PR, extends an active lease or completes a lost handoff, and releases to Ready only when no active or recoverable work remains. No separate monitoring scheduler or duplicate worker is created.

`profile.yml` remains the project-specific declarative source. This PR does not add a bespoke YAML parser to each dispatcher; the trusted status workflow and Local Codex helper emit runtime JSON projections, while a future generic framework can compile profiles once into versioned runtime JSON.

## Verification

Exact head: `eacdacbe0f6abaaf1680fec5cc0a28a078b81401`

- [x] local combined 28 policy/projection/budget tests
- [x] JavaScript syntax checks, shell syntax check, and profile YAML parse
- [x] prompt/model/telemetry byte budgets
- [x] complete published 25-file PR diff and lease delta reviewed; no code/design blocker found
- [x] no unresolved review threads or independent review findings at this exact head
- [x] exact-head `AI delivery status`
- [x] exact-head `AI delivery control`
- [ ] exact-head full `Check Pull Request` matrix — queued behind superseded runs

Focused CI iterations exposed omitted embedded-scheduler wording and preserved contract phrases for Cloud acknowledgement, canonical `closingIssueNumbers`, fork ownership, and `@dependabot rebase`. Those findings are fixed and both focused workflows are green on the exact head above. A superseded full matrix already passed Frontend and JDK 8/11/17/25 smoke jobs, but it is not counted as exact-head proof.

The PR intentionally remains draft while the exact-head full matrix is incomplete. The active GitHub identity authored this PR, so it cannot independently approve it.

Never merge or enable auto-merge without Dmitry's explicit instruction.