### PR TITLE
Run Local Codex work in the automation thread

### DIFF
--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -28,26 +28,34 @@ subagent, `client-new-thread:*` reference, or claimed app-owned worktree. Perfor
 2. Run `.codex/local/project-queue-snapshot.sh` exactly once. It is the only normal full-Project query. Retain that JSON for the
    whole selection phase. Do not run `gh project item-list`, raw Project GraphQL, schema probes, or the helper again. If it exits 75,
    do not switch to another connector, combine stale snapshots, or claim work; return RATE_LIMITED plus telemetry.
-3. Inspect `ownedInProgress` first. Select an owned item only when its Worker reference names adapter
+3. Inspect `ownedInProgress` first. A valid future `leaseUntil` consumes capacity and is ignored when it belongs to another adapter,
+   host, conversation, or generation. Select an owned item only when its Worker reference names adapter
    `codex-app-same-thread-v1` and this persistent automation conversation, and its exact token/generation is recoverable here.
-   Resume that one generation before considering Ready work, even when its lease is still valid. Do not inspect or adopt ownership
-   created by another adapter, host, conversation, or generation.
+   Resume that one generation before considering Ready work, even when its lease is still valid. Targeted provider inventory is
+   allowed only for that selected recovery and only for its exact claim token/generation; this same-thread adapter has no child
+   inventory, so use only this conversation state and targeted GitHub evidence. Never adopt another adapter's ownership.
 4. If no same-thread generation is resumable, use the already sorted `readyCandidates` and select at most the first canonical
-   candidate. `executors.Local Codex.maxConcurrentWorkers` is one; any other owned Local Codex item consumes capacity and prevents
-   a new claim. Do not list projects, tasks, conversations, or use provider-wide inventory.
+   candidate. Compute available capacity from `executors.Local Codex.maxConcurrentWorkers` minus every item in `ownedInProgress`.
+   The configured maximum is one. Do not call `List projects`, list all tasks/conversations, or use provider-wide inventory on the
+   normal Ready path.
 5. If no resumable or Ready candidate exists, create no target comment, control command, task, worktree, branch, or Project
    mutation. Return NO_CHANGE plus telemetry.
 6. Only after selection, perform the minimum targeted live reads needed to validate canonical identity, source state, formal links,
    exact existing PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue.
-   For fresh work, read the complete authoritative issue before choosing a branch.
+   Do not read the complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker
+   owns those reads after claim in this same conversation. For fresh work, read the complete authoritative issue before choosing a
+   branch.
 7. Branch authority is deterministic:
-   - continuation reuses the exact verified same-repository PR branch;
+   - an existing same-repository PR may be an adopted continuation only when the verified canonical Project route selects Local
+     Codex; Reuse the exact branch and PR;
+   - Do not adopt fork or Dependabot branches for direct correction;
    - an explicit branch in the authoritative issue, Project route, or maintainer decision must be used exactly and overrides any
      generated slug;
-   - only when no explicit branch exists may fresh work derive `agent/issue-<number>-<short-slug>` after the targeted read;
+   - only when no existing PR or explicit branch exists may fresh work derive `agent/issue-<number>-<short-slug>` after the targeted
+     read;
    - a branch conflict is a Planning/maintainer reconciliation, never permission to invent another branch.
 8. Claim Ready work with one guarded `delivery-control/v1` command. Use the human-readable Markdown wrapper, exact start/end markers,
-   and lowercase `json` fence; the marked JSON is authoritative. Guard current type, Status, Execution=Ready,
+   and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type, Status, Execution=Ready,
    Executor=Local Codex, and exact PR head when applicable. Set Execution=In progress and a Worker reference containing the exact
    token, generation, adapter=codex-app-same-thread-v1, conversation=self, branch, claimedAt, and leaseUntil. Verify the terminal
    reaction and resulting Project state before source mutation.

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -1,13 +1,14 @@
-# Token-efficient Local Codex dispatcher
+# Local Codex app automation: same-thread dispatcher and worker
 
-Configure the persistent app automation with **`gpt-5.6-luna` / low reasoning**. The dispatcher coordinates only. A selected
-normal worker uses **`gpt-5.6-terra` / medium reasoning**. Use `gpt-5.6-sol` / high only for an explicitly recorded difficult-task
-escalation; xhigh is exceptional, not the default.
+Configure the persistent app automation with **`gpt-5.6-terra` / medium reasoning**. This automation performs both deterministic
+queue selection and the selected Implementation or Verification lifecycle turn in the same persistent conversation. Do not use
+Luna/low for this adapter: there is no separate child worker model.
 
-Repository merges do not rewrite an existing Codex automation. Replace the embedded prompt manually and smoke-test it.
+Repository merges do not rewrite an existing Codex automation. After merge, replace the embedded prompt and model manually, then
+smoke-test one empty tick and one disposable/read-only lifecycle candidate before enabling recurrence.
 
 ```text
-Run one logically stateless Sniffy Local Codex dispatcher tick in this persistent dispatcher conversation.
+Run one logically stateless Sniffy Local Codex app tick in this persistent automation conversation.
 
 Repository: sniffy/sniffy
 Base branch: develop
@@ -15,57 +16,61 @@ Project: organization sniffy, number 2
 Executor: Local Codex
 Queue helper: .codex/local/project-queue-snapshot.sh
 Runtime contract: docs/ai-delivery/runtime-contract.md
-Worker template: .codex/local/worker-task-prompt.md
-Dispatcher model/profile: gpt-5.6-luna / low
-Default worker model/profile: gpt-5.6-terra / medium
+Lifecycle template: .codex/local/worker-task-prompt.md
+Automation model/profile: gpt-5.6-terra / medium
+Adapter identity: codex-app-same-thread-v1
 
-Record startedAt. This conversation coordinates only: never edit source, create a work branch, perform lifecycle proof, review a
-worker PR, merge, or enable auto-merge.
+Record startedAt. This conversation is both dispatcher and lifecycle worker. Never create a child thread, child task, hidden
+subagent, `client-new-thread:*` reference, or claimed app-owned worktree. Perform at most one lifecycle generation at a time.
 
-1. Fetch current origin/develop. In one batched local command read this prompt, runtime-contract.md, profile.yml, and the worker
+1. Fetch current origin/develop. In one batched local command read this prompt, runtime-contract.md, profile.yml, and the lifecycle
    template exactly once. Do not load detailed lifecycle/control/routing/supervision/verification documents before selection.
 2. Run `.codex/local/project-queue-snapshot.sh` exactly once. It is the only normal full-Project query. Retain that JSON for the
    whole selection phase. Do not run `gh project item-list`, raw Project GraphQL, schema probes, or the helper again. If it exits 75,
    do not switch to another connector, combine stale snapshots, or claim work; return RATE_LIMITED plus telemetry.
-3. Inspect `ownedInProgress` without querying any worker. An item with a valid future `leaseUntil` consumes capacity and is ignored.
-   Select at most one stale owned item only when its worker reference or lease is missing/invalid, or the lease has expired.
-   Targeted provider inventory is allowed only for that selected recovery and only for its claim token/generation.
-4. Otherwise use the already sorted `readyCandidates` and select at most the first canonical candidate. Compute available capacity
-   from `executors.Local Codex.maxConcurrentWorkers` minus all `ownedInProgress`, including stale ownership until recovery resolves
-   it. Do not call `List projects`, list all tasks/conversations, or use provider-wide inventory on the normal Ready path.
-5. If no stale recovery or Ready candidate exists, create no target comment, control command, task, worktree, branch, or Project
+3. Inspect `ownedInProgress` first. Select an owned item only when its Worker reference names adapter
+   `codex-app-same-thread-v1` and this persistent automation conversation, and its exact token/generation is recoverable here.
+   Resume that one generation before considering Ready work, even when its lease is still valid. Do not inspect or adopt ownership
+   created by another adapter, host, conversation, or generation.
+4. If no same-thread generation is resumable, use the already sorted `readyCandidates` and select at most the first canonical
+   candidate. `executors.Local Codex.maxConcurrentWorkers` is one; any other owned Local Codex item consumes capacity and prevents
+   a new claim. Do not list projects, tasks, conversations, or use provider-wide inventory.
+5. If no resumable or Ready candidate exists, create no target comment, control command, task, worktree, branch, or Project
    mutation. Return NO_CHANGE plus telemetry.
-6. Only after selection, perform minimum targeted live reads: canonical item type/open state, formal closing links, exact existing
-   PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue. Do not read the
-   complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker owns those reads.
-7. For stale recovery, preserve the exact generation/branch/task. If the same worker is demonstrably active, extend its lease by a
-   guarded update and stop. If completion evidence exists but handoff was lost, finish the deterministic handoff. If the worker
-   failed or disappeared, recover the same workspace/branch when possible. Release to Ready only when no active or recoverable work
-   remains. Never spawn a duplicate generation.
-8. An existing same-repository PR may be an adopted continuation only when the verified canonical Project route selects Local
-   Codex. Reuse the exact branch and PR. Do not adopt fork or Dependabot branches for direct correction.
-9. Claim Ready work with one guarded `delivery-control/v1` command. Use the human-readable Markdown wrapper, exact start/end markers,
-   and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Guard current type, Status,
-   Execution=Ready, Executor=Local Codex, and exact PR head when applicable; set In progress with token, owner, claimedAt,
-   leaseUntil, and provisional worker reference. Verify the terminal reaction and resulting Project state before spawning.
-10. Render every worker placeholder. Create exactly one standalone one-time app-owned worker task and isolated worktree with the
-    default worker model/profile. Select Sol/high only when the canonical issue or routing decision explicitly records an escalation
-    reason. Never create the worker inside this dispatcher conversation.
-11. After confirmed child creation, publish one guarded update with the concrete worker reference and verify it. If creation
-    definitively fails, release to Ready. If ambiguous, preserve the one provisional generation with the configured provisional
-    lease for targeted recovery; never redispatch speculatively. Block only for an exact Dmitry decision/action.
-12. Finish with one telemetry JSON object containing startedAt, finishedAt, durationSeconds, adapter, scheduler, model, reasoning,
+6. Only after selection, perform the minimum targeted live reads needed to validate canonical identity, source state, formal links,
+   exact existing PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue.
+   For fresh work, read the complete authoritative issue before choosing a branch.
+7. Branch authority is deterministic:
+   - continuation reuses the exact verified same-repository PR branch;
+   - an explicit branch in the authoritative issue, Project route, or maintainer decision must be used exactly and overrides any
+     generated slug;
+   - only when no explicit branch exists may fresh work derive `agent/issue-<number>-<short-slug>` after the targeted read;
+   - a branch conflict is a Planning/maintainer reconciliation, never permission to invent another branch.
+8. Claim Ready work with one guarded `delivery-control/v1` command. Use the human-readable Markdown wrapper, exact start/end markers,
+   and lowercase `json` fence; the marked JSON is authoritative. Guard current type, Status, Execution=Ready,
+   Executor=Local Codex, and exact PR head when applicable. Set Execution=In progress and a Worker reference containing the exact
+   token, generation, adapter=codex-app-same-thread-v1, conversation=self, branch, claimedAt, and leaseUntil. Verify the terminal
+   reaction and resulting Project state before source mutation.
+9. After claim, apply the lifecycle template in this same conversation for the selected Status. Read the complete canonical item,
+   applicable AGENTS.md, detailed policy sections, exact PR/reviews/threads/CI, and proof obligations. Implement or verify the
+   smallest coherent result. Never dispatch another worker or defer normal lifecycle work back to this dispatcher.
+10. If legitimate work cannot finish before lease expiry, renew the same token/generation through a guarded Worker reference update.
+    If this automation occurrence ends before completion, preserve the same branch and ownership so the next occurrence resumes it.
+11. On completion, publish human-useful evidence and perform the lifecycle template's guarded handoff, clearing same-thread
+    ownership. Implementation normally hands off to Review / Ready / ChatGPT with exact PR/head evidence. Verification uses its
+    classified result. Verify Project, assignment, branch, PR, and exact head before stopping.
+12. A genuine Dmitry decision/action may route Blocked / Human. Routine CI, build, publication, or long-running work remains under
+    the same generation and lease. Never merge, enable auto-merge, reset, rebase, force-push, create a duplicate branch/PR, or
+    fabricate a child worker.
+13. Finish with one telemetry JSON object containing startedAt, finishedAt, durationSeconds, adapter, scheduler, model, reasoning,
     snapshot identity/counts, selected candidate, outcome, and provider token counters when exposed. Otherwise use null token fields
     and usageSource=unavailable; never fabricate exact usage.
-
-A worker must perform its own guarded lifecycle handoff when complete and may renew its lease before expiry. Never poll active
-workers. Never dispatch the same lifecycle generation twice. Never merge or enable auto-merge.
 ```
 
 ## Smoke test
 
-Before enabling recurrence, prove that the snapshot helper runs once; an empty tick creates no worker/worktree; a rate-limited tick
-claims nothing; active leased workers are not queried; only expired/malformed ownership triggers targeted recovery; normal Ready
-selection performs no provider-wide inventory; one issue creates one worker; a routed same-repository PR reuses its exact branch/PR;
-fork and Dependabot PRs are rejected for adoption; concurrent guarded claims have one winner; failed creation releases; and a
-completed worker performs a guarded lifecycle handoff rather than spawning a reviewer.
+Before recurrence, prove that the snapshot helper runs once; an empty tick performs no source/Project mutation; one eligible issue
+is claimed and worked in this same conversation; an explicit issue branch such as `agent/demo-history-import` is preserved exactly;
+no `client-new-thread:*`, child task, hidden subagent, or child worktree is created; a same-thread In-progress generation resumes
+before Ready work; concurrent guarded claims have one winner; completion performs the guarded handoff; and no task can merge or
+enable auto-merge.

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -40,8 +40,7 @@ subagent, `client-new-thread:*` reference, or claimed app-owned worktree. Perfor
    mutation. Return NO_CHANGE plus telemetry.
 6. Only after selection, perform the minimum targeted live reads needed to validate canonical identity, source state, formal links,
    exact existing PR branch/head/draft/ownership, current route/assignment/worker reference, and newest active control issue.
-   Do not read the complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker
-   owns those reads after claim in this same conversation. For fresh work, read the complete authoritative issue before choosing a
+   Do not read the complete discussion, proof matrix, review submissions, review threads, or CI before claim; the lifecycle worker owns those reads after claim in this same conversation. For fresh work, read the complete authoritative issue before choosing a
    branch.
 7. Branch authority is deterministic:
    - an existing same-repository PR may be an adopted continuation only when the verified canonical Project route selects Local

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -36,8 +36,7 @@ subagent, `client-new-thread:*` reference, or claimed app-owned worktree. Perfor
    inventory, so use only this conversation state and targeted GitHub evidence. Never adopt another adapter's ownership.
 4. If no same-thread generation is resumable, use the already sorted `readyCandidates` and select at most the first canonical
    candidate. Compute available capacity from `executors.Local Codex.maxConcurrentWorkers` minus every item in `ownedInProgress`.
-   The configured maximum is one. Do not call `List projects`, list all tasks/conversations, or use provider-wide inventory on the
-   normal Ready path.
+   The configured maximum is one. Do not call `List projects`, list all tasks/conversations, or use provider-wide inventory on the normal Ready path.
 5. If no resumable or Ready candidate exists, create no target comment, control command, task, worktree, branch, or Project
    mutation. Return NO_CHANGE plus telemetry.
 6. Only after selection, perform the minimum targeted live reads needed to validate canonical identity, source state, formal links,

--- a/.codex/local/scheduled-task-prompt.md
+++ b/.codex/local/scheduled-task-prompt.md
@@ -31,8 +31,7 @@ subagent, `client-new-thread:*` reference, or claimed app-owned worktree. Perfor
 3. Inspect `ownedInProgress` first. A valid future `leaseUntil` consumes capacity and is ignored when it belongs to another adapter,
    host, conversation, or generation. Select an owned item only when its Worker reference names adapter
    `codex-app-same-thread-v1` and this persistent automation conversation, and its exact token/generation is recoverable here.
-   Resume that one generation before considering Ready work, even when its lease is still valid. Targeted provider inventory is
-   allowed only for that selected recovery and only for its exact claim token/generation; this same-thread adapter has no child
+   Resume that one generation before considering Ready work, even when its lease is still valid. Targeted provider inventory is allowed only for that selected recovery and only for its exact claim token/generation; this same-thread adapter has no child
    inventory, so use only this conversation state and targeted GitHub evidence. Never adopt another adapter's ownership.
 4. If no same-thread generation is resumable, use the already sorted `readyCandidates` and select at most the first canonical
    candidate. Compute available capacity from `executors.Local Codex.maxConcurrentWorkers` minus every item in `ownedInProgress`.

--- a/.github/scripts/delivery-runtime-budget.test.js
+++ b/.github/scripts/delivery-runtime-budget.test.js
@@ -32,20 +32,33 @@ test('ChatGPT recurring scheduler is Chat, not Work, and reads compact policy', 
   assert.match(profile, /ChatGPT:[\s\S]*surface:\s*Chat[\s\S]*forbiddenSurface:\s*Work/);
 });
 
-test('Local Codex uses Luna dispatcher, Terra worker, and explicit Sol escalation', () => {
+test('app-native Local Codex uses Terra medium in one thread and forbids nested spawn', () => {
   const profile = read('docs/ai-delivery/profile.yml');
-  const dispatcher = read('.codex/local/scheduled-task-prompt.md');
+  const automation = read('.codex/local/scheduled-task-prompt.md');
   const worker = read('.codex/local/worker-task-prompt.md');
   const runIssue = read('.codex/local/run-issue.sh');
 
-  assert.match(profile, /dispatcherModel:\s*gpt-5\.6-luna/);
-  assert.match(profile, /dispatcherReasoning:\s*low/);
+  assert.match(profile, /appNativeAdapter:\s*codex-app-same-thread-v1/);
+  assert.match(profile, /appNativeModel:\s*gpt-5\.6-terra/);
+  assert.match(profile, /appNativeReasoning:\s*medium/);
+  assert.match(profile, /appNativeSameThread:\s*true/);
+  assert.doesNotMatch(profile, /dispatcherModel:\s*gpt-5\.6-luna/);
+  assert.doesNotMatch(profile, /dispatcherReasoning:\s*low/);
   assert.match(profile, /workerModel:\s*gpt-5\.6-terra/);
   assert.match(profile, /workerReasoning:\s*medium/);
   assert.match(profile, /escalationModel:\s*gpt-5\.6-sol/);
   assert.match(profile, /escalationReasoning:\s*high/);
-  assert.match(dispatcher, /gpt-5\.6-luna.*low/i);
-  assert.match(dispatcher, /gpt-5\.6-terra.*medium/is);
+
+  assert.match(automation, /gpt-5\.6-terra.*medium/is);
+  assert.match(automation, /adapter=codex-app-same-thread-v1/);
+  assert.match(automation, /conversation=self/);
+  assert.match(automation, /same conversation/i);
+  assert.match(automation, /explicit branch.*overrides/is);
+  assert.match(automation, /resume that one generation before considering Ready work/is);
+  assert.match(automation, /Never create a child thread, child task, hidden\s+subagent, `client-new-thread:\*` reference/is);
+  assert.doesNotMatch(automation, /Create exactly one standalone one-time app-owned worker task/i);
+  assert.doesNotMatch(automation, /After confirmed child creation/i);
+
   assert.match(worker, /gpt-5\.6-terra.*medium/is);
   assert.match(runIssue, /CODEX_MODEL:-gpt-5\.6-terra/);
   assert.match(runIssue, /CODEX_REASONING_EFFORT:-medium/);
@@ -94,7 +107,7 @@ test('worker supervision is lease-based stale recovery rather than periodic poll
   assert.match(runtime, /Normal `In progress` ownership is not polled/i);
   assert.match(runtime, /missing, invalid, or expired lease/i);
   assert.match(chat, /valid future `leaseUntil` is invisible to this tick/i);
-  assert.match(dispatcher, /valid future `leaseUntil` consumes capacity and is ignored/i);
+  assert.match(dispatcher, /same-thread generation.*resume/is);
   assert.match(worker, /renew the same\s+claim\/generation before expiry/i);
   assert.match(projection, /stale-owned-recovery/);
   assert.match(projection, /activeInProgressByExecutor/);

--- a/docs/ai-delivery/executors/codex-local.md
+++ b/docs/ai-delivery/executors/codex-local.md
@@ -1,16 +1,24 @@
 # Local Codex executors
 
-Local Codex supports an app-native dispatcher/worker topology and a headless CLI topology. Both follow root/nested `AGENTS.md`, the
-compact runtime contract, shared lifecycle/control protocol, exact PR continuity, truthful proof, and the no-merge boundary.
+Local Codex has two explicit adapter modes:
+
+- **app-native same-thread**: the persistent Codex Automation performs selection and one lifecycle turn in the same conversation;
+- **headless CLI**: a repository-owned process launches isolated `codex exec` workers.
+
+Both follow root/nested `AGENTS.md`, the compact runtime contract, shared lifecycle/control protocol, exact PR continuity, truthful
+proof, and the no-merge boundary. They must not impersonate one another in Worker reference evidence.
 
 ## Model profiles
 
-- persistent dispatcher: `gpt-5.6-luna` / low;
-- normal implementation or verification worker: `gpt-5.6-terra` / medium;
+- app-native same-thread automation: `gpt-5.6-terra` / medium;
+- headless CLI dispatcher: deterministic shell/no model;
+- headless lifecycle worker: `gpt-5.6-terra` / medium;
 - explicit difficult-task escalation: `gpt-5.6-sol` / high;
 - xhigh only for an exceptional recorded need.
 
-Model choice does not change authority, claim ownership, branch continuity, review independence, or proof obligations.
+The app-native adapter cannot cheaply use Luna for empty ticks while switching to Terra for the claimed lifecycle turn: the
+automation occurrence has one effective model/profile. Correctness therefore requires Terra/medium for the complete app-native
+automation. The separate CLI adapter is the path for restoring a model-free dispatcher.
 
 ## Route to Local Codex
 
@@ -21,25 +29,27 @@ non-convergence caused by environment/context limitations.
 Do not send unresolved product/architecture/canonicalization/credential/privilege decisions to a stronger model. Never adopt fork
 or Dependabot branches for direct autonomous correction.
 
-## App-native topology
+## App-native same-thread topology
 
 ```text
-persistent Luna/low dispatcher
+persistent Terra/medium automation conversation
   -> one normalized Project snapshot
   -> empty: NO_CHANGE + telemetry
-  -> selected Ready or stale-lease candidate
-      -> targeted live read + guarded claim/recovery
-      -> one standalone Terra/medium worker and isolated worktree
-      -> optional explicit Sol/high escalation
+  -> same-thread owned generation: resume it
+  -> otherwise one selected Ready candidate
+      -> targeted live read + guarded claim
+      -> Implementation or Verification in this same conversation
       -> exact branch/PR evidence and guarded handoff
 ```
 
-The dispatcher reads its compact prompt, `runtime-contract.md`, profile, worker template, and one queue snapshot. It does not read
-complete discussions/diffs/reviews/CI before selection. Provider-wide task inventory is only targeted recovery for one selected
-missing/invalid/expired lease.
+The app-native adapter does not create a standalone child thread, child task, hidden subagent, or child worktree. An opaque
+`client-new-thread:*` acknowledgement is never worker evidence. The claim identifies
+`adapter=codex-app-same-thread-v1; conversation=self`, and a later occurrence of this same persistent automation resumes that exact
+generation before selecting new Ready work.
 
-Canonical prompts are `.codex/local/scheduled-task-prompt.md` and `.codex/local/worker-task-prompt.md`. Repository merges do not
-rewrite embedded automations; replace and smoke-test them manually.
+Canonical prompts are `.codex/local/scheduled-task-prompt.md` and `.codex/local/worker-task-prompt.md`. The automation loads the
+worker template after claim and applies it in the same conversation. Repository merges do not rewrite an embedded automation;
+replace its prompt and model manually and smoke-test it.
 
 ## Headless topology
 
@@ -52,58 +62,68 @@ systemd timer or cron
   -> exact branch/PR publication and guarded handoff
 ```
 
-`.codex/local/run-issue.sh` defaults to Terra/medium. Override to Sol/high only for an exceptional task and record why normal worker
-capability was insufficient.
+`.codex/local/run-issue.sh` remains the legacy one-shot headless entry point. The durable CLI dispatcher/supervisor is delivered
+separately under issue #814.
 
-## Dispatcher contract
+## Shared selection and branch authority
 
-The dispatcher:
+Each adapter:
 
 - selects canonical issue/PR work routed `Execution = Ready`, `Executor = Local Codex`, with empty/local assignee;
-- counts every owned `In progress` item against capacity;
-- ignores owned work with a valid future lease without opening its worker;
-- selects stale recovery only for missing/invalid worker evidence or expired `leaseUntil`;
-- uses the retained normalized snapshot once and deterministic ordering;
-- live-reads only the selected target;
+- uses one retained normalized snapshot and deterministic ordering;
+- live-reads only the selected target before claim;
 - suppresses duplicate representations and multi-issue linked work;
-- claims Ready work before spawning exactly one worker/generation;
-- preserves an ambiguous spawn as one provisional generation rather than redispatching;
-- creates no source/Project/worker mutation for an empty queue.
+- claims before lifecycle mutation;
+- creates no source/Project mutation for an empty queue;
+- allows at most one active Local Codex generation during the initial rollout.
 
-Every autonomous command uses the control-plane human-readable Markdown wrapper, exact start/end markers, and lowercase `json` fence; the marked JSON is authoritative. Never emit bare JSON. Inspect the terminal reaction and re-read Project state before
-worker creation, recovery, or handoff.
+Branch authority is ordered:
+
+1. exact branch of a verified same-repository continuation PR;
+2. explicit branch in the authoritative issue, Project route, or maintainer decision;
+3. only if neither exists, deterministic fresh `agent/issue-<number>-<short-slug>` derivation after the targeted read.
+
+An explicit branch always wins. A conflict returns to Planning or a precise maintainer decision; it never authorizes an invented
+replacement branch.
+
+Every autonomous command uses the control-plane human-readable Markdown wrapper, exact start/end markers, and lowercase `json`
+fence; the marked JSON is authoritative. Never emit bare JSON. Inspect the terminal reaction and re-read Project state before
+source mutation, recovery, or handoff.
 
 ## Existing PR continuation
 
 An existing same-repository PR may be an adopted continuation only when the canonical Project route deliberately selects Local
-Codex. Reuse the exact same-repository open PR branch and PR even if Dmitry, ChatGPT, an IDE agent, or another worker created it.
-Do not create a fresh branch or duplicate PR. Never reset, rebase, force-push, discard useful commits, or silently narrow scope.
-Never adopt a fork or Dependabot branch.
+Codex. Reuse its exact branch and PR even if Dmitry, ChatGPT, an IDE agent, or another worker created it. Do not create a fresh
+branch or duplicate PR. Never reset, rebase, force-push, discard useful commits, or silently narrow scope. Never adopt a fork or
+Dependabot branch.
 
-## Worker contract
+## Lifecycle contract
 
-A worker performs one routed status. Implementation maps acceptance criteria to proof, changes code, tests, inspects the complete
-diff, commits/pushes, and publishes one intended PR. Verification proves observable behavior in a representative environment.
-Review requires an independent configured identity.
+An app-native automation or headless worker performs one routed status. Implementation maps acceptance criteria to proof, changes
+code, tests, inspects the complete diff, commits/pushes, and publishes one intended PR. Verification proves observable behavior in
+a representative environment. Review requires an independent configured identity.
 
 For fresh work create one branch/PR. For continuation update the exact existing branch/PR. When Implementation is complete, mark
 the PR ready for review and re-read it as open, targeting develop, non-draft, and at the exact published head. Then publish evidence
-and use one guarded handoff to `Review / Ready / ChatGPT`; a canonical issue includes `reviewPullRequest.number/head`, while a
-canonical PR guards `expected.head`. Verify reaction, Project state, bedrin-gpt assignment, and exact-head PR state.
+and use one guarded handoff to `Review / Ready / ChatGPT`; a canonical issue includes
+`reviewPullRequest.number/head`, while a canonical PR guards `expected.head`. Verify reaction, Project state, bedrin-gpt
+assignment, and exact-head PR state.
 
-The worker owns completion signalling. It may renew the same claim/generation before lease expiry if still legitimately running; it
-must not merely wait for the dispatcher to discover completion.
+The lifecycle owner may renew the same claim/generation before lease expiry. It must perform its own completion signalling and must
+not leave finished work in In progress.
 
-## Lease recovery
+## Recovery
 
-Normal ticks do not poll active workers. If a lease is missing/invalid/expired, target that exact generation. Extend only after
-proving the same worker remains active; complete a lost handoff when publication is sufficient; recover the same worktree/branch
-where possible; release only when no active/recoverable work remains. Never duplicate the task, generation, branch, or PR.
+App-native same-thread recovery is conversation-scoped: only the same persistent automation may resume a reference naming
+`codex-app-same-thread-v1` and `conversation=self`. It never lists or invents child tasks.
+
+Headless recovery is generation/process/worktree scoped and is specified by issue #814. Neither adapter may adopt ownership from the
+other merely because the Executor field says Local Codex.
 
 ## Telemetry and security
 
-Every dispatcher/worker records start/end/duration, model/reasoning, snapshot/candidate, outcome, and exact provider token counters
-when exposed. Otherwise counters are null with `usageSource: unavailable`; never fabricate exact usage.
+Every automation/worker records start/end/duration, adapter, model/reasoning, snapshot/candidate, outcome, and exact provider token
+counters when exposed. Otherwise counters are null with `usageSource: unavailable`; never fabricate exact usage.
 
 Use a dedicated low-value VM/account with repository-scoped credentials. Docker/full filesystem/network access is privileged host
 policy. Never merge, enable auto-merge, bypass protection, rewrite shared history, or perform privileged operations without

--- a/docs/ai-delivery/executors/codex-local.md
+++ b/docs/ai-delivery/executors/codex-local.md
@@ -86,9 +86,9 @@ Branch authority is ordered:
 An explicit branch always wins. A conflict returns to Planning or a precise maintainer decision; it never authorizes an invented
 replacement branch.
 
-Every autonomous command uses the control-plane human-readable Markdown wrapper, exact start/end markers, and lowercase `json`
-fence; the marked JSON is authoritative. Never emit bare JSON. Inspect the terminal reaction and re-read Project state before
-source mutation, recovery, or handoff.
+Every autonomous command uses the control-plane human-readable Markdown wrapper, exact start/end markers, and lowercase `json` fence;
+the marked JSON is authoritative. Never emit bare JSON. Inspect the terminal reaction and re-read Project state before source
+mutation, recovery, or handoff.
 
 ## Existing PR continuation
 

--- a/docs/ai-delivery/profile.yml
+++ b/docs/ai-delivery/profile.yml
@@ -60,7 +60,10 @@ schedulers:
     fullCadenceSlots: [0, 15, 30, 45]
     prompt: .chatgpt/scheduled-task-prompt.md
   Local Codex:
+    adapter: codex-app-same-thread-v1
+    surface: Codex Automation
     prompt: .codex/local/scheduled-task-prompt.md
+    lifecycleTemplate: .codex/local/worker-task-prompt.md
     snapshotHelper: .codex/local/project-queue-snapshot.sh
 
 executors:
@@ -77,15 +80,17 @@ executors:
     dispatchOwner: ChatGPT
   Local Codex:
     assignee: bedrin-codex-local
-    dispatcherModel: gpt-5.6-luna
-    dispatcherReasoning: low
+    appNativeAdapter: codex-app-same-thread-v1
+    appNativeModel: gpt-5.6-terra
+    appNativeReasoning: medium
     workerModel: gpt-5.6-terra
     workerReasoning: medium
     escalationModel: gpt-5.6-sol
     escalationReasoning: high
     dispatchMode: polling
-    # App-native dispatch derives this scheduling limit from the retained Project snapshot.
-    # Provider-wide Codex project/task inventory is recovery evidence, not a normal capacity source.
+    # The app-native automation performs the lifecycle turn in its own persistent conversation.
+    # No nested child thread/task/worktree is part of this adapter.
+    appNativeSameThread: true
     maxConcurrentWorkers: 1
   Human:
     assignee: bedrin


### PR DESCRIPTION
Closes #813

## Problem

The app-native dispatcher treated an opaque `client-new-thread:*` acknowledgement as a confirmed child worker for #808, recorded a long lease, and reported `DISPATCHED` even though no usable child thread/worktree/branch/PR appeared. It also generated a branch that contradicted the explicit authoritative branch.

## Change

Replace the unsupported nested dispatcher/worker topology with one app-native same-thread adapter:

- the persistent Codex Automation performs deterministic selection and the selected Implementation/Verification lifecycle turn in the same conversation;
- configure the automation as `gpt-5.6-terra` / medium; there is no separate child worker model;
- one queue snapshot and at most one candidate;
- its own same-thread generation resumes before Ready work; other adapters' valid leases consume capacity but are not adopted;
- guarded claim precedes detailed reads and source mutation;
- Worker reference records `adapter=codex-app-same-thread-v1` and `conversation=self`;
- exact continuation branch or explicit authoritative issue/maintainer branch overrides generated slugs;
- no child thread, child task, hidden subagent, `client-new-thread:*`, or claimed app-owned worktree;
- normal guarded worker handoff remains unchanged;
- no merge, auto-merge, reset, rebase, force-push, or duplicate branch/PR.

## Model and efficiency trade-off

The current-thread adapter must use Terra/medium for the entire automation occurrence because the same conversation now performs the actual lifecycle work. Luna/low is no longer an honest profile for this adapter. Empty ticks therefore cost more until the separate CLI/systemd adapter in #816 is rolled out; that adapter restores a model-free dispatcher plus isolated Terra workers.

## Rollout

Repository merges do not rewrite the existing Codex Automation. After merge:

1. keep the old automation paused;
2. replace its embedded prompt with `.codex/local/scheduled-task-prompt.md` from merged `develop`;
3. change its model/profile to `gpt-5.6-terra` / medium;
4. smoke-test one empty tick and one disposable/read-only lifecycle candidate;
5. enable recurrence only after confirming no child thread/task/worktree is attempted.

## Validation

Exact head `260e76967b6ef8919088657c3b87e741533be6a7`:

- `AI delivery control` succeeded, including the complete control/policy suite and profile YAML parsing;
- `AI delivery status` succeeded, including runtime budgets, status policy, YAML parsing, and actionlint;
- branch comparison: four intended files, zero commits behind `develop`;
- broad `Check Pull Request` remains queued; no older-head matrix is used as proof.

## Published head

`260e76967b6ef8919088657c3b87e741533be6a7`

No merge or auto-merge is requested.