### PR TITLE
Fix suppressed PR dispatch intake

### DIFF
--- a/.github/scripts/delivery-dispatch-view.js
+++ b/.github/scripts/delivery-dispatch-view.js
@@ -6,6 +6,7 @@ const DOWNSTREAM_HEAD_STATUSES = new Set(['Review', 'Verification', 'Approval'])
 const PRIORITY_RANK = new Map([['Urgent', 0], ['High', 1], ['Medium', 2], ['Low', 3]]);
 const SHA_PATTERN = /\b[0-9a-f]{40}\b/gi;
 const LEASE_UNTIL_PATTERN = /\b"?leaseUntil"?\s*[=:]\s*"?([^"\s;,}]+)/i;
+const SUPPRESSED_DUPLICATE_PATTERN = /^Suppressed duplicate lifecycle item\b/i;
 
 function asArray(value) {
   return Array.isArray(value) ? value : [];
@@ -31,6 +32,11 @@ function labelNames(rawPullRequest) {
     if (value && typeof value === 'object') return [value.name].filter(Boolean);
     return [];
   }).sort();
+}
+
+function isDependabotAuthor(author) {
+  const login = String(author ?? '').trim().toLowerCase();
+  return login === 'dependabot' || login === 'dependabot[bot]' || login === 'app/dependabot';
 }
 
 function normalizedType(value) {
@@ -124,6 +130,12 @@ function exactHeads(workerReference) {
   return [...new Set(workerReference.match(SHA_PATTERN) || [])].map(value => value.toLowerCase());
 }
 
+function isSuppressedDuplicateItem(item) {
+  return item?.status === 'Draft' &&
+    typeof item.workerReference === 'string' &&
+    SUPPRESSED_DUPLICATE_PATTERN.test(item.workerReference.trim());
+}
+
 function projectItemsForPullRequest(pullRequest, itemsByIdentity) {
   const identities = [{type: 'PullRequest', number: pullRequest.number}];
   for (const issueNumber of asArray(pullRequest.closingIssueNumbers)) {
@@ -132,12 +144,12 @@ function projectItemsForPullRequest(pullRequest, itemsByIdentity) {
   return identities.flatMap(identity => itemsByIdentity.get(itemKey(identity.type, identity.number)) || []);
 }
 
-function conflictModeFor({pullRequest, canonicalItem, dependabot, reviewable}) {
+function conflictModeFor({pullRequest, canonicalItem, dependabot, reviewable, suppressed}) {
   const hasConflict = reviewable &&
     (pullRequest.mergeable === 'CONFLICTING' || pullRequest.mergeStateStatus === 'DIRTY');
   const routedImplementation = canonicalItem?.status === 'Implementation' &&
     ['Ready', 'In progress'].includes(canonicalItem.execution) && canonicalItem.executor !== null;
-  if (!hasConflict || routedImplementation) return null;
+  if (suppressed || !hasConflict || routedImplementation) return null;
   if (dependabot) return 'dependabot-operation';
   if (pullRequest.repositoryOwnership === 'fork') return 'contributor-feedback';
   if (pullRequest.repositoryOwnership === 'same-repository') return 'same-repository-continuation';
@@ -149,14 +161,17 @@ function pullRequestProjection(pullRequest, rawPullRequestsByNumber, itemsByIden
   const canonicalItems = itemsByIdentity.get(itemKey(canonical.type, canonical.number)) || [];
   const relatedItems = projectItemsForPullRequest(pullRequest, itemsByIdentity);
   const duplicateItems = relatedItems.filter(item => projectIdentity(item) !== itemKey(canonical.type, canonical.number));
+  const suppressedDuplicateItems = duplicateItems.filter(isSuppressedDuplicateItem);
+  const actionableDuplicateItems = duplicateItems.filter(item => !isSuppressedDuplicateItem(item));
   const canonicalItem = canonicalItems[0] ?? null;
+  const suppressed = isSuppressedDuplicateItem(canonicalItem);
   const raw = rawPullRequestsByNumber.get(Number(pullRequest.number)) || {};
   const labels = labelNames(raw);
-  const dependabot = String(pullRequest.author ?? '').toLowerCase().startsWith('dependabot');
+  const dependabot = isDependabotAuthor(pullRequest.author);
   const onBase = pullRequest.baseRefName === baseBranch;
   const reviewable = onBase && pullRequest.isDraft === false;
   const statusNeedsIntake = canonicalItem === null || canonicalItem.status === null || canonicalItem.status === 'Draft';
-  const conflictMode = conflictModeFor({pullRequest, canonicalItem, dependabot, reviewable});
+  const conflictMode = conflictModeFor({pullRequest, canonicalItem, dependabot, reviewable, suppressed});
   return {
     number: pullRequest.number,
     url: pullRequest.url,
@@ -173,8 +188,10 @@ function pullRequestProjection(pullRequest, rawPullRequestsByNumber, itemsByIden
     canonical,
     canonicalProjectItem: canonicalItem,
     duplicateProjectItems: duplicateItems,
+    suppressedDuplicateProjectItems: suppressedDuplicateItems,
+    suppressed,
     isDependabot: dependabot,
-    needsIntake: reviewable && (statusNeedsIntake || duplicateItems.length > 0),
+    needsIntake: reviewable && !suppressed && (statusNeedsIntake || actionableDuplicateItems.length > 0),
     conflictMode,
     conflictCandidate: conflictMode !== null
   };

--- a/.github/scripts/delivery-dispatch-view.test.js
+++ b/.github/scripts/delivery-dispatch-view.test.js
@@ -179,6 +179,18 @@ test('keeps fork and Dependabot conflicts visible without direct branch adoption
   assert.deepEqual(result.orderedCandidates.map(value => value.kind), ['managed-pr-conflict', 'managed-pr-conflict']);
 });
 
+test('recognizes GitHub App Dependabot login', () => {
+  const dependabot = pullRequest(12, [], {author: 'app/dependabot', mergeable: 'CONFLICTING'});
+  const result = buildDispatch(
+    snapshot([], [dependabot]),
+    {items: []},
+    [{number: 12, labels: [{name: 'dependencies'}]}],
+    {}
+  );
+  assert.equal(result.pullRequests.managedConflicts[0].isDependabot, true);
+  assert.equal(result.pullRequests.managedConflicts[0].conflictMode, 'dependabot-operation');
+});
+
 test('does not treat a human dependency PR as Dependabot', () => {
   const human = pullRequest(13, [], {author: 'human', mergeable: 'CONFLICTING'});
   const result = buildDispatch(
@@ -205,6 +217,45 @@ test('does not steal an explicit Local Codex correction route as intake or confl
   assert.equal(result.pullRequests.intake.length, 0);
   assert.equal(result.pullRequests.conflicting.length, 0);
   assert.equal(result.pullRequests.managedConflicts.length, 0);
+  assert.equal(result.orderedCandidates.length, 0);
+});
+
+test('does not requeue an explicitly suppressed PR item', () => {
+  const suppressedPr = projectItem(761, {
+    Status: 'Draft',
+    'Worker reference': 'Suppressed duplicate lifecycle item; canonical replacement issue https://github.com/sniffy/sniffy/issues/772 owns the lifecycle'
+  }, 'PullRequest');
+  const pr = pullRequest(761, [], {
+    author: 'app/dependabot',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY'
+  });
+  const result = buildDispatch(
+    snapshot([suppressedPr], [pr]),
+    {items: [rawItem(suppressedPr, ['bedrin-gpt'])]},
+    [{number: 761, labels: [{name: 'dependencies'}]}],
+    {}
+  );
+  assert.equal(result.pullRequests.intake.length, 0);
+  assert.equal(result.pullRequests.conflicting.length, 0);
+  assert.equal(result.pullRequests.managedConflicts.length, 0);
+  assert.equal(result.orderedCandidates.length, 0);
+});
+
+test('does not requeue an already suppressed duplicate representation', () => {
+  const issue = projectItem(9, {Status: 'Review', Execution: 'Ready', Executor: 'Human'}, 'Issue');
+  const duplicatePr = projectItem(10, {
+    Status: 'Draft',
+    'Worker reference': 'Suppressed duplicate lifecycle item; canonical issue https://github.com/sniffy/sniffy/issues/9'
+  }, 'PullRequest');
+  const pr = pullRequest(10, [9]);
+  const result = buildDispatch(
+    snapshot([issue, duplicatePr], [pr]),
+    {items: [rawItem(issue), rawItem(duplicatePr)]},
+    [{number: 10, labels: []}],
+    {}
+  );
+  assert.equal(result.pullRequests.intake.length, 0);
   assert.equal(result.orderedCandidates.length, 0);
 });
 


### PR DESCRIPTION
## Problem

The compact dispatcher projection repeatedly selected PR #761 as `pr-intake` even though its Project item had already been deliberately suppressed in favor of canonical replacement issue #772.

Two details combined to produce the false candidate:

- GitHub normalized the Dependabot author as `app/dependabot`, while the projection only recognized logins beginning with `dependabot`;
- every Project item with `Status = Draft` was treated as needing intake, including items whose Worker reference explicitly records `Suppressed duplicate lifecycle item`.

This would keep the paused ChatGPT heartbeat focused on the same superseded bot PR instead of allowing an empty tick or the next real candidate.

## Design

- Recognize the supported Dependabot actor forms: `dependabot`, `dependabot[bot]`, and `app/dependabot`.
- Treat an item as already suppressed only when both conditions hold:
  - `Status = Draft`;
  - Worker reference starts with the existing exact marker `Suppressed duplicate lifecycle item`.
- Keep suppressed canonical or duplicate PR representations visible in diagnostics, but exclude them from generic intake and conflict candidates.
- Preserve ordinary Draft intake, actionable duplicate reconciliation, fork handling, Dependabot bot operations, and explicitly routed implementation continuations.

## Compatibility and scope

This changes only deterministic `dispatch` projection behavior. It does not alter Project fields, the `delivery-control/v1` mutation protocol, status workflow permissions, scheduler prompts, or lifecycle policy.

## Validation

- `node --check .github/scripts/delivery-dispatch-view.js`
- `node --check .github/scripts/delivery-dispatch-view.test.js`
- `node --test .github/scripts/delivery-dispatch-view.test.js` — 13/13 passed
- Replayed the modified projection against status artifact `8853046668` generated from current `develop`; the false PR #761 candidate disappeared and `dispatch.orderedCandidates` became empty.
- Remote comparison: two intended files only, 73 additions / 5 deletions, branch is 0 commits behind `develop`.

## Limitations and risk

Suppression remains explicit and reversible: it is recognized only through the existing exact marker prefix plus Draft status. Removing that marker or changing lifecycle state makes the PR eligible for normal reconciliation again.

## Published head

`4382fec0827b379231a30abaaaacdd3d31edc9bd`

No merge or auto-merge is requested.