### PR TITLE
Complete merged delivery items deterministically

### DIFF
--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -15,20 +15,31 @@ the whole Project or inspect every open PR.
    `ai-delivery-status/v1`, repository `sniffy/sniffy`, Project `sniffy/2`, artifact name `ai-delivery-status-project-2`, numeric
    artifact ID, snapshot file `project-2-status.json`, acceptable age, and `generatedAt` strictly later than the request. Normally
    require matching refresh comment provenance; a later serialized successful publication is acceptable when demonstrably newer.
-4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts, top-level `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
+4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts, top-level
+   `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
 5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to rebuild
-   executor queues, canonical PR identity, route mismatches, conflicts, stale exact-head state, or lease classification from raw
-   arrays. Raw files are diagnostics only.
-6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their contributor. Dependabot PRs use `@dependabot rebase`; never adopt or rewrite those branches through this rule.
+   executor queues, canonical PR identity, completion drift, route initialization/defaults, route mismatches, conflicts, stale
+   exact-head state, or lease classification from raw arrays. Raw files are diagnostics only.
+6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use
+   `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their contributor. Dependabot PRs use
+   `@dependabot rebase`; never adopt or rewrite those branches through this rule.
 7. `dispatch.activeInProgressByExecutor` is capacity/diagnostic state. A valid future `leaseUntil` is not actionable and must not
    cause a worker/task lookup. Only `stale-owned-recovery` may inspect an existing worker, scoped to the exact claim/generation.
-8. Live-read only the selected candidate: current issue/PR state, exact branch/head, formal links, ownership, assignment, Project
-   route, worker reference/lease, reviews/threads/CI/mergeability when relevant, and active control issue. Snapshot values are
-   selection hints, not mutation authority.
-9. Construct guarded `delivery-control/v1` expected state from the snapshot, but act only after targeted live re-read. On
-   `confused`, make no work mutation or retry from the same snapshot. On `-1`, inspect the failed control run. On `+1`, the control
-   workflow's final verification is authoritative.
-10. Before a later dependent Project transition, request one snapshot generated after the preceding successful command. Do not add
+8. Treat deterministic reconciliation candidates as narrow, targeted work:
+   - `completion-drift`: verify the selected item is still `Approval / Ready / Human` and its selected PR is merged, then apply one
+     guarded Done transition and clear assignment; normal completion belongs to the event adapter;
+   - `uninitialized-item`: verify one open non-technical issue, then initialize only the suggested `Planning / Ready` route;
+   - `default-planning-route`: verify `Planning / Ready` still has no Executor, then apply the suggested unique-assignee route or
+     ChatGPT default;
+   - `route-ambiguity`: inspect only that item and fail closed or route to a precise human decision; never guess from unknown or
+     multiple assignees.
+9. Live-read only the selected candidate: current issue/PR state, exact branch/head or merged state, formal links, ownership,
+   assignment, Project route, worker reference/lease, reviews/threads/CI/mergeability when relevant, and active control issue.
+   Snapshot values are selection hints, not mutation authority.
+10. Construct guarded `delivery-control/v1` expected state from the snapshot, but act only after targeted live re-read. On
+    `confused`, make no work mutation or retry from the same snapshot. On `-1`, inspect the failed control run. On `+1`, the control
+    workflow's final verification is authoritative.
+11. Before a later dependent Project transition, request one snapshot generated after the preceding successful command. Do not add
     speculative refreshes or chain dependent Project writes from an older materialized view.
-11. If no candidate remains actionable after live re-read, return `NO_CHANGE` plus telemetry without target/source/worker/control
+12. If no candidate remains actionable after live re-read, return `NO_CHANGE` plus telemetry without target/source/worker/control
     mutation.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -16,14 +16,13 @@ the whole Project or inspect every open PR.
    artifact ID, snapshot file `project-2-status.json`, acceptable age, and `generatedAt` strictly later than the request. Normally
    require matching refresh comment provenance; a later serialized successful publication is acceptable when demonstrably newer.
 4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts,
-   top-level `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or
-   inaccessible data.
+   top-level `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
 5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to rebuild
    executor queues, canonical PR identity, completion drift, route initialization/defaults, route mismatches, conflicts, stale
    exact-head state, or lease classification from raw arrays. Raw files are diagnostics only.
-6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use
-   `closingIssueNumbers` to resolve the canonical issue-versus-PR identity. Fork PRs wait for their contributor. Dependabot PRs use
-   `@dependabot rebase`; never adopt or rewrite those branches through this rule.
+6. Top-level PR observations cover every open base-branch PR independently of Project item type. Always use `closingIssueNumbers` to resolve the
+   canonical issue-versus-PR identity. Fork PRs wait for their contributor. Dependabot PRs use `@dependabot rebase`; never adopt or rewrite those
+   branches through this rule.
 7. `dispatch.activeInProgressByExecutor` is capacity/diagnostic state. A valid future `leaseUntil` is not actionable and must not
    cause a worker/task lookup. Only `stale-owned-recovery` may inspect an existing worker, scoped to the exact claim/generation.
 8. Treat deterministic reconciliation candidates as narrow, targeted work:

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -15,8 +15,9 @@ the whole Project or inspect every open PR.
    `ai-delivery-status/v1`, repository `sniffy/sniffy`, Project `sniffy/2`, artifact name `ai-delivery-status-project-2`, numeric
    artifact ID, snapshot file `project-2-status.json`, acceptable age, and `generatedAt` strictly later than the request. Normally
    require matching refresh comment provenance; a later serialized successful publication is acceptable when demonstrably newer.
-4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts, top-level
-   `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or inaccessible data.
+4. Download that artifact by numeric ID and validate matching identity, generation, provenance, complete counts,
+   top-level `pullRequests` observations, and `dispatch` projections. Reject malformed, inconsistent, incomplete, stale, or
+   inaccessible data.
 5. Use `dispatch.orderedCandidates` as the normal attention queue and select at most its first entry. Do not ask the model to rebuild
    executor queues, canonical PR identity, completion drift, route initialization/defaults, route mismatches, conflicts, stale
    exact-head state, or lease classification from raw arrays. Raw files are diagnostics only.

--- a/.chatgpt/status-snapshot-instructions.md
+++ b/.chatgpt/status-snapshot-instructions.md
@@ -26,8 +26,9 @@ the whole Project or inspect every open PR.
 7. `dispatch.activeInProgressByExecutor` is capacity/diagnostic state. A valid future `leaseUntil` is not actionable and must not
    cause a worker/task lookup. Only `stale-owned-recovery` may inspect an existing worker, scoped to the exact claim/generation.
 8. Treat deterministic reconciliation candidates as narrow, targeted work:
-   - `completion-drift`: verify the selected item is still `Approval / Ready / Human` and its selected PR is merged, then apply one
-     guarded Done transition and clear assignment; normal completion belongs to the event adapter;
+   - `completion-drift`: verify the selected item is still `Approval / Ready / Human`, or `Done` with lingering active
+     routing/assignment, and its selected PR is merged, then apply one guarded Done transition and clear assignment; normal
+     completion belongs to the event adapter;
    - `uninitialized-item`: verify one open non-technical issue, then initialize only the suggested `Planning / Ready` route;
    - `default-planning-route`: verify `Planning / Ready` still has no Executor, then apply the suggested unique-assignee route or
      ChatGPT default;

--- a/.github/scripts/delivery-completion.edge.test.js
+++ b/.github/scripts/delivery-completion.edge.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  clearAssigneesAndVerify,
+  commandFor,
+  prepareCompletion,
+  verifyMergedPullRequest
+} = require('./delivery-completion');
+
+function fieldValues(fields) {
+  return Object.entries(fields).map(([name, value]) => ({
+    __typename: ['Status', 'Execution', 'Executor'].includes(name)
+      ? 'ProjectV2ItemFieldSingleSelectValue'
+      : 'ProjectV2ItemFieldTextValue',
+    ...(['Status', 'Execution', 'Executor'].includes(name) ? {name: value} : {text: value}),
+    field: {name}
+  }));
+}
+
+function item(fields = {}) {
+  return {
+    project: {id: 'project'},
+    fieldValues: {nodes: fieldValues({
+      Status: 'Approval', Execution: 'Ready', Executor: 'Human', 'Worker reference': null, ...fields
+    })}
+  };
+}
+
+function mergedPullRequest({projectItems = [item()], closingIssues = []} = {}) {
+  return {
+    number: 12,
+    state: 'MERGED',
+    mergedAt: '2026-08-03T12:00:00Z',
+    mergeCommit: {oid: 'c'.repeat(40)},
+    headRefOid: 'a'.repeat(40),
+    headRefName: 'agent/example',
+    baseRefName: 'develop',
+    projectItems: {nodes: projectItems},
+    closingIssuesReferences: {nodes: closingIssues}
+  };
+}
+
+function coreStub() {
+  const outputs = new Map();
+  const summary = {addHeading() { return this; }, addRaw() { return this; }, addCodeBlock() { return this; }};
+  return {outputs, summary, setOutput(name, value) { outputs.set(name, value); }};
+}
+
+function context() {
+  return {
+    eventName: 'pull_request_target',
+    payload: {action: 'closed', pull_request: {number: 12, merged: true, base: {ref: 'develop'}}}
+  };
+}
+
+test('skips explicit suppressed canonical representation', async () => {
+  const result = await prepareCompletion({
+    github: {graphql: async () => ({
+      organization: {projectV2: {id: 'project'}},
+      repository: {pullRequest: mergedPullRequest({projectItems: [item({
+        Status: 'Draft',
+        'Worker reference': 'Suppressed duplicate lifecycle item; canonical issue #9'
+      })]})}
+    })},
+    context: context(),
+    core: coreStub()
+  });
+  assert.equal(result.shouldTransition, false);
+  assert.match(result.reason, /suppressed duplicate/);
+});
+
+test('rejects a current PR that is no longer merged or on develop', async () => {
+  const wrongState = await prepareCompletion({
+    github: {graphql: async () => ({
+      organization: {projectV2: {id: 'project'}},
+      repository: {pullRequest: {...mergedPullRequest(), state: 'CLOSED', mergedAt: null}}
+    })},
+    context: context(),
+    core: coreStub()
+  });
+  assert.equal(wrongState.shouldTransition, false);
+
+  const wrongBase = await prepareCompletion({
+    github: {graphql: async () => ({
+      organization: {projectV2: {id: 'project'}},
+      repository: {pullRequest: {...mergedPullRequest(), baseRefName: 'main'}}
+    })},
+    context: context(),
+    core: coreStub()
+  });
+  assert.equal(wrongBase.shouldTransition, false);
+});
+
+test('recognizes an idempotent already-completed command', () => {
+  const target = {
+    type: 'PullRequest',
+    number: 12,
+    pullRequest: {
+      number: 12,
+      head: 'a'.repeat(40),
+      mergeCommit: 'c'.repeat(40),
+      mergedAt: '2026-08-03T12:00:00Z'
+    },
+    item: item({
+      Status: 'Done',
+      Execution: null,
+      Executor: null,
+      'Worker reference': `Merged PR #12 head ${'a'.repeat(40)} as ${'c'.repeat(40)} at 2026-08-03T12:00:00Z`
+    })
+  };
+  assert.equal(commandFor(target).alreadyCompleted, true);
+});
+
+test('fails exact live verification on stale head or merge commit', async () => {
+  const github = {rest: {pulls: {get: async () => ({data: {
+    merged_at: '2026-08-03T12:00:00Z',
+    base: {ref: 'develop'},
+    head: {sha: 'a'.repeat(40)},
+    merge_commit_sha: 'c'.repeat(40)
+  }})}}};
+
+  await assert.rejects(
+    verifyMergedPullRequest({github, pullRequestNumber: 12, expectedHead: 'b'.repeat(40), expectedMergeCommit: 'c'.repeat(40)}),
+    /head is/
+  );
+  await assert.rejects(
+    verifyMergedPullRequest({github, pullRequestNumber: 12, expectedHead: 'a'.repeat(40), expectedMergeCommit: 'd'.repeat(40)}),
+    /merge commit is/
+  );
+});
+
+test('clears and verifies canonical assignment', async () => {
+  let updated = false;
+  const github = {rest: {issues: {
+    update: async ({assignees}) => { updated = true; assert.deepEqual(assignees, []); },
+    get: async () => ({data: {assignees: []}})
+  }}};
+  await clearAssigneesAndVerify({github, targetNumber: 9});
+  assert.equal(updated, true);
+});
+
+test('fails assignment cleanup when an assignee remains', async () => {
+  const github = {rest: {issues: {
+    update: async () => {},
+    get: async () => ({data: {assignees: [{login: 'bedrin'}]}})
+  }}};
+  await assert.rejects(clearAssigneesAndVerify({github, targetNumber: 9}), /still assigned/);
+});

--- a/.github/scripts/delivery-completion.js
+++ b/.github/scripts/delivery-completion.js
@@ -1,0 +1,233 @@
+'use strict';
+
+const REPOSITORY = 'sniffy/sniffy';
+const ORGANIZATION = 'sniffy';
+const PROJECT_NUMBER = 2;
+const BASE_BRANCH = 'develop';
+const SUPPRESSED_DUPLICATE_PATTERN = /^Suppressed duplicate lifecycle item\b/i;
+const GUARDED_FIELDS = ['Status', 'Execution', 'Executor', 'Worker reference'];
+
+function values(nodes) {
+  const result = new Map();
+  for (const value of nodes || []) {
+    if (!value.field?.name) continue;
+    if (value.__typename === 'ProjectV2ItemFieldSingleSelectValue') {
+      result.set(value.field.name, value.name ?? null);
+    }
+    if (value.__typename === 'ProjectV2ItemFieldTextValue') {
+      result.set(value.field.name, value.text ?? null);
+    }
+  }
+  return result;
+}
+
+function projectItems(content, projectId) {
+  return (content?.projectItems?.nodes || []).filter(item => item.project?.id === projectId);
+}
+
+function pullRequestReference(pullRequest) {
+  return {
+    number: pullRequest.number,
+    branch: pullRequest.headRefName,
+    head: String(pullRequest.headRefOid || '').toLowerCase(),
+    mergeCommit: String(pullRequest.mergeCommit?.oid || '').toLowerCase(),
+    mergedAt: pullRequest.mergedAt
+  };
+}
+
+function selectProjectItem(content, projectId, description) {
+  const items = projectItems(content, projectId);
+  if (items.length === 0) return {item: null, reason: `${description} is not represented in Project 2.`};
+  if (items.length > 1) return {item: null, reason: `${description} has ${items.length} Project 2 representations; completion requires explicit reconciliation.`};
+  return {item: items[0], reason: null};
+}
+
+function selectCanonicalTarget(pullRequest, projectId) {
+  const closingIssues = pullRequest.closingIssuesReferences?.nodes || [];
+  const pullRequestRef = pullRequestReference(pullRequest);
+
+  if (closingIssues.length === 1) {
+    const issue = closingIssues[0];
+    const selected = selectProjectItem(issue, projectId, `Canonical closing issue #${issue.number}`);
+    if (!selected.item) return {target: null, reason: selected.reason};
+    return {
+      target: {type: 'Issue', number: issue.number, item: selected.item, pullRequest: pullRequestRef},
+      reason: null
+    };
+  }
+
+  const selected = selectProjectItem(
+    pullRequest,
+    projectId,
+    closingIssues.length === 0
+      ? `Canonical standalone pull request #${pullRequest.number}`
+      : `Canonical multi-issue coordination pull request #${pullRequest.number}`
+  );
+  if (!selected.item) return {target: null, reason: selected.reason};
+  return {
+    target: {type: 'PullRequest', number: pullRequest.number, item: selected.item, pullRequest: pullRequestRef},
+    reason: null
+  };
+}
+
+function completionReference(target) {
+  const pullRequest = target.pullRequest;
+  return `Merged PR #${pullRequest.number} head ${pullRequest.head} as ${pullRequest.mergeCommit} at ${pullRequest.mergedAt}`;
+}
+
+function isSuppressed(item) {
+  const current = values(item.fieldValues?.nodes);
+  const workerReference = current.get('Worker reference') ?? null;
+  return current.get('Status') === 'Draft' &&
+    typeof workerReference === 'string' &&
+    SUPPRESSED_DUPLICATE_PATTERN.test(workerReference.trim());
+}
+
+function commandFor(target) {
+  const current = values(target.item.fieldValues?.nodes);
+  const expectedFields = {};
+  for (const field of GUARDED_FIELDS) expectedFields[field] = current.get(field) ?? null;
+  const expected = {type: target.type, fields: expectedFields};
+  if (target.type === 'PullRequest') expected.head = target.pullRequest.head;
+
+  const reference = completionReference(target);
+  const command = {
+    command: 'delivery-control/v1',
+    target: {repository: REPOSITORY, number: target.number},
+    expected,
+    set: {Status: 'Done', 'Worker reference': reference},
+    clear: ['Execution', 'Executor'],
+    addIfMissing: false
+  };
+  const alreadyCompleted = current.get('Status') === 'Done' &&
+    (current.get('Execution') ?? null) === null &&
+    (current.get('Executor') ?? null) === null &&
+    (current.get('Worker reference') ?? null) === reference;
+  return {alreadyCompleted, command, reference};
+}
+
+function skip(core, reason) {
+  core.setOutput('should_transition', 'false');
+  core.setOutput('reason', reason);
+  core.summary.addHeading('AI delivery completion skipped').addRaw(`${reason}\n`);
+  return {shouldTransition: false, reason};
+}
+
+async function prepareCompletion({github, context, core}) {
+  const payload = context.payload || {};
+  const eventPullRequest = payload.pull_request;
+  if (context.eventName !== 'pull_request_target' || payload.action !== 'closed') {
+    return skip(core, 'The event is not a closed pull_request_target event.');
+  }
+  if (!eventPullRequest?.merged) return skip(core, 'The pull request was closed without merging.');
+  if (eventPullRequest.base?.ref !== BASE_BRANCH) return skip(core, `The pull request does not target ${BASE_BRANCH}.`);
+
+  const [owner, name] = REPOSITORY.split('/');
+  const result = await github.graphql(`query($org: String!, $project: Int!, $owner: String!, $name: String!, $number: Int!) {
+    organization(login: $org) { projectV2(number: $project) { id } }
+    repository(owner: $owner, name: $name) { pullRequest(number: $number) {
+      id
+      number
+      state
+      mergedAt
+      mergeCommit { oid }
+      headRefOid
+      headRefName
+      baseRefName
+      projectItems(first: 50) { nodes { ...ProjectItem } }
+      closingIssuesReferences(first: 50) { nodes {
+        id
+        number
+        projectItems(first: 50) { nodes { ...ProjectItem } }
+      } }
+    } }
+  }
+  fragment ProjectItem on ProjectV2Item {
+    id
+    project { id }
+    fieldValues(first: 100) { nodes {
+      __typename
+      ... on ProjectV2ItemFieldSingleSelectValue {
+        name
+        field { ... on ProjectV2SingleSelectField { name } }
+      }
+      ... on ProjectV2ItemFieldTextValue {
+        text
+        field { ... on ProjectV2Field { name } }
+      }
+    } }
+  }`, {org: ORGANIZATION, project: PROJECT_NUMBER, owner, name, number: eventPullRequest.number});
+
+  const project = result.organization?.projectV2;
+  const pullRequest = result.repository?.pullRequest;
+  if (!project || !pullRequest) throw new Error('Project 2 or the merged pull request was not found.');
+  if (pullRequest.state !== 'MERGED' || !pullRequest.mergedAt || !pullRequest.mergeCommit?.oid) {
+    return skip(core, 'The current pull request is not verified as merged.');
+  }
+  if (pullRequest.baseRefName !== BASE_BRANCH) return skip(core, `The current pull request no longer targets ${BASE_BRANCH}.`);
+
+  const selection = selectCanonicalTarget(pullRequest, project.id);
+  if (!selection.target) return skip(core, selection.reason);
+  if (isSuppressed(selection.target.item)) {
+    return skip(core, 'The selected Project item is an explicitly suppressed duplicate; completion must reconcile its canonical replacement instead.');
+  }
+
+  const target = selection.target;
+  const prepared = commandFor(target);
+  core.setOutput('should_transition', 'true');
+  core.setOutput('payload_base64', Buffer.from(JSON.stringify(prepared.command)).toString('base64'));
+  core.setOutput('target_repository', REPOSITORY.replace('/', '-'));
+  core.setOutput('target_number', String(target.number));
+  core.setOutput('target_type', target.type);
+  core.setOutput('pull_request_number', String(target.pullRequest.number));
+  core.setOutput('pull_request_head', target.pullRequest.head);
+  core.setOutput('merge_commit', target.pullRequest.mergeCommit);
+  core.summary.addHeading('AI delivery completion prepared')
+    .addRaw(`Target: \`${target.type} ${REPOSITORY}#${target.number}\`\n\n`)
+    .addRaw(`Merged pull request: \`#${target.pullRequest.number}\` at \`${target.pullRequest.head}\`\n\n`)
+    .addCodeBlock(JSON.stringify(prepared.command, null, 2), 'json');
+  if (prepared.alreadyCompleted) {
+    core.summary.addRaw('Project completion is already recorded; assignee cleanup will still be verified.\n');
+  }
+  return {shouldTransition: true, target, ...prepared};
+}
+
+async function verifyMergedPullRequest({github, pullRequestNumber, expectedHead, expectedMergeCommit}) {
+  const [owner, repo] = REPOSITORY.split('/');
+  const response = await github.rest.pulls.get({owner, repo, pull_number: Number(pullRequestNumber)});
+  const pullRequest = response.data || {};
+  const actualHead = String(pullRequest.head?.sha || '').toLowerCase();
+  const actualMergeCommit = String(pullRequest.merge_commit_sha || '').toLowerCase();
+  if (!pullRequest.merged_at) throw new Error(`Pull request #${pullRequestNumber} is not merged.`);
+  if (pullRequest.base?.ref !== BASE_BRANCH) throw new Error(`Pull request #${pullRequestNumber} does not target ${BASE_BRANCH}.`);
+  if (actualHead !== String(expectedHead || '').toLowerCase()) {
+    throw new Error(`Pull request #${pullRequestNumber} head is ${actualHead || '(missing)'}, not ${expectedHead || '(missing)'}.`);
+  }
+  if (actualMergeCommit !== String(expectedMergeCommit || '').toLowerCase()) {
+    throw new Error(`Pull request #${pullRequestNumber} merge commit is ${actualMergeCommit || '(missing)'}, not ${expectedMergeCommit || '(missing)'}.`);
+  }
+  return {head: actualHead, mergeCommit: actualMergeCommit, mergedAt: pullRequest.merged_at};
+}
+
+async function clearAssigneesAndVerify({github, targetNumber}) {
+  const [owner, repo] = REPOSITORY.split('/');
+  const issueNumber = Number(targetNumber);
+  await github.rest.issues.update({owner, repo, issue_number: issueNumber, assignees: []});
+  const response = await github.rest.issues.get({owner, repo, issue_number: issueNumber});
+  const remaining = (response.data?.assignees || []).map(assignee => assignee.login);
+  if (remaining.length > 0) {
+    throw new Error(`Failed to clear assignees from #${issueNumber}; still assigned: ${remaining.join(', ')}.`);
+  }
+}
+
+module.exports = {
+  clearAssigneesAndVerify,
+  commandFor,
+  completionReference,
+  isSuppressed,
+  prepareCompletion,
+  projectItems,
+  selectCanonicalTarget,
+  values,
+  verifyMergedPullRequest
+};

--- a/.github/scripts/delivery-completion.test.js
+++ b/.github/scripts/delivery-completion.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  commandFor,
+  isSuppressed,
+  prepareCompletion,
+  selectCanonicalTarget,
+  verifyMergedPullRequest
+} = require('./delivery-completion');
+
+function fieldValues(fields = {}) {
+  return Object.entries(fields).map(([name, value]) => ({
+    __typename: ['Status', 'Execution', 'Executor'].includes(name)
+      ? 'ProjectV2ItemFieldSingleSelectValue'
+      : 'ProjectV2ItemFieldTextValue',
+    ...(['Status', 'Execution', 'Executor'].includes(name) ? {name: value} : {text: value}),
+    field: {name}
+  }));
+}
+
+function item(fields = {}, project = 'project') {
+  return {
+    project: {id: project},
+    fieldValues: {nodes: fieldValues({
+      Status: 'Approval', Execution: 'Ready', Executor: 'Human', 'Worker reference': null, ...fields
+    })}
+  };
+}
+
+function issue(number, items = [item()]) {
+  return {number, projectItems: {nodes: items}};
+}
+
+function pr({closing = [], items = [item()]} = {}) {
+  return {
+    number: 12,
+    state: 'MERGED',
+    mergedAt: '2026-08-03T12:00:00Z',
+    mergeCommit: {oid: 'c'.repeat(40)},
+    headRefOid: 'a'.repeat(40),
+    headRefName: 'agent/example',
+    baseRefName: 'develop',
+    projectItems: {nodes: items},
+    closingIssuesReferences: {nodes: closing}
+  };
+}
+
+function core() {
+  const outputs = new Map();
+  const summary = {addHeading() { return this; }, addRaw() { return this; }, addCodeBlock() { return this; }};
+  return {outputs, summary, setOutput(name, value) { outputs.set(name, value); }};
+}
+
+test('resolves issue, standalone PR, and multi-issue PR canonical targets', () => {
+  assert.equal(selectCanonicalTarget(pr({closing: [issue(9)]}), 'project').target.type, 'Issue');
+  assert.equal(selectCanonicalTarget(pr(), 'project').target.type, 'PullRequest');
+  assert.equal(selectCanonicalTarget(pr({closing: [issue(8), issue(9)]}), 'project').target.type, 'PullRequest');
+});
+
+test('fails closed for missing or duplicate canonical Project items', () => {
+  assert.match(selectCanonicalTarget(pr({closing: [issue(9, [])]}), 'project').reason, /not represented/);
+  assert.match(selectCanonicalTarget(pr({closing: [issue(9, [item(), item()])]}), 'project').reason, /2 Project 2/);
+});
+
+test('builds guarded Done transition with compact merge evidence', () => {
+  const target = selectCanonicalTarget(pr({closing: [issue(9)]}), 'project').target;
+  const prepared = commandFor(target);
+  assert.equal(prepared.command.set.Status, 'Done');
+  assert.deepEqual(prepared.command.clear, ['Execution', 'Executor']);
+  assert.equal(prepared.command.expected.fields.Status, 'Approval');
+  assert.match(prepared.reference, /^Merged PR #12 head a{40} as c{40}/);
+});
+
+test('recognizes explicit suppressed duplicate marker', () => {
+  assert.equal(isSuppressed(item({
+    Status: 'Draft',
+    'Worker reference': 'Suppressed duplicate lifecycle item; canonical replacement issue #9'
+  })), true);
+});
+
+test('prepares only a trusted merged completion event', async () => {
+  const output = core();
+  const result = await prepareCompletion({
+    github: {graphql: async () => ({
+      organization: {projectV2: {id: 'project'}},
+      repository: {pullRequest: pr({closing: [issue(9)]})}
+    })},
+    context: {
+      eventName: 'pull_request_target',
+      payload: {action: 'closed', pull_request: {number: 12, merged: true, base: {ref: 'develop'}}}
+    },
+    core: output
+  });
+  assert.equal(result.shouldTransition, true);
+  assert.equal(output.outputs.get('target_number'), '9');
+  assert.ok(output.outputs.get('payload_base64'));
+
+  const skipped = await prepareCompletion({
+    github: {},
+    context: {eventName: 'pull_request_target', payload: {action: 'closed', pull_request: {merged: false}}},
+    core: core()
+  });
+  assert.equal(skipped.shouldTransition, false);
+});
+
+test('verifies exact merged head and merge commit', async () => {
+  const result = await verifyMergedPullRequest({
+    github: {rest: {pulls: {get: async () => ({data: {
+      merged_at: '2026-08-03T12:00:00Z',
+      base: {ref: 'develop'},
+      head: {sha: 'a'.repeat(40)},
+      merge_commit_sha: 'c'.repeat(40)
+    }})}}},
+    pullRequestNumber: 12,
+    expectedHead: 'a'.repeat(40),
+    expectedMergeCommit: 'c'.repeat(40)
+  });
+  assert.equal(result.mergeCommit, 'c'.repeat(40));
+});

--- a/.github/scripts/delivery-dispatch-view.js
+++ b/.github/scripts/delivery-dispatch-view.js
@@ -247,7 +247,9 @@ function mergedPullRequestSummary(raw) {
 
 function completionDriftCandidate(item, rawPullRequestsByNumber, baseBranch) {
   const awaitingMerge = item.status === 'Approval' && item.execution === 'Ready' && item.executor === 'Human';
-  if (!awaitingMerge || isSuppressedDuplicateItem(item)) return null;
+  const terminalRoutingDrift = item.status === 'Done' &&
+    (item.execution !== null || item.executor !== null || item.assignees.length > 0);
+  if ((!awaitingMerge && !terminalRoutingDrift) || isSuppressedDuplicateItem(item)) return null;
 
   if (item.type === 'PullRequest') {
     const pullRequest = mergedPullRequestSummary(rawPullRequestsByNumber.get(Number(item.number)));

--- a/.github/scripts/delivery-dispatch-view.js
+++ b/.github/scripts/delivery-dispatch-view.js
@@ -7,6 +7,7 @@ const PRIORITY_RANK = new Map([['Urgent', 0], ['High', 1], ['Medium', 2], ['Low'
 const SHA_PATTERN = /\b[0-9a-f]{40}\b/gi;
 const LEASE_UNTIL_PATTERN = /\b"?leaseUntil"?\s*[=:]\s*"?([^"\s;,}]+)/i;
 const SUPPRESSED_DUPLICATE_PATTERN = /^Suppressed duplicate lifecycle item\b/i;
+const TECHNICAL_LABELS = new Set(['ai-delivery-control', 'ai-delivery-status']);
 
 function asArray(value) {
   return Array.isArray(value) ? value : [];
@@ -84,10 +85,15 @@ function compactItem(item, rawById) {
     title: item.content?.title ?? null,
     url: item.content?.url ?? null,
     state: item.content?.state ?? null,
+    stateReason: item.content?.stateReason ?? null,
     isDraft: item.content?.isDraft ?? false,
+    mergedAt: item.content?.mergedAt ?? null,
+    closedAt: item.content?.closedAt ?? null,
     baseRefName: item.content?.baseRefName ?? null,
     headRefName: item.content?.headRefName ?? null,
     headRefOid: item.content?.headRefOid ?? null,
+    labels: asArray(item.content?.labels),
+    linkedPullRequests: asArray(field(item, 'Linked pull requests')),
     status: field(item, 'Status'),
     execution: field(item, 'Execution'),
     executor: field(item, 'Executor'),
@@ -222,6 +228,82 @@ function staleOwnershipReason(item, generatedAt) {
   return leaseUntil <= generatedAt ? 'lease-expired' : null;
 }
 
+function pullRequestNumberFromUrl(url) {
+  const match = String(url ?? '').match(/\/pull\/(\d+)(?:$|[/?#])/);
+  return match ? Number(match[1]) : null;
+}
+
+function mergedPullRequestSummary(raw) {
+  if (!raw?.mergedAt) return null;
+  return {
+    number: Number(raw.number),
+    url: raw.url ?? null,
+    baseRefName: raw.baseRefName ?? null,
+    headRefName: raw.headRefName ?? null,
+    headRefOid: raw.headRefOid ?? null,
+    mergedAt: raw.mergedAt
+  };
+}
+
+function completionDriftCandidate(item, rawPullRequestsByNumber, baseBranch) {
+  const awaitingMerge = item.status === 'Approval' && item.execution === 'Ready' && item.executor === 'Human';
+  if (!awaitingMerge || isSuppressedDuplicateItem(item)) return null;
+
+  if (item.type === 'PullRequest') {
+    const pullRequest = mergedPullRequestSummary(rawPullRequestsByNumber.get(Number(item.number)));
+    if (!pullRequest || pullRequest.baseRefName !== baseBranch) return null;
+    return {kind: 'completion-drift', canonical: {type: 'PullRequest', number: item.number}, item, pullRequest};
+  }
+
+  if (item.type !== 'Issue' || item.state !== 'CLOSED' || item.stateReason !== 'COMPLETED') return null;
+  const linkedNumbers = [...new Set(item.linkedPullRequests.map(pullRequestNumberFromUrl).filter(Number.isInteger))];
+  if (linkedNumbers.length !== 1) return null;
+  const pullRequest = mergedPullRequestSummary(rawPullRequestsByNumber.get(linkedNumbers[0]));
+  if (!pullRequest || pullRequest.baseRefName !== baseBranch) return null;
+  return {kind: 'completion-drift', canonical: {type: 'Issue', number: item.number}, item, pullRequest};
+}
+
+function executorByAssignee(executorAssignees) {
+  return new Map(Object.entries(executorAssignees).map(([executor, assignee]) => [assignee, executor]));
+}
+
+function routeSuggestion(item, executorAssignees, defaultExecutor = 'ChatGPT') {
+  if (item.executor) return {executor: item.executor, reason: 'existing-executor'};
+  if (item.assignees.length === 0) return {executor: defaultExecutor, reason: 'default-unassigned'};
+  if (item.assignees.length !== 1) return {executor: null, reason: 'multiple-assignees'};
+  const executor = executorByAssignee(executorAssignees).get(item.assignees[0]) ?? null;
+  return executor
+    ? {executor, reason: 'assignee-route'}
+    : {executor: null, reason: 'unknown-assignee'};
+}
+
+function isTechnicalItem(item) {
+  return item.labels.some(label => TECHNICAL_LABELS.has(label));
+}
+
+function routingReconciliationCandidates(compactItems, executorAssignees) {
+  const candidates = [];
+  for (const item of compactItems) {
+    if (item.type !== 'Issue' || item.state !== 'OPEN' || isTechnicalItem(item)) continue;
+
+    if (item.status === null) {
+      const suggestion = routeSuggestion(item, executorAssignees);
+      candidates.push(suggestion.executor
+        ? {kind: 'uninitialized-item', item, suggestedStatus: 'Planning', suggestedExecution: 'Ready', suggestedExecutor: suggestion.executor, routeReason: suggestion.reason}
+        : {kind: 'route-ambiguity', item, routeReason: suggestion.reason});
+      continue;
+    }
+
+    if (item.status === 'Planning' && item.execution === 'Ready' && item.executor === null) {
+      const suggestion = routeSuggestion(item, executorAssignees);
+      candidates.push(suggestion.executor
+        ? {kind: 'default-planning-route', item, suggestedExecutor: suggestion.executor, routeReason: suggestion.reason}
+        : {kind: 'route-ambiguity', item, routeReason: suggestion.reason});
+    }
+  }
+  return candidates.sort((left, right) => compareCandidates(left.item, right.item));
+}
+
 function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
   const baseBranch = options.baseBranch ?? 'develop';
   const executorAssignees = options.executorAssignees || {};
@@ -246,8 +328,15 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
 
   const routeMismatches = ready.filter(item => {
     const expected = executorAssignees[item.executor];
-    return expected && item.assignees.length > 0 && !item.assignees.includes(expected);
+    return expected && item.assignees.length > 0 &&
+      (item.assignees.length !== 1 || item.assignees[0] !== expected);
   }).sort(compareCandidates);
+
+  const completionDrift = compactItems
+    .map(item => completionDriftCandidate(item, rawPullRequestsByNumber, baseBranch))
+    .filter(Boolean)
+    .sort((left, right) => compareCandidates(left.item, right.item));
+  const routingReconciliations = routingReconciliationCandidates(compactItems, executorAssignees);
 
   const pullRequests = asArray(snapshot.pullRequests)
     .filter(value => value.baseRefName === baseBranch)
@@ -263,7 +352,9 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
     ...conflicting.map(value => ({kind: 'conflicting-pr', canonical: value.canonical, pullRequest: value})),
     ...managedConflicts.map(value => ({kind: 'managed-pr-conflict', canonical: value.canonical, pullRequest: value})),
     ...intake.map(value => ({kind: 'pr-intake', canonical: value.canonical, pullRequest: value})),
+    ...completionDrift,
     ...staleExactHead,
+    ...routingReconciliations,
     ...routeMismatches.map(value => ({kind: 'route-mismatch', item: value})),
     ...staleInProgress
       .filter(value => value.executor === 'ChatGPT' || value.executor === 'Codex Cloud')
@@ -286,6 +377,8 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
     inProgressByExecutor: groupByExecutor(inProgress),
     activeInProgressByExecutor: groupByExecutor(activeInProgress),
     staleInProgressByExecutor: groupByExecutor(staleInProgress),
+    completionDrift,
+    routingReconciliations,
     routeMismatches,
     pullRequests: {conflicting, managedConflicts, intake, drafts},
     staleExactHead,
@@ -295,6 +388,8 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
       inProgress: inProgress.length,
       activeInProgress: activeInProgress.length,
       staleInProgress: staleInProgress.length,
+      completionDrift: completionDrift.length,
+      routingReconciliations: routingReconciliations.length,
       routeMismatches: routeMismatches.length,
       conflictingPullRequests: conflicting.length,
       managedConflictPullRequests: managedConflicts.length,
@@ -350,7 +445,11 @@ module.exports = {
   buildDispatch,
   canonicalIdentity,
   compareCandidates,
+  completionDriftCandidate,
   exactHeads,
   leaseUntilFrom,
+  pullRequestNumberFromUrl,
+  routeSuggestion,
+  routingReconciliationCandidates,
   staleOwnershipReason
 };

--- a/.github/scripts/delivery-dispatch-view.js
+++ b/.github/scripts/delivery-dispatch-view.js
@@ -283,10 +283,11 @@ function isTechnicalItem(item) {
   return item.labels.some(label => TECHNICAL_LABELS.has(label));
 }
 
-function routingReconciliationCandidates(compactItems, executorAssignees) {
+function routingReconciliationCandidates(compactItems, executorAssignees, excludedIdentities = new Set()) {
   const candidates = [];
   for (const item of compactItems) {
-    if (item.type !== 'Issue' || item.state !== 'OPEN' || isTechnicalItem(item)) continue;
+    if (item.type !== 'Issue' || item.state !== 'OPEN' || isTechnicalItem(item) ||
+        excludedIdentities.has(projectIdentity(item))) continue;
 
     if (item.status === null) {
       const suggestion = routeSuggestion(item, executorAssignees);
@@ -338,11 +339,18 @@ function buildDispatch(snapshot, rawItems, rawPullRequests, options = {}) {
     .map(item => completionDriftCandidate(item, rawPullRequestsByNumber, baseBranch))
     .filter(Boolean)
     .sort((left, right) => compareCandidates(left.item, right.item));
-  const routingReconciliations = routingReconciliationCandidates(compactItems, executorAssignees);
 
   const pullRequests = asArray(snapshot.pullRequests)
     .filter(value => value.baseRefName === baseBranch)
     .map(value => pullRequestProjection(value, rawPullRequestsByNumber, itemsByIdentity, baseBranch));
+  const prAttentionCanonicals = new Set(pullRequests
+    .filter(value => value.needsIntake || value.conflictMode !== null)
+    .map(value => itemKey(value.canonical.type, value.canonical.number)));
+  const routingReconciliations = routingReconciliationCandidates(
+    compactItems,
+    executorAssignees,
+    prAttentionCanonicals
+  );
   const conflicting = pullRequests.filter(value => value.conflictMode === 'same-repository-continuation');
   const managedConflicts = pullRequests.filter(value =>
     value.conflictMode !== null && value.conflictMode !== 'same-repository-continuation');

--- a/.github/scripts/delivery-dispatch-view.test.js
+++ b/.github/scripts/delivery-dispatch-view.test.js
@@ -7,10 +7,12 @@ const {
   canonicalIdentity,
   exactHeads,
   leaseUntilFrom,
+  pullRequestNumberFromUrl,
+  routeSuggestion,
   staleOwnershipReason
 } = require('./delivery-dispatch-view');
 
-function projectItem(number, fields = {}, type = 'Issue') {
+function projectItem(number, fields = {}, type = 'Issue', content = {}) {
   return {
     projectItemId: `${type}-${number}`,
     content: {
@@ -18,7 +20,14 @@ function projectItem(number, fields = {}, type = 'Issue') {
       number,
       repository: 'sniffy/sniffy',
       title: `${type} ${number}`,
-      url: `https://github.com/sniffy/sniffy/${type === 'Issue' ? 'issues' : 'pull'}/${number}`
+      url: `https://github.com/sniffy/sniffy/${type === 'Issue' ? 'issues' : 'pull'}/${number}`,
+      state: 'OPEN',
+      stateReason: '',
+      isDraft: false,
+      mergedAt: null,
+      closedAt: null,
+      labels: [],
+      ...content
     },
     fields: {
       Status: null,
@@ -28,6 +37,7 @@ function projectItem(number, fields = {}, type = 'Issue') {
       Verifier: null,
       Priority: null,
       'Ready timestamp': null,
+      'Linked pull requests': null,
       'Worker reference': null,
       ...fields
     }
@@ -47,6 +57,19 @@ function pullRequest(number, closingIssueNumbers = [], overrides = {}) {
     mergeable: 'MERGEABLE',
     mergeStateStatus: 'CLEAN',
     closingIssueNumbers,
+    ...overrides
+  };
+}
+
+function rawPullRequest(number, overrides = {}) {
+  return {
+    number,
+    url: `https://github.com/sniffy/sniffy/pull/${number}`,
+    baseRefName: 'develop',
+    headRefName: `agent/pr-${number}`,
+    headRefOid: String(number).padStart(40, 'b').slice(-40),
+    mergedAt: null,
+    labels: [],
     ...overrides
   };
 }
@@ -101,6 +124,17 @@ test('groups active and stale in-progress work and detects route mismatch', () =
   assert.deepEqual(result.routeMismatches.map(item => item.number), [2]);
   assert.equal(result.orderedCandidates[0].kind, 'route-mismatch');
   assert.equal(result.orderedCandidates[1].kind, 'stale-owned-recovery');
+});
+
+test('treats multiple assignees as a route mismatch even when one is correct', () => {
+  const ready = projectItem(2, {Status: 'Review', Execution: 'Ready', Executor: 'ChatGPT'});
+  const result = buildDispatch(
+    snapshot([ready]),
+    {items: [rawItem(ready, ['bedrin-gpt', 'bedrin'])]},
+    [],
+    {executorAssignees: {ChatGPT: 'bedrin-gpt', Human: 'bedrin'}}
+  );
+  assert.deepEqual(result.routeMismatches.map(item => item.number), [2]);
 });
 
 test('ignores normal in-progress ownership until its lease expires', () => {
@@ -297,4 +331,74 @@ test('sorts ready work by priority and ready timestamp', () => {
     {}
   );
   assert.deepEqual(result.readyByExecutor.ChatGPT.map(item => item.number), [2, 3, 1]);
+});
+
+test('projects merged completion drift for a canonical issue and standalone PR', () => {
+  const issue = projectItem(755, {
+    Status: 'Approval', Execution: 'Ready', Executor: 'Human',
+    'Linked pull requests': ['https://github.com/sniffy/sniffy/pull/764']
+  }, 'Issue', {state: 'CLOSED', stateReason: 'COMPLETED', closedAt: '2026-07-30T19:09:52Z'});
+  const standalone = projectItem(900, {
+    Status: 'Approval', Execution: 'Ready', Executor: 'Human'
+  }, 'PullRequest', {state: 'CLOSED'});
+  const result = buildDispatch(
+    snapshot([issue, standalone]),
+    {items: [rawItem(issue, ['bedrin']), rawItem(standalone, ['bedrin'])]},
+    [
+      rawPullRequest(764, {mergedAt: '2026-07-30T19:09:51Z'}),
+      rawPullRequest(900, {mergedAt: '2026-08-03T10:00:00Z'})
+    ],
+    {executorAssignees: {Human: 'bedrin'}}
+  );
+  assert.deepEqual(result.completionDrift.map(value => value.canonical), [
+    {type: 'Issue', number: 755},
+    {type: 'PullRequest', number: 900}
+  ]);
+  assert.deepEqual(result.orderedCandidates.map(value => value.kind), ['completion-drift', 'completion-drift']);
+});
+
+test('does not complete a closed unmerged or explicitly suppressed pull request', () => {
+  const closed = projectItem(757, {Status: 'Draft'}, 'PullRequest', {state: 'CLOSED'});
+  const suppressed = projectItem(761, {
+    Status: 'Draft',
+    'Worker reference': 'Suppressed duplicate lifecycle item; canonical replacement issue #772'
+  }, 'PullRequest', {state: 'CLOSED'});
+  const result = buildDispatch(
+    snapshot([closed, suppressed]),
+    {items: [rawItem(closed), rawItem(suppressed)]},
+    [rawPullRequest(757), rawPullRequest(761, {mergedAt: '2026-08-03T10:00:00Z'})],
+    {}
+  );
+  assert.equal(result.completionDrift.length, 0);
+  assert.equal(result.orderedCandidates.length, 0);
+});
+
+test('routes uninitialized and unassigned Planning issues without whole-Project live reads', () => {
+  const planning = projectItem(727, {Status: 'Planning', Execution: 'Ready'});
+  const uninitialized = projectItem(803);
+  const result = buildDispatch(
+    snapshot([planning, uninitialized]),
+    {items: [rawItem(planning), rawItem(uninitialized, ['bedrin-gpt'])]},
+    [],
+    {executorAssignees: {ChatGPT: 'bedrin-gpt', Human: 'bedrin'}}
+  );
+  assert.deepEqual(result.routingReconciliations.map(value => ({kind: value.kind, number: value.item.number, executor: value.suggestedExecutor})), [
+    {kind: 'default-planning-route', number: 727, executor: 'ChatGPT'},
+    {kind: 'uninitialized-item', number: 803, executor: 'ChatGPT'}
+  ]);
+  assert.deepEqual(result.orderedCandidates.map(value => value.kind), ['default-planning-route', 'uninitialized-item']);
+});
+
+test('does not guess a route from unknown or conflicting assignees', () => {
+  const unknown = projectItem(803);
+  const multiple = projectItem(804);
+  const result = buildDispatch(
+    snapshot([unknown, multiple]),
+    {items: [rawItem(unknown, ['someone']), rawItem(multiple, ['bedrin-gpt', 'bedrin'])]},
+    [],
+    {executorAssignees: {ChatGPT: 'bedrin-gpt', Human: 'bedrin'}}
+  );
+  assert.deepEqual(result.routingReconciliations.map(value => value.kind), ['route-ambiguity', 'route-ambiguity']);
+  assert.equal(routeSuggestion({executor: null, assignees: []}, {ChatGPT: 'bedrin-gpt'}).executor, 'ChatGPT');
+  assert.equal(pullRequestNumberFromUrl('https://github.com/sniffy/sniffy/pull/764'), 764);
 });

--- a/.github/scripts/delivery-dispatch-view.test.js
+++ b/.github/scripts/delivery-dispatch-view.test.js
@@ -406,6 +406,19 @@ test('routes uninitialized and unassigned Planning issues without whole-Project 
   assert.deepEqual(result.orderedCandidates.map(value => value.kind), ['default-planning-route', 'uninitialized-item']);
 });
 
+test('does not duplicate an uninitialized canonical issue already selected for PR intake', () => {
+  const issue = projectItem(806, {'Linked pull requests': ['https://github.com/sniffy/sniffy/pull/807']});
+  const pr = pullRequest(807, [806]);
+  const result = buildDispatch(
+    snapshot([issue], [pr]),
+    {items: [rawItem(issue, ['bedrin-gpt'])]},
+    [rawPullRequest(807)],
+    {executorAssignees: {ChatGPT: 'bedrin-gpt'}}
+  );
+  assert.deepEqual(result.orderedCandidates.map(value => value.kind), ['pr-intake']);
+  assert.equal(result.routingReconciliations.length, 0);
+});
+
 test('does not guess a route from unknown or conflicting assignees', () => {
   const unknown = projectItem(803);
   const multiple = projectItem(804);

--- a/.github/scripts/delivery-dispatch-view.test.js
+++ b/.github/scripts/delivery-dispatch-view.test.js
@@ -357,6 +357,23 @@ test('projects merged completion drift for a canonical issue and standalone PR',
   assert.deepEqual(result.orderedCandidates.map(value => value.kind), ['completion-drift', 'completion-drift']);
 });
 
+test('repairs Done items only when active routing or assignment still lingers', () => {
+  const clean = projectItem(754, {Status: 'Done'}, 'PullRequest', {state: 'CLOSED'});
+  const routed = projectItem(755, {Status: 'Done', Execution: 'Ready', Executor: 'Human'}, 'PullRequest', {state: 'CLOSED'});
+  const assigned = projectItem(756, {Status: 'Done'}, 'PullRequest', {state: 'CLOSED'});
+  const result = buildDispatch(
+    snapshot([clean, routed, assigned]),
+    {items: [rawItem(clean), rawItem(routed), rawItem(assigned, ['bedrin'])]},
+    [
+      rawPullRequest(754, {mergedAt: '2026-08-03T10:00:00Z'}),
+      rawPullRequest(755, {mergedAt: '2026-08-03T10:00:00Z'}),
+      rawPullRequest(756, {mergedAt: '2026-08-03T10:00:00Z'})
+    ],
+    {}
+  );
+  assert.deepEqual(result.completionDrift.map(value => value.item.number), [755, 756]);
+});
+
 test('does not complete a closed unmerged or explicitly suppressed pull request', () => {
   const closed = projectItem(757, {Status: 'Draft'}, 'PullRequest', {state: 'CLOSED'});
   const suppressed = projectItem(761, {

--- a/.github/workflows/delivery-completion.yml
+++ b/.github/workflows/delivery-completion.yml
@@ -1,0 +1,141 @@
+name: Complete merged AI delivery work
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/delivery-completion.js
+      - .github/scripts/delivery-completion.test.js
+      - .github/workflows/delivery-completion.yml
+      - docs/ai-delivery/completion.md
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.18.0
+      - name: Check and test delivery completion
+        run: |
+          node --check .github/scripts/delivery-completion.js
+          node --check .github/scripts/delivery-completion.test.js
+          node --test .github/scripts/delivery-completion.test.js
+      - name: Parse workflow YAML
+        run: ruby -e 'require "yaml"; YAML.load_file(".github/workflows/delivery-completion.yml")'
+      - name: Lint GitHub Actions workflow
+        run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/delivery-completion.yml
+
+  prepare:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'develop'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      should_transition: ${{ steps.prepare.outputs.should_transition }}
+      payload_base64: ${{ steps.prepare.outputs.payload_base64 }}
+      target_repository: ${{ steps.prepare.outputs.target_repository }}
+      target_number: ${{ steps.prepare.outputs.target_number }}
+      target_type: ${{ steps.prepare.outputs.target_type }}
+      pull_request_number: ${{ steps.prepare.outputs.pull_request_number }}
+      pull_request_head: ${{ steps.prepare.outputs.pull_request_head }}
+      merge_commit: ${{ steps.prepare.outputs.merge_commit }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Prepare guarded completion transition
+        id: prepare
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const completion = require('./.github/scripts/delivery-completion.js');
+            await completion.prepareCompletion({github, context, core});
+            await core.summary.write();
+
+  transition:
+    needs: prepare
+    if: needs.prepare.outputs.should_transition == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: ai-delivery-${{ needs.prepare.outputs.target_repository }}-${{ needs.prepare.outputs.target_number }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Apply guarded Done transition
+        id: transition
+        uses: actions/github-script@v9
+        env:
+          PAYLOAD_BASE64: ${{ needs.prepare.outputs.payload_base64 }}
+          PULL_REQUEST_NUMBER: ${{ needs.prepare.outputs.pull_request_number }}
+          PULL_REQUEST_HEAD: ${{ needs.prepare.outputs.pull_request_head }}
+          MERGE_COMMIT: ${{ needs.prepare.outputs.merge_commit }}
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const control = require('./.github/scripts/delivery-control.js');
+            const completion = require('./.github/scripts/delivery-completion.js');
+            await completion.verifyMergedPullRequest({
+              github,
+              pullRequestNumber: process.env.PULL_REQUEST_NUMBER,
+              expectedHead: process.env.PULL_REQUEST_HEAD,
+              expectedMergeCommit: process.env.MERGE_COMMIT
+            });
+            await control.executeTransition({
+              github,
+              core,
+              payloadBase64: process.env.PAYLOAD_BASE64
+            });
+            await completion.verifyMergedPullRequest({
+              github,
+              pullRequestNumber: process.env.PULL_REQUEST_NUMBER,
+              expectedHead: process.env.PULL_REQUEST_HEAD,
+              expectedMergeCommit: process.env.MERGE_COMMIT
+            });
+      - name: Fail conflicting completion
+        if: steps.transition.outputs.outcome == 'conflict'
+        run: |
+          echo 'The guarded completion transition conflicted with current Project state.' >&2
+          exit 1
+      - name: Clear completed assignment
+        if: steps.transition.outputs.outcome == 'success'
+        uses: actions/github-script@v9
+        env:
+          TARGET_NUMBER: ${{ needs.prepare.outputs.target_number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const completion = require('./.github/scripts/delivery-completion.js');
+            await completion.clearAssigneesAndVerify({
+              github,
+              targetNumber: process.env.TARGET_NUMBER
+            });
+            core.summary.addRaw('Cleared and verified GitHub assignees for the completed canonical item.\n');
+            await core.summary.write();

--- a/.github/workflows/delivery-completion.yml
+++ b/.github/workflows/delivery-completion.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/scripts/delivery-completion.js
       - .github/scripts/delivery-completion.test.js
+      - .github/scripts/delivery-completion.edge.test.js
       - .github/workflows/delivery-completion.yml
       - docs/ai-delivery/completion.md
   pull_request_target:
@@ -29,7 +30,10 @@ jobs:
         run: |
           node --check .github/scripts/delivery-completion.js
           node --check .github/scripts/delivery-completion.test.js
-          node --test .github/scripts/delivery-completion.test.js
+          node --check .github/scripts/delivery-completion.edge.test.js
+          node --test \
+            .github/scripts/delivery-completion.test.js \
+            .github/scripts/delivery-completion.edge.test.js
       - name: Parse workflow YAML
         run: ruby -e 'require "yaml"; YAML.load_file(".github/workflows/delivery-completion.yml")'
       - name: Lint GitHub Actions workflow

--- a/docs/ai-delivery/completion.md
+++ b/docs/ai-delivery/completion.md
@@ -1,0 +1,111 @@
+# Merge completion and routing reconciliation
+
+Merge completion is an objective source event. It should normally be processed by GitHub Actions without spending a ChatGPT
+heartbeat on interpretation. The generated dispatcher projection remains a narrow repair path for missed events and missing
+routes.
+
+## Canonical completion
+
+For a merged pull request targeting `develop`:
+
+- exactly one formal closing issue -> that issue is canonical;
+- no formal closing issue -> the pull request is canonical;
+- multiple formal closing issues -> the pull request is the canonical coordination item; linked issue propagation remains the
+  explicit Planning decision recorded before Review.
+
+The completion adapter requires exactly one Project 2 representation for the canonical content. Missing or duplicate
+representations fail closed. An item explicitly marked as a suppressed duplicate is never completed independently.
+
+A verified merge applies one guarded `delivery-control/v1` transition:
+
+```text
+Status: Done
+Execution: clear
+Executor: clear
+Worker reference: compact merged PR/head/merge-commit/time evidence
+Assignee: clear and verify separately
+```
+
+`Implementer`, `Verifier`, model, and reasoning fields remain historical metadata. The adapter verifies the current base, merged
+state, exact PR head, and merge commit before and after the Project transition. Repeated delivery of the same event is idempotent.
+
+## Trusted-base workflow
+
+`.github/workflows/delivery-completion.yml` uses `pull_request_target.closed` so a merged fork PR can update organization Project
+state. This is safe only under these enforced boundaries:
+
+- checkout is pinned to trusted `develop`;
+- no PR-head file, action, script, build, or command is executed;
+- top-level `permissions: {}` remains empty;
+- the prepare job receives only `contents: read` and uses the existing Project token for Project/live metadata;
+- the transition job receives `contents: read` and `issues: write`; repository `GITHUB_TOKEN` is used only to clear assignees;
+- concurrency is serialized by canonical Project target;
+- no branch write, merge, auto-merge, deployment, environment, repository-setting, or secret mutation is possible.
+
+The workflow creates no target comments or control-log commands. Its Actions summary is the operational audit record.
+
+## Dispatcher repair candidates
+
+The status projection computes these candidates from the existing normalized snapshot and raw exports. It performs no new GitHub
+calls and adds no recurring polling pass.
+
+### `completion-drift`
+
+A narrow backstop for the normal pre-merge state only:
+
+```text
+Status = Approval
+Execution = Ready
+Executor = Human
+source PR is already merged
+```
+
+For an issue, exactly one linked PR must be present and merged. For a PR item, the item itself must be merged. Historical items in
+Implementation, Draft, or an uninitialized state are deliberately excluded so the hourly ChatGPT loop does not spend many ticks
+cleaning old Project archaeology.
+
+### `uninitialized-item`
+
+An open non-technical issue with no Status receives a deterministic suggested initialization:
+
+```text
+Status = Planning
+Execution = Ready
+Executor = unique known assignee route, otherwise ChatGPT
+```
+
+The dispatcher still live-reads only this selected issue and applies one guarded command. Technical control/status issues are
+excluded.
+
+### `default-planning-route`
+
+An open issue in `Planning / Ready` with no Executor uses a unique configured assignee route when present. With no assignee, it
+defaults to ChatGPT. This makes ordinary unowned Planning work visible without requiring the model to rescan Project 2.
+
+### `route-ambiguity`
+
+Unknown or multiple assignees are never guessed. They produce one explicit reconciliation candidate. Likewise, a Ready item with
+multiple assignees remains a route mismatch even when one login happens to match the configured executor pool.
+
+## Efficiency contract
+
+A scheduled ChatGPT tick still:
+
+1. requests one fresh status artifact;
+2. reads `dispatch.orderedCandidates`;
+3. selects at most the first candidate;
+4. live-reads only that canonical target and relevant PR;
+5. performs at most one guarded reconciliation or lifecycle turn;
+6. returns `NO_CHANGE` immediately when the projection is empty.
+
+Normal merge completion should therefore cost no ChatGPT tick. The loop pays for reconciliation only when the event adapter missed
+or when a new/unrouted issue actually needs one bounded Planning action.
+
+## Failure response and removal
+
+A missing/duplicate canonical representation, suppressed item, stale expected state, exact-head mismatch, merge-commit mismatch,
+control conflict, or failed assignment cleanup causes a visible workflow failure or skip without speculative mutation. Inspect the
+workflow summary and the next generated dispatch projection.
+
+Remove or simplify the adapter only when native GitHub Project automation can provide equivalent canonical resolution, guarded
+multi-field mutation, exact merge verification, and assignment cleanup.

--- a/docs/ai-delivery/completion.md
+++ b/docs/ai-delivery/completion.md
@@ -51,18 +51,19 @@ calls and adds no recurring polling pass.
 
 ### `completion-drift`
 
-A narrow backstop for the normal pre-merge state only:
+A narrow backstop for the normal pre-merge state, plus the small built-in-workflow race:
 
 ```text
-Status = Approval
-Execution = Ready
-Executor = Human
 source PR is already merged
+and either:
+  Status = Approval, Execution = Ready, Executor = Human
+or:
+  Status = Done with lingering Execution, Executor, or Assignee
 ```
 
 For an issue, exactly one linked PR must be present and merged. For a PR item, the item itself must be merged. Historical items in
-Implementation, Draft, or an uninitialized state are deliberately excluded so the hourly ChatGPT loop does not spend many ticks
-cleaning old Project archaeology.
+Implementation, Draft, an uninitialized state, or clean terminal Done are deliberately excluded so the hourly ChatGPT loop does
+not spend many ticks cleaning old Project archaeology.
 
 ### `uninitialized-item`
 

--- a/docs/ai-delivery/runtime-contract.md
+++ b/docs/ai-delivery/runtime-contract.md
@@ -23,12 +23,14 @@ A tick is selection and coordination, not lifecycle work. It must:
    - conflicting same-repository PR requiring deliberate continuation routing;
    - fork or Dependabot conflict requiring contributor feedback or a documented bot operation, never branch adoption;
    - PR intake/canonicalization or duplicate representation;
-   - exact-head drift or invalid current route/assignee;
+   - merged completion drift missed by the event adapter;
+   - exact-head drift, uninitialized/default Planning routing, or invalid current route/assignee;
    - stale owned `In progress` recovery caused by a missing, invalid, or expired lease;
    - `Ready` work for an executor this supervisor dispatches;
    - `Ready` work for this dispatcher;
 5. only after selection, perform the minimum live reads needed for that candidate: current target, formal closing links, exact
-   branch/head/draft/ownership, current Project route, worker reference, and the newest active control issue;
+   branch/head/draft/ownership or merged state, current Project route, worker reference, assignment, and the newest active control
+   issue;
 6. claim or reconcile through one guarded control command, verify the terminal reaction, and then either perform one bounded
    lifecycle turn or create one durably acknowledged external worker;
 7. publish human-useful evidence and one guarded handoff when work finishes;
@@ -40,6 +42,25 @@ selection.
 
 When no candidate needs action, perform no Project, source, worker, target-comment, or control-command mutation and return
 `NO_CHANGE` plus telemetry.
+
+## Event-driven completion and routing backstops
+
+Objective merge completion belongs to `.github/workflows/delivery-completion.yml`, not to a recurring LLM heartbeat. The trusted
+base adapter resolves the canonical issue/PR, verifies the merged PR head and merge commit, sets `Status = Done`, clears active
+routing, and verifies assignment cleanup through the common guarded control implementation.
+
+The dispatcher is only the repair path:
+
+- `completion-drift` is emitted only when a canonical item remains in the normal pre-merge state
+  `Approval / Ready / Human` and its single linked PR, or the canonical PR itself, is already merged. This narrow predicate avoids
+  flooding the queue with historical closed items.
+- `uninitialized-item` initializes an open non-technical issue with missing Status as `Planning / Ready`; a unique configured
+  assignee determines Executor, otherwise ChatGPT is the default.
+- `default-planning-route` assigns `Planning / Ready` with no Executor using the same assignee rule and ChatGPT default.
+- `route-ambiguity` represents unknown or multiple assignees. Never guess a route.
+
+For these candidates, use the suggested route only as snapshot evidence. Re-read the selected item live and guard every current
+field before mutation. Process one candidate per tick. Detailed semantics are in [`completion.md`](completion.md).
 
 ## Canonical PR invariants
 
@@ -69,8 +90,8 @@ when it is still legitimately running. A conflict means another actor won or sta
 view.
 
 A configured unclaimable `Execution = Ready` route whose Assignee belongs to a different executor pool is a reconciliation
-candidate. Never silently filter out that mismatch. `Blocked / Human` is reserved for an exact Dmitry decision or action; routine
-waiting remains `In progress`.
+candidate. Multiple assignees are also a mismatch even when one login matches the expected pool. Never silently filter out that
+state. `Blocked / Human` is reserved for an exact Dmitry decision or action; routine waiting remains `In progress`.
 
 ## Lease-based stale recovery
 

--- a/docs/ai-delivery/runtime-contract.md
+++ b/docs/ai-delivery/runtime-contract.md
@@ -51,9 +51,9 @@ routing, and verifies assignment cleanup through the common guarded control impl
 
 The dispatcher is only the repair path:
 
-- `completion-drift` is emitted only when a canonical item remains in the normal pre-merge state
-  `Approval / Ready / Human` and its single linked PR, or the canonical PR itself, is already merged. This narrow predicate avoids
-  flooding the queue with historical closed items.
+- `completion-drift` is emitted when a canonical item remains in the normal pre-merge state `Approval / Ready / Human`, or is
+  already `Done` but retains active Execution, Executor, or Assignee after a built-in-workflow race, and its single linked PR (or
+  the canonical PR itself) is merged. Clean terminal Done and historical non-Approval states stay out of the queue.
 - `uninitialized-item` initializes an open non-technical issue with missing Status as `Planning / Ready`; a unique configured
   assignee determines Executor, otherwise ChatGPT is the default.
 - `default-planning-route` assigns `Planning / Ready` with no Executor using the same assignee rule and ChatGPT default.


### PR DESCRIPTION
Closes #806

## Problem

GitHub source state and Project 2 lifecycle can diverge after merge: a canonical issue may be closed and its single implementation PR merged while the Project item remains `Approval / Ready / Human`. Open Project issues with missing Status, or `Planning / Ready` with no Executor, can also remain invisible to the generated dispatcher queue.

The current examples are #755, #762, #727, #803, and #804.

## Design

### Event-driven completion

Add a trusted-base `pull_request_target.closed` adapter that processes only merged PRs targeting `develop`.

It resolves canonical identity structurally:

- exactly one formal closing issue: the issue is canonical;
- no formal closing issue: the PR is canonical;
- multiple closing issues: the coordination PR is canonical and linked issue propagation remains a Planning decision.

The adapter requires exactly one Project 2 representation, excludes explicit suppressed duplicates, verifies the merged state, exact head, merge commit, and base before and after mutation, then reuses `delivery-control/v1` to set `Done`, clear active routing, record compact merge evidence, and clear/verify assignees.

### Cheap dispatcher backstop

Extend the existing generated projection using only the snapshot and raw exports already loaded by `delivery-status.yml`:

- `completion-drift` for the normal pre-merge state `Approval / Ready / Human` whose canonical PR is already merged, plus `Done` with lingering Execution, Executor, or Assignee after a built-in-workflow race;
- `uninitialized-item` for an open non-technical issue with missing Status;
- `default-planning-route` for `Planning / Ready` with no Executor;
- `route-ambiguity` for unknown or multiple assignees;
- multiple assignees remain a route mismatch even when one matches the expected executor pool;
- a canonical item already selected for higher-priority PR intake/conflict is excluded from routing reconciliation, so it appears only once in the queue.

No recurring API call, Project scan, PR scan, worker lookup, or second snapshot is added. ChatGPT still consumes one generated `orderedCandidates` array, selects at most one entry, and live-reads only that target.

## Security and permissions

- Top-level workflow permissions remain `{}`.
- `pull_request_target` checks out trusted `develop`, never the PR head.
- No contributor code, action, build, or command is executed.
- Prepare receives only `contents: read` and the existing Project token for guarded metadata/Project access.
- Transition receives `contents: read` and `issues: write`; repository `GITHUB_TOKEN` is used only for assignee cleanup.
- Per-target concurrency reuses the existing control-plane key.
- No merge, auto-merge, push, deployment, environment, repository-setting, or secret mutation is added.

## Efficiency validation

The first broad replay exposed 20 historical closed items. The backstop was deliberately narrowed to exact `Approval / Ready / Human`, or terminal `Done` with active routing/assignment. Clean historical `Done` and non-Approval closed items stay out of the hourly queue.

A fresh Project 2 artifact generated after issue #806 and PR #807 existed (`8861632660`, 70 exported items, 32 active items, 3 open PRs) produces exactly six candidates:

1. `pr-intake` for current PR #807 / canonical issue #806;
2. `completion-drift` #755;
3. `completion-drift` #762;
4. `default-planning-route` #727 -> ChatGPT;
5. `uninitialized-item` #803 -> ChatGPT;
6. `uninitialized-item` #804 -> ChatGPT.

The current PR intake is expected and appears only once. After it is handled, the steady repair backlog is the five intended items. Normal future merges are handled by Actions without consuming an LLM tick.

## Validation

- `node --check .github/scripts/delivery-completion.js`
- `node --check .github/scripts/delivery-completion.test.js`
- `node --check .github/scripts/delivery-completion.edge.test.js`
- `node --test .github/scripts/delivery-completion.test.js .github/scripts/delivery-completion.edge.test.js` — 12/12 passed
- `node --check .github/scripts/delivery-dispatch-view.js`
- `node --check .github/scripts/delivery-dispatch-view.test.js`
- `node --test .github/scripts/delivery-dispatch-view.test.js` — 20/20 passed
- Ruby parsed `.github/workflows/delivery-completion.yml`
- fresh real-snapshot replay against artifact `8861632660` produced the exact six-candidate queue above, with no duplicate #806 and no historical flood
- exact-head `Complete merged AI delivery work` succeeded, including Node tests, YAML parsing, and actionlint
- exact-head `AI delivery status` succeeded, including the full status/policy/runtime-budget suite, YAML parsing, and actionlint
- exact-head `AI delivery control` succeeded
- branch comparison: nine intended files, zero commits behind `develop`

The broad `Check Pull Request` matrix is still queued for this head; no older-head result is used as proof.

## Limitations and rollout

The runtime merge event path cannot execute until this workflow is merged into `develop`. After merge, smoke-test one disposable canonical issue/PR completion and verify Project fields plus assignment cleanup. The hourly projection is the repair backstop if an event or guarded transition is missed.

This PR does not immediately mutate #755, #762, #727, #803, or #804; after merge, normal dispatcher ticks can reconcile them one bounded item at a time, or the two completion drifts can be repaired deliberately through the same guarded path.

## Published head

`82a3f0abdbda48903fa8f5eb6d6d683cb4aa40a7`

No merge or auto-merge is requested.